### PR TITLE
feat(skills): add ai-procedure-maintenance skill and explicit context loading

### DIFF
--- a/.claude/commands/ai-procedure-maintenance.md
+++ b/.claude/commands/ai-procedure-maintenance.md
@@ -1,0 +1,92 @@
+# /ai-procedure-maintenance
+
+Maintain and update AI coding procedures when adding new ADRs, constraints, patterns, protocols, or skills.
+
+## Usage
+
+```
+/ai-procedure-maintenance [element-type]
+```
+
+**Examples**:
+- `/ai-procedure-maintenance` - Show available checklists
+- `/ai-procedure-maintenance adr` - Run Checklist A: New ADR
+- `/ai-procedure-maintenance constraint` - Run Checklist B: New Constraint
+- `/ai-procedure-maintenance pattern` - Run Checklist C: New Pattern
+- `/ai-procedure-maintenance protocol` - Run Checklist D: New Protocol/AIP
+- `/ai-procedure-maintenance skill` - Run Checklist E: New Skill
+- `/ai-procedure-maintenance claude-md` - Run Checklist F: Root CLAUDE.md Updates
+- `/ai-procedure-maintenance verify` - Run cross-reference verification only
+
+## What This Command Does
+
+This command ensures that when you add new elements to the AI coding procedure system, all related files are updated consistently:
+
+- **INDEX files** are updated
+- **Skill mappings** are synchronized (adr-aware, task-execute, task-create)
+- **Cross-references** are verified
+- **Paths** are correct (using `.claude/` structure)
+
+## Execution Instructions
+
+**IMPORTANT**: When this command is invoked, you MUST:
+
+1. **Load the skill**: Read `.claude/skills/ai-procedure-maintenance/SKILL.md`
+2. **Identify the element type** from the argument (or ask user)
+3. **Follow the appropriate checklist** step by step
+4. **Run verification** after completing the checklist
+
+## Skill Location
+
+`.claude/skills/ai-procedure-maintenance/SKILL.md`
+
+## Available Checklists
+
+| Checklist | Element Type | Steps | Key Updates |
+|-----------|--------------|-------|-------------|
+| **A** | New ADR | 11 | Both ADR locations, constraints, patterns, skill mappings |
+| **B** | New Constraint | 6 | Constraint file, INDEX, pattern directory, skill mappings |
+| **C** | New Pattern | 5 | Pattern file, INDEX files, skill mappings |
+| **D** | New Protocol | 4 | Protocol file, INDEX, CLAUDE.md embedding |
+| **E** | New Skill | 7 | Skill directory, INDEX, SKILL-INTERACTION-GUIDE, CLAUDE.md |
+| **F** | CLAUDE.md Update | 4 | Path verification, parallel updates, date consistency |
+
+## Verification Checks
+
+After any checklist, the skill runs these verifications:
+
+1. **Path Consistency** - No old/broken paths like `docs/reference/adr`
+2. **INDEX Completeness** - All files listed in their INDEX
+3. **Mapping Consistency** - Skill mappings aligned across adr-aware, task-execute, task-create
+4. **Date Consistency** - All modified files have current "Last Updated"
+
+## Example: Adding ADR-023
+
+```bash
+# You just created docs/adr/ADR-023-api-rate-limiting.md
+/ai-procedure-maintenance adr
+
+# Claude Code will:
+# 1. Create concise version in .claude/adr/
+# 2. Update both INDEX files
+# 3. Add constraints to .claude/constraints/api.md
+# 4. Create pattern file if needed
+# 5. Update skill mappings
+# 6. Verify cross-references
+```
+
+## Related Skills
+
+- `adr-aware` - Uses the ADR mappings this command maintains
+- `task-execute` - Uses constraint/pattern mappings
+- `task-create` - Uses knowledge mapping tables
+- `repo-cleanup` - Can validate procedure file structure
+
+## When to Use
+
+Use this command when:
+- Creating a new ADR
+- Adding a new constraint or pattern file
+- Creating or significantly modifying a skill
+- Updating root CLAUDE.md with new procedures
+- Discovering inconsistent references across files

--- a/.claude/constraints/INDEX.md
+++ b/.claude/constraints/INDEX.md
@@ -3,7 +3,7 @@
 > **Purpose**: MUST/MUST NOT rules organized by domain for efficient AI loading
 > **Target**: 100-200 lines per domain
 > **Source**: Extracted from ADRs and validated against codebase
-> **Last Updated**: 2025-12-19
+> **Last Updated**: 2025-12-25
 
 ---
 
@@ -25,6 +25,7 @@ This directory contains actionable constraints (rules, requirements, limits) org
 | AI Features | [ai.md](ai.md) | ADR-013 | ~100 |
 | Jobs/Workers | [jobs.md](jobs.md) | ADR-001, 004, 017 | ~100 |
 | Configuration | [config.md](config.md) | ADR-018, 020 | ~115 |
+| Testing | [testing.md](testing.md) | ADR-022 | ~115 |
 
 ---
 
@@ -41,6 +42,7 @@ This directory contains actionable constraints (rules, requirements, limits) org
 | Background jobs | `jobs.md` |
 | AI features | `ai.md` |
 | Configuration/flags | `config.md` |
+| Writing tests | `testing.md` |
 
 This provides focused, actionable rules without loading full ADR context.
 

--- a/.claude/constraints/testing.md
+++ b/.claude/constraints/testing.md
@@ -1,0 +1,133 @@
+# Testing Constraints
+
+> **Domain**: Unit and Integration Testing
+> **Source ADRs**: ADR-022 (Testing Strategy)
+> **Last Updated**: 2025-12-25
+
+---
+
+## When to Load This File
+
+Load when:
+- Writing unit tests for new code
+- Creating integration tests
+- Setting up test fixtures and mocks
+- Reviewing test coverage
+- Implementing test data builders
+
+---
+
+## MUST Rules
+
+### Test Structure (ADR-022)
+
+- ✅ **MUST** write tests for all code changes
+- ✅ **MUST** mirror `src/` directory structure in `tests/unit/`
+- ✅ **MUST** use xUnit as the test framework
+- ✅ **MUST** use NSubstitute for mocking
+- ✅ **MUST** follow Arrange-Act-Assert (AAA) pattern
+- ✅ **MUST** name tests using `{Method}_{Scenario}_{ExpectedResult}` convention
+
+### Unit Tests
+
+- ✅ **MUST** test one behavior per test method
+- ✅ **MUST** isolate unit tests from external dependencies
+- ✅ **MUST** mock all I/O operations (database, HTTP, file system)
+- ✅ **MUST** use test data builders for complex object creation
+- ✅ **MUST** keep unit tests fast (<100ms per test)
+
+### Integration Tests
+
+- ✅ **MUST** use `WebApplicationFactory<Program>` for API integration tests
+- ✅ **MUST** use test containers or in-memory databases where appropriate
+- ✅ **MUST** clean up test data after each test run
+- ✅ **MUST** use separate test configuration (not production settings)
+
+### Coverage Requirements
+
+- ✅ **MUST** maintain minimum 80% line coverage for new code
+- ✅ **MUST** cover all public API endpoints with integration tests
+- ✅ **MUST** cover error handling paths (not just happy path)
+
+---
+
+## MUST NOT Rules
+
+### Anti-Patterns
+
+- ❌ **MUST NOT** test implementation details (private methods directly)
+- ❌ **MUST NOT** use production databases or services in tests
+- ❌ **MUST NOT** create interdependent tests (tests must be isolated)
+- ❌ **MUST NOT** ignore or skip tests without documented reason
+- ❌ **MUST NOT** use `Thread.Sleep` or arbitrary delays in tests
+- ❌ **MUST NOT** hard-code test data that could change (use builders)
+
+### Mocking Anti-Patterns
+
+- ❌ **MUST NOT** mock value objects or DTOs
+- ❌ **MUST NOT** over-mock (verify behavior, not implementation)
+- ❌ **MUST NOT** use `Arg.Any<>()` when specific values matter
+
+---
+
+## Quick Reference Patterns
+
+### Test Naming
+
+```csharp
+// ✅ Good: Clear scenario and expected result
+[Fact]
+public async Task GetDocument_WhenNotFound_ReturnsNotFound()
+
+// ❌ Bad: Unclear what's being tested
+[Fact]
+public async Task Test1()
+```
+
+### AAA Pattern
+
+```csharp
+[Fact]
+public async Task CreateContainer_WithValidInput_ReturnsCreatedContainer()
+{
+    // Arrange
+    var request = new CreateContainerRequestBuilder().Build();
+    _speFileStore.CreateContainerAsync(Arg.Any<CreateContainerRequest>())
+        .Returns(new Container { Id = "123" });
+
+    // Act
+    var result = await _sut.CreateContainer(request);
+
+    // Assert
+    result.Should().BeOfType<Created<Container>>();
+}
+```
+
+### Mocking with NSubstitute
+
+```csharp
+// Setup
+var speFileStore = Substitute.For<ISpeFileStore>();
+speFileStore.GetContainerAsync("123").Returns(new Container { Id = "123" });
+
+// Verification
+await speFileStore.Received(1).GetContainerAsync("123");
+```
+
+---
+
+## Pattern Files (Complete Examples)
+
+- [Unit Test Structure](.claude/patterns/testing/unit-test-structure.md)
+- [Mocking Patterns](.claude/patterns/testing/mocking-patterns.md)
+- [Integration Tests](.claude/patterns/testing/integration-tests.md)
+
+---
+
+## Source ADRs (Full Context)
+
+- [ADR-022 Testing Strategy](../../docs/adr/ADR-022-testing-strategy.md) - Full rationale and examples
+
+---
+
+**Lines**: ~115

--- a/.claude/patterns/INDEX.md
+++ b/.claude/patterns/INDEX.md
@@ -3,6 +3,7 @@
 > **Purpose**: Reusable code examples organized by domain for efficient AI reference
 > **Target**: 100-200 lines per pattern file
 > **Source**: Extracted from guides and existing code
+> **Last Updated**: 2025-12-25
 
 ## About This Directory
 
@@ -29,65 +30,152 @@ This directory contains focused, copy-paste-ready code patterns organized by tec
 
 ```
 patterns/
-├── api/          # BFF API patterns (endpoints, filters, services)
-├── pcf/          # PCF control patterns (React, hooks, Dataverse)
-├── auth/         # Authentication patterns (OAuth, OBO, tokens)
-├── dataverse/    # Dataverse patterns (plugins, Web API, metadata)
-└── testing/      # Testing patterns (unit, integration, mocks)
+├── INDEX.md              # This file
+├── api/                  # BFF API patterns
+│   ├── INDEX.md
+│   ├── background-workers.md
+│   ├── endpoint-definition.md
+│   ├── endpoint-filters.md
+│   ├── error-handling.md
+│   ├── resilience.md
+│   └── service-registration.md
+├── auth/                 # Authentication patterns
+│   ├── INDEX.md
+│   ├── msal-client.md
+│   ├── oauth-scopes.md
+│   ├── obo-flow.md
+│   ├── service-principal.md
+│   └── token-caching.md
+├── caching/              # Caching patterns
+│   ├── INDEX.md
+│   ├── distributed-cache.md
+│   ├── request-cache.md
+│   └── token-cache.md
+├── dataverse/            # Dataverse patterns
+│   ├── INDEX.md
+│   ├── entity-operations.md
+│   ├── plugin-structure.md
+│   ├── relationship-navigation.md
+│   └── web-api-client.md
+├── pcf/                  # PCF control patterns
+│   ├── INDEX.md
+│   ├── control-initialization.md
+│   ├── dataverse-queries.md
+│   ├── dialog-patterns.md
+│   ├── error-handling.md
+│   └── theme-management.md
+├── ai/                   # AI patterns
+│   ├── INDEX.md
+│   ├── analysis-scopes.md
+│   ├── streaming-endpoints.md
+│   └── text-extraction.md
+└── testing/              # Testing patterns
+    ├── INDEX.md
+    ├── integration-tests.md
+    ├── mocking-patterns.md
+    └── unit-test-structure.md
 ```
 
-## Planned Pattern Files
+---
 
-<!-- TODO: Phase 3 - Create these files -->
+## Available Pattern Files
 
-### api/
-- [ ] **endpoint-definition.md** - Minimal API endpoint patterns
-- [ ] **endpoint-filters.md** - Authorization filter patterns
-- [ ] **service-registration.md** - DI registration patterns
-- [ ] **error-handling.md** - ProblemDetails patterns
-- [ ] **resilience.md** - Polly retry patterns
+### API Patterns (`api/`)
 
-### pcf/
-- [ ] **control-initialization.md** - PCF init and updateView patterns
-- [ ] **react-hooks.md** - React hook patterns for PCF
-- [ ] **dataverse-queries.md** - WebAPI query patterns
-- [ ] **error-display.md** - User-friendly error UI patterns
-- [ ] **metadata-caching.md** - Metadata retrieval and caching
+| Pattern | File | Source ADRs |
+|---------|------|-------------|
+| Background Workers | [background-workers.md](api/background-workers.md) | ADR-001 |
+| Endpoint Definition | [endpoint-definition.md](api/endpoint-definition.md) | ADR-001 |
+| Endpoint Filters | [endpoint-filters.md](api/endpoint-filters.md) | ADR-008 |
+| Error Handling | [error-handling.md](api/error-handling.md) | ADR-019 |
+| Resilience | [resilience.md](api/resilience.md) | ADR-017 |
+| Service Registration | [service-registration.md](api/service-registration.md) | ADR-010 |
 
-### auth/
-- [ ] **oauth-scopes.md** - Correct OAuth scope patterns
-- [ ] **token-acquisition.md** - MSAL token patterns
-- [ ] **obo-flow.md** - On-Behalf-Of implementation
-- [ ] **service-principal.md** - Service-to-service auth
+### Auth Patterns (`auth/`)
 
-### dataverse/
-- [ ] **plugin-structure.md** - Thin plugin patterns
-- [ ] **early-binding.md** - Strongly-typed entity patterns
-- [ ] **web-api-calls.md** - Dataverse Web API patterns
-- [ ] **relationship-navigation.md** - N:1, 1:N navigation
+| Pattern | File | Source ADRs |
+|---------|------|-------------|
+| MSAL Client | [msal-client.md](auth/msal-client.md) | ADR-004 |
+| OAuth Scopes | [oauth-scopes.md](auth/oauth-scopes.md) | ADR-004, ADR-008 |
+| OBO Flow | [obo-flow.md](auth/obo-flow.md) | ADR-004, ADR-009 |
+| Service Principal | [service-principal.md](auth/service-principal.md) | ADR-004, ADR-016 |
+| Token Caching | [token-caching.md](auth/token-caching.md) | ADR-009 |
 
-### testing/
-- [ ] **unit-test-structure.md** - xUnit test patterns
-- [ ] **mocking.md** - NSubstitute mock patterns
-- [ ] **integration-tests.md** - WebApplicationFactory patterns
-- [ ] **test-data-builders.md** - Test data creation patterns
+### Caching Patterns (`caching/`)
 
-## Phase 3 TODO
+| Pattern | File | Source ADRs |
+|---------|------|-------------|
+| Distributed Cache | [distributed-cache.md](caching/distributed-cache.md) | ADR-009 |
+| Request Cache | [request-cache.md](caching/request-cache.md) | ADR-009 |
+| Token Cache | [token-cache.md](caching/token-cache.md) | ADR-009 |
 
-- [ ] Extract patterns from existing guides
-- [ ] Create focused pattern files (100-200 lines)
-- [ ] Add correct and incorrect examples
-- [ ] Cross-reference related constraints and ADRs
-- [ ] Validate patterns against current codebase
+### Dataverse Patterns (`dataverse/`)
+
+| Pattern | File | Source ADRs |
+|---------|------|-------------|
+| Entity Operations | [entity-operations.md](dataverse/entity-operations.md) | ADR-002, ADR-007 |
+| Plugin Structure | [plugin-structure.md](dataverse/plugin-structure.md) | ADR-002 |
+| Relationship Navigation | [relationship-navigation.md](dataverse/relationship-navigation.md) | ADR-007 |
+| Web API Client | [web-api-client.md](dataverse/web-api-client.md) | ADR-007, ADR-010 |
+
+### PCF Patterns (`pcf/`)
+
+| Pattern | File | Source ADRs |
+|---------|------|-------------|
+| Control Initialization | [control-initialization.md](pcf/control-initialization.md) | ADR-006, ADR-012 |
+| Dataverse Queries | [dataverse-queries.md](pcf/dataverse-queries.md) | ADR-006, ADR-009 |
+| Dialog Patterns | [dialog-patterns.md](pcf/dialog-patterns.md) | ADR-006 |
+| Error Handling | [error-handling.md](pcf/error-handling.md) | ADR-006, ADR-012 |
+| Theme Management | [theme-management.md](pcf/theme-management.md) | ADR-012 |
+
+### AI Patterns (`ai/`)
+
+| Pattern | File | Source ADRs |
+|---------|------|-------------|
+| Analysis Scopes | [analysis-scopes.md](ai/analysis-scopes.md) | ADR-013 |
+| Streaming Endpoints | [streaming-endpoints.md](ai/streaming-endpoints.md) | ADR-013 |
+| Text Extraction | [text-extraction.md](ai/text-extraction.md) | ADR-013 |
+
+### Testing Patterns (`testing/`)
+
+| Pattern | File | Source ADRs |
+|---------|------|-------------|
+| Integration Tests | [integration-tests.md](testing/integration-tests.md) | ADR-022 |
+| Mocking Patterns | [mocking-patterns.md](testing/mocking-patterns.md) | ADR-022 |
+| Unit Test Structure | [unit-test-structure.md](testing/unit-test-structure.md) | ADR-022 |
+
+---
 
 ## Usage by AI Agents
 
 **Loading strategy**: Load specific pattern files when implementing related features.
 
-**Examples**:
-- Creating BFF endpoint → Load `patterns/api/endpoint-definition.md` + `patterns/api/endpoint-filters.md`
-- Creating PCF control → Load `patterns/pcf/control-initialization.md` + `patterns/pcf/react-hooks.md`
-- Implementing auth → Load `patterns/auth/oauth-scopes.md` + `patterns/auth/token-acquisition.md`
-- Writing plugin → Load `patterns/dataverse/plugin-structure.md`
+| Task Type | Load These Patterns |
+|-----------|---------------------|
+| Creating BFF endpoint | `api/endpoint-definition.md` + `api/endpoint-filters.md` |
+| Implementing auth | `auth/oauth-scopes.md` + `auth/obo-flow.md` |
+| Creating PCF control | `pcf/control-initialization.md` + `pcf/theme-management.md` |
+| Writing plugin | `dataverse/plugin-structure.md` |
+| Adding caching | `caching/distributed-cache.md` |
+| Writing tests | `testing/unit-test-structure.md` + `testing/mocking-patterns.md` |
+| Background jobs | `api/background-workers.md` + `auth/service-principal.md` |
 
-Patterns provide immediate, actionable code examples without verbose explanation.
+---
+
+## Related Constraint Files
+
+Patterns show **how** - constraints define **what**:
+
+| Pattern Domain | Constraint File |
+|----------------|-----------------|
+| api/ | `.claude/constraints/api.md` |
+| auth/ | `.claude/constraints/auth.md` |
+| pcf/ | `.claude/constraints/pcf.md` |
+| dataverse/ | `.claude/constraints/plugins.md` |
+| caching/ | `.claude/constraints/data.md` |
+| ai/ | `.claude/constraints/ai.md` |
+| testing/ | `.claude/constraints/testing.md` |
+
+---
+
+**Lines**: ~160

--- a/.claude/patterns/api/resilience.md
+++ b/.claude/patterns/api/resilience.md
@@ -1,0 +1,224 @@
+# Resilience Pattern
+
+> **Domain**: BFF API / Fault Tolerance
+> **Last Validated**: 2025-12-25
+> **Source ADRs**: ADR-017
+
+---
+
+## Canonical Implementations
+
+| File | Purpose |
+|------|---------|
+| `src/server/api/Sprk.Bff.Api/Infrastructure/Http/ResilientHttpHandler.cs` | Polly policy handler |
+| `src/server/api/Sprk.Bff.Api/Infrastructure/Extensions/HttpClientExtensions.cs` | HttpClient setup |
+| `src/server/api/Sprk.Bff.Api/Program.cs` | Policy registration |
+
+---
+
+## Resilience Strategy
+
+```
+Request → Retry (3x) → Circuit Breaker → Timeout → Fallback
+```
+
+1. **Retry**: Transient failures (5xx, network errors)
+2. **Circuit Breaker**: Prevent cascade failures
+3. **Timeout**: Prevent hanging requests
+4. **Fallback**: Graceful degradation
+
+---
+
+## Implementation Pattern
+
+### 1. Polly Policy Configuration
+
+```csharp
+// HttpClientExtensions.cs
+public static IHttpClientBuilder AddResilientHttpClient(
+    this IServiceCollection services,
+    string name,
+    Action<HttpClient> configureClient)
+{
+    return services.AddHttpClient(name, configureClient)
+        .AddPolicyHandler(GetRetryPolicy())
+        .AddPolicyHandler(GetCircuitBreakerPolicy())
+        .AddPolicyHandler(Policy.TimeoutAsync<HttpResponseMessage>(30));
+}
+
+private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
+{
+    return HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .OrResult(msg => msg.StatusCode == HttpStatusCode.TooManyRequests)
+        .WaitAndRetryAsync(
+            retryCount: 3,
+            sleepDurationProvider: retryAttempt =>
+                TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)), // Exponential backoff
+            onRetry: (outcome, timespan, retryAttempt, context) =>
+            {
+                Log.Warning("Retry {Attempt} after {Delay}s due to {StatusCode}",
+                    retryAttempt, timespan.TotalSeconds, outcome.Result?.StatusCode);
+            });
+}
+
+private static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy()
+{
+    return HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .CircuitBreakerAsync(
+            handledEventsAllowedBeforeBreaking: 5,
+            durationOfBreak: TimeSpan.FromSeconds(30),
+            onBreak: (outcome, breakDelay) =>
+                Log.Warning("Circuit breaker opened for {BreakDelay}s", breakDelay.TotalSeconds),
+            onReset: () => Log.Information("Circuit breaker reset"));
+}
+```
+
+### 2. Service Registration
+
+```csharp
+// Program.cs
+services.AddResilientHttpClient("GraphApi", client =>
+{
+    client.BaseAddress = new Uri("https://graph.microsoft.com/v1.0/");
+    client.Timeout = TimeSpan.FromSeconds(60);
+});
+
+services.AddResilientHttpClient("AzureOpenAI", client =>
+{
+    client.BaseAddress = new Uri(config["AzureOpenAI:Endpoint"]);
+    client.DefaultRequestHeaders.Add("api-key", config["AzureOpenAI:ApiKey"]);
+});
+```
+
+### 3. Usage in Services
+
+```csharp
+public class SpeFileStore
+{
+    private readonly HttpClient _httpClient;
+
+    public SpeFileStore(IHttpClientFactory httpClientFactory)
+    {
+        _httpClient = httpClientFactory.CreateClient("GraphApi");
+    }
+
+    public async Task<Container> GetContainerAsync(string id, CancellationToken ct)
+    {
+        // Polly policies are applied automatically via the handler
+        var response = await _httpClient.GetAsync($"storage/fileStorage/containers/{id}", ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<Container>(ct);
+    }
+}
+```
+
+---
+
+## Retry Configuration by Service
+
+| Service | Retries | Base Delay | Max Timeout |
+|---------|---------|------------|-------------|
+| Graph API | 3 | 2s exponential | 60s |
+| Azure OpenAI | 3 | 2s exponential | 120s |
+| Dataverse | 2 | 1s exponential | 30s |
+| Redis | 2 | 500ms | 5s |
+
+---
+
+## Circuit Breaker Settings
+
+```csharp
+// Default settings
+handledEventsAllowedBeforeBreaking: 5,  // Open after 5 failures
+durationOfBreak: TimeSpan.FromSeconds(30),  // Stay open for 30s
+samplingDuration: TimeSpan.FromMinutes(1)  // Rolling window
+```
+
+---
+
+## Rate Limit Handling
+
+```csharp
+// Handle 429 with Retry-After header
+.OrResult(response => response.StatusCode == HttpStatusCode.TooManyRequests)
+.WaitAndRetryAsync(
+    retryCount: 3,
+    sleepDurationProvider: (retryAttempt, response, context) =>
+    {
+        var retryAfter = response.Result?.Headers.RetryAfter;
+        if (retryAfter?.Delta.HasValue == true)
+            return retryAfter.Delta.Value;
+        return TimeSpan.FromSeconds(Math.Pow(2, retryAttempt));
+    });
+```
+
+---
+
+## Fallback Pattern
+
+```csharp
+// Graceful degradation for non-critical features
+var fallbackPolicy = Policy<AnalysisResult>
+    .Handle<Exception>()
+    .FallbackAsync(
+        fallbackValue: AnalysisResult.Unavailable("Service temporarily unavailable"),
+        onFallbackAsync: (result, context) =>
+        {
+            Log.Warning("Fallback activated: {Exception}", result.Exception?.Message);
+            return Task.CompletedTask;
+        });
+```
+
+---
+
+## Observability
+
+```csharp
+// Log policy events for monitoring
+.WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+    onRetry: (outcome, timespan, retryAttempt, context) =>
+    {
+        _logger.LogWarning(
+            "Retry {RetryAttempt}/3 for {PolicyKey} after {Delay}ms. Reason: {Reason}",
+            retryAttempt,
+            context.PolicyKey,
+            timespan.TotalMilliseconds,
+            outcome.Exception?.Message ?? outcome.Result?.StatusCode.ToString());
+
+        // Emit metric
+        _metrics.IncrementCounter("http_retry_total", new[] { context.PolicyKey });
+    });
+```
+
+---
+
+## Anti-Patterns
+
+```csharp
+// ❌ Bad: No resilience
+var response = await _httpClient.GetAsync(url);
+
+// ❌ Bad: Retry on all errors (including 4xx)
+.HandleResult(r => !r.IsSuccessStatusCode)
+
+// ❌ Bad: Fixed delay (causes thundering herd)
+.WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(1))
+
+// ✅ Good: Exponential backoff with jitter
+.WaitAndRetryAsync(3, retryAttempt =>
+    TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)) +
+    TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000)))
+```
+
+---
+
+## Related Patterns
+
+- [Error Handling](error-handling.md) - Error response format
+- [Service Registration](service-registration.md) - HttpClient DI setup
+
+---
+
+**Lines**: ~175

--- a/.claude/patterns/auth/service-principal.md
+++ b/.claude/patterns/auth/service-principal.md
@@ -1,0 +1,280 @@
+# Service Principal Authentication Pattern
+
+> **Domain**: OAuth / Service-to-Service Auth
+> **Last Validated**: 2025-12-25
+> **Source ADRs**: ADR-004, ADR-016
+
+---
+
+## Canonical Implementations
+
+| File | Purpose |
+|------|---------|
+| `src/server/api/Sprk.Bff.Api/Infrastructure/Auth/ServicePrincipalAuth.cs` | SP token acquisition |
+| `src/server/api/Sprk.Bff.Api/Services/DataverseClient.cs` | Dataverse SP auth |
+| `src/server/api/Sprk.Bff.Api/Infrastructure/Graph/AppOnlyGraphClient.cs` | Graph SP auth |
+
+---
+
+## Service Principal vs OBO
+
+| Scenario | Use |
+|----------|-----|
+| User-delegated access (user context) | OBO Flow |
+| Background jobs (no user) | Service Principal |
+| Admin operations | Service Principal |
+| Cross-tenant access | Service Principal |
+
+---
+
+## Implementation Pattern
+
+### 1. ConfidentialClientApplication Setup
+
+```csharp
+public class ServicePrincipalAuth
+{
+    private readonly IConfidentialClientApplication _cca;
+    private readonly ILogger<ServicePrincipalAuth> _logger;
+
+    public ServicePrincipalAuth(IOptions<AzureAdOptions> options, ILogger<ServicePrincipalAuth> logger)
+    {
+        _logger = logger;
+        var config = options.Value;
+
+        _cca = ConfidentialClientApplicationBuilder
+            .Create(config.ClientId)
+            .WithAuthority(AzureCloudInstance.AzurePublic, config.TenantId)
+            .WithClientSecret(config.ClientSecret)
+            .Build();
+    }
+
+    public async Task<string> AcquireTokenAsync(string[] scopes)
+    {
+        try
+        {
+            var result = await _cca
+                .AcquireTokenForClient(scopes)
+                .ExecuteAsync();
+
+            return result.AccessToken;
+        }
+        catch (MsalServiceException ex)
+        {
+            _logger.LogError(ex, "Failed to acquire SP token: {ErrorCode}", ex.ErrorCode);
+            throw;
+        }
+    }
+}
+```
+
+### 2. Scopes for Common Services
+
+```csharp
+// Graph API - app permissions
+private static readonly string[] GraphScopes = new[]
+{
+    "https://graph.microsoft.com/.default"
+};
+
+// Dataverse - app permissions
+private static readonly string[] DataverseScopes = new[]
+{
+    "https://{org}.crm.dynamics.com/.default"
+};
+
+// SharePoint - app permissions
+private static readonly string[] SharePointScopes = new[]
+{
+    "https://{tenant}.sharepoint.com/.default"
+};
+```
+
+### 3. Usage in Background Workers
+
+```csharp
+public class DocumentProcessingWorker : BackgroundService
+{
+    private readonly ServicePrincipalAuth _spAuth;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public DocumentProcessingWorker(
+        ServicePrincipalAuth spAuth,
+        IHttpClientFactory httpClientFactory)
+    {
+        _spAuth = spAuth;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Acquire app-only token
+            var token = await _spAuth.AcquireTokenAsync(
+                new[] { "https://graph.microsoft.com/.default" });
+
+            var client = _httpClientFactory.CreateClient("GraphApi");
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", token);
+
+            // Make Graph API calls with app permissions
+            await ProcessDocumentsAsync(client, stoppingToken);
+
+            await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+        }
+    }
+}
+```
+
+---
+
+## Token Caching
+
+MSAL caches tokens automatically, but for distributed scenarios:
+
+```csharp
+public class ServicePrincipalAuth
+{
+    private readonly IDistributedCache _cache;
+    private readonly TimeSpan _tokenCacheDuration = TimeSpan.FromMinutes(55);
+
+    public async Task<string> AcquireTokenAsync(string[] scopes)
+    {
+        var cacheKey = $"sp_token:{string.Join(",", scopes)}";
+
+        // Check cache first
+        var cached = await _cache.GetStringAsync(cacheKey);
+        if (!string.IsNullOrEmpty(cached))
+            return cached;
+
+        // Acquire fresh token
+        var result = await _cca.AcquireTokenForClient(scopes).ExecuteAsync();
+
+        // Cache with 55-minute TTL (tokens valid for 60 min)
+        await _cache.SetStringAsync(cacheKey, result.AccessToken,
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = _tokenCacheDuration });
+
+        return result.AccessToken;
+    }
+}
+```
+
+---
+
+## Certificate Authentication (Production)
+
+```csharp
+// Prefer certificates over secrets in production
+_cca = ConfidentialClientApplicationBuilder
+    .Create(config.ClientId)
+    .WithAuthority(AzureCloudInstance.AzurePublic, config.TenantId)
+    .WithCertificate(LoadCertificate(config.CertificateThumbprint))
+    .Build();
+
+private static X509Certificate2 LoadCertificate(string thumbprint)
+{
+    using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+    store.Open(OpenFlags.ReadOnly);
+
+    var certs = store.Certificates.Find(
+        X509FindType.FindByThumbprint, thumbprint, validOnly: false);
+
+    return certs.Count > 0
+        ? certs[0]
+        : throw new InvalidOperationException($"Certificate {thumbprint} not found");
+}
+```
+
+---
+
+## Managed Identity (Azure)
+
+```csharp
+// Use DefaultAzureCredential in Azure (App Service, Functions, AKS)
+public class ManagedIdentityAuth
+{
+    private readonly TokenCredential _credential;
+
+    public ManagedIdentityAuth()
+    {
+        _credential = new DefaultAzureCredential();
+    }
+
+    public async Task<string> AcquireTokenAsync(string resource)
+    {
+        var context = new TokenRequestContext(new[] { $"{resource}/.default" });
+        var token = await _credential.GetTokenAsync(context);
+        return token.Token;
+    }
+}
+```
+
+---
+
+## Service Registration
+
+```csharp
+// Program.cs
+services.Configure<AzureAdOptions>(configuration.GetSection("AzureAd"));
+services.AddSingleton<ServicePrincipalAuth>();
+
+// For Managed Identity
+services.AddSingleton<TokenCredential>(sp =>
+    new DefaultAzureCredential(new DefaultAzureCredentialOptions
+    {
+        ExcludeEnvironmentCredential = true,
+        ExcludeVisualStudioCredential = true
+    }));
+```
+
+---
+
+## Error Handling
+
+```csharp
+try
+{
+    var token = await _spAuth.AcquireTokenAsync(scopes);
+}
+catch (MsalServiceException ex) when (ex.ErrorCode == "AADSTS700016")
+{
+    // App not found in tenant
+    _logger.LogError("Service principal not configured in tenant");
+    throw new InvalidOperationException("Authentication configuration error");
+}
+catch (MsalServiceException ex) when (ex.ErrorCode == "AADSTS7000215")
+{
+    // Invalid client secret
+    _logger.LogError("Invalid client secret");
+    throw new InvalidOperationException("Authentication configuration error");
+}
+catch (MsalServiceException ex) when (ex.ErrorCode == "AADSTS70011")
+{
+    // Invalid scope
+    _logger.LogError("Invalid scope: {Scopes}", string.Join(", ", scopes));
+    throw;
+}
+```
+
+---
+
+## Key Points
+
+1. **Always use `.default` scope** for client credentials flow
+2. **Prefer managed identity** in Azure (no secrets to manage)
+3. **Use certificates** in production (more secure than secrets)
+4. **Cache tokens** to reduce token requests (55-min TTL)
+5. **Separate app registrations** for SP auth vs user auth
+
+---
+
+## Related Patterns
+
+- [OAuth Scopes](oauth-scopes.md) - Scope format requirements
+- [OBO Flow](obo-flow.md) - User-delegated authentication
+- [Token Caching](token-caching.md) - Distributed token caching
+
+---
+
+**Lines**: ~200

--- a/.claude/skills/INDEX.md
+++ b/.claude/skills/INDEX.md
@@ -8,6 +8,8 @@
 | Skill | Description | Always Apply | Trigger |
 |-------|-------------|--------------|---------|
 | [adr-aware](adr-aware/SKILL.md) | Proactively load ADRs when creating resources | **Yes** | Auto-applied |
+| [ai-procedure-maintenance](ai-procedure-maintenance/SKILL.md) | Maintain AI procedures when adding ADRs, patterns, skills | No | "update AI procedures", "add new ADR" |
+| [script-aware](script-aware/SKILL.md) | Discover and reuse scripts from library before writing new code | **Yes** | Auto-applied |
 | [adr-check](adr-check/SKILL.md) | Validate code against Architecture Decision Records | No | `/adr-check`, "check ADRs" |
 | [code-review](code-review/SKILL.md) | Comprehensive code review (security, performance, style) | No | `/code-review`, "review code" |
 | [dataverse-deploy](dataverse-deploy/SKILL.md) | Deploy solutions, PCF controls, web resources to Dataverse | No | "deploy to dataverse", "pac pcf push" |
@@ -26,6 +28,7 @@
 
 ### 📐 Standards (Always-Apply)
 - **adr-aware** - Proactive ADR loading based on resource type
+- **script-aware** - Script library discovery and reuse before writing new automation
 - **spaarke-conventions** - Naming, patterns, file organization
 
 ### 🚀 Project Lifecycle
@@ -40,6 +43,9 @@
 - **code-review** - General code quality review
 - **adr-check** - Architecture compliance validation (post-hoc)
 - **repo-cleanup** - Repository structure validation and hygiene
+
+### 🔧 Maintenance
+- **ai-procedure-maintenance** - Propagate updates when adding ADRs, constraints, patterns, skills
 
 ### ⚙️ Dataverse/Platform
 - **dataverse-deploy** - Deploy solutions, PCF controls, web resources via PAC CLI
@@ -100,6 +106,7 @@ AI-Optimized Spec (spec.md)
         └──────────────────┘
             │
             ├─→ adr-aware (Tier 0 - implicit)
+            ├─→ script-aware (Tier 0 - implicit)
             ├─→ spaarke-conventions (Tier 0 - implicit)
             ├─→ Execute task steps
             ├─→ code-review (Tier 3 - quality gate)
@@ -118,7 +125,7 @@ AI-Optimized Spec (spec.md)
 ```
 
 **Skill Tiers**:
-- **Tier 0**: Always-Apply (adr-aware, spaarke-conventions)
+- **Tier 0**: Always-Apply (adr-aware, script-aware, spaarke-conventions)
 - **Tier 1**: Components (design-to-spec, project-setup, task-create)
 - **Tier 2**: Orchestrators (project-pipeline, task-execute)
 - **Tier 3**: Operational (code-review, adr-check, dataverse-deploy, etc.)
@@ -199,6 +206,8 @@ alwaysApply: false  # Only true for universal skills like conventions
 │       └── assets/
 ├── adr-aware/                  ← Proactive ADR loading
 │   └── SKILL.md
+├── ai-procedure-maintenance/   ← Maintain AI procedures when adding new elements
+│   └── SKILL.md
 ├── adr-check/
 │   ├── SKILL.md
 │   └── references/
@@ -219,6 +228,8 @@ alwaysApply: false  # Only true for universal skills like conventions
 │   └── SKILL.md
 ├── ribbon-edit/                ← Dataverse ribbon customization
 │   └── SKILL.md
+├── script-aware/               ← Script library discovery and reuse
+│   └── SKILL.md
 ├── spaarke-conventions/
 │   ├── SKILL.md
 │   └── references/
@@ -229,4 +240,4 @@ alwaysApply: false  # Only true for universal skills like conventions
 
 ---
 
-*Last updated: December 24, 2025*
+*Last updated: December 25, 2025*

--- a/.claude/skills/adr-aware/SKILL.md
+++ b/.claude/skills/adr-aware/SKILL.md
@@ -42,18 +42,53 @@ Ensures Architecture Decision Records (ADRs) are automatically considered when A
 | **Versioning** | `v1/`, `ApiVersion`, contracts/DTO versioning | ADR-020 |
 | **Storage/Documents** | `*Store*.cs`, `*Document*.cs`, `*File*.cs` | ADR-005, ADR-007 |
 
-### Rule 2: Automatic ADR Loading
+### Rule 2: Automatic Context Loading (Two-Tier Strategy)
 
 When a task or prompt involves creating/modifying files matching the patterns above:
 
 ```
 BEFORE writing any code:
   1. IDENTIFY resource types from task/file patterns
-  2. LOOKUP applicable ADRs from mapping table
-  3. LOAD ADR summaries from root CLAUDE.md (already in context)
-  4. IF constraint needs clarification → READ full ADR from docs/reference/adr/
+  2. LOOKUP applicable ADRs from mapping table (Rule 1)
+
+  3. LOAD Tier 1 context (concise, AI-optimized):
+     a. LOAD .claude/constraints/{domain}.md for MUST/MUST NOT rules
+        - API work → .claude/constraints/api.md
+        - PCF work → .claude/constraints/pcf.md
+        - Plugin work → .claude/constraints/plugins.md
+        - Auth work → .claude/constraints/auth.md
+        - Caching work → .claude/constraints/data.md
+        - AI work → .claude/constraints/ai.md
+        - Testing → .claude/constraints/testing.md
+
+     b. LOAD .claude/adr/ADR-XXX.md for each applicable ADR
+        - These are 100-150 line concise versions
+        - Focus on constraints, not full rationale
+
+     c. LOAD .claude/patterns/{domain}/*.md for code examples
+        - API patterns → .claude/patterns/api/
+        - Auth patterns → .claude/patterns/auth/
+        - PCF patterns → .claude/patterns/pcf/
+        - Dataverse patterns → .claude/patterns/dataverse/
+
+  4. IF more context needed (rare):
+     → READ docs/adr/ADR-XXX-*.md for full rationale and history
+
   5. APPLY constraints during implementation
 ```
+
+### Resource Type to Context Files Mapping
+
+| Resource Type | Constraints File | Pattern Directory | ADRs |
+|---------------|------------------|-------------------|------|
+| API Endpoint | `.claude/constraints/api.md` | `.claude/patterns/api/` | ADR-001, 008, 010 |
+| PCF Control | `.claude/constraints/pcf.md` | `.claude/patterns/pcf/` | ADR-006, 011, 012, 021 |
+| Plugin | `.claude/constraints/plugins.md` | `.claude/patterns/dataverse/` | ADR-002 |
+| Auth/OAuth | `.claude/constraints/auth.md` | `.claude/patterns/auth/` | ADR-003, 008 |
+| Caching | `.claude/constraints/data.md` | `.claude/patterns/caching/` | ADR-009 |
+| AI Features | `.claude/constraints/ai.md` | `.claude/patterns/ai/` | ADR-013, 014, 015, 016 |
+| Background Jobs | `.claude/constraints/jobs.md` | — | ADR-001, 004, 017 |
+| Testing | `.claude/constraints/testing.md` | `.claude/patterns/testing/` | ADR-022 |
 
 ### Rule 3: ADR Constraint Comments
 
@@ -99,7 +134,9 @@ IF detected violation pattern:
 
 ## ADR Quick Reference
 
-Reference this table for common constraints. The source of truth is the ADR index: `docs/reference/adr/README-ADRs.md`.
+Reference this table for common constraints. The source of truth is:
+- **Concise ADRs**: `.claude/adr/` (AI-optimized, 100-150 lines each)
+- **Full ADRs**: `docs/adr/INDEX.md` (complete with history and rationale)
 
 | ADR | Title | Key Constraint | Violation Pattern |
 |-----|-------|----------------|-------------------|
@@ -230,4 +267,4 @@ Run `/adr-check` after completing tasks to verify no violations were introduced.
 
 ---
 
-*Last updated: December 24, 2025*
+*Last updated: December 25, 2025*

--- a/.claude/skills/ai-procedure-maintenance/SKILL.md
+++ b/.claude/skills/ai-procedure-maintenance/SKILL.md
@@ -1,0 +1,363 @@
+# ai-procedure-maintenance
+
+---
+description: Maintain and update AI coding procedures when new elements are added
+tags: [maintenance, adr, constraints, patterns, protocols, skills]
+techStack: [all]
+appliesTo: ["new ADR", "new pattern", "new constraint", "new skill", "procedure update"]
+alwaysApply: false
+---
+
+## Purpose
+
+Ensure the AI coding procedure ecosystem stays current and consistent when new elements are introduced. This skill provides a **checklist-driven approach** to propagating updates across all affected files.
+
+**Problem Solved**: Without this procedure, adding a new ADR might update `docs/adr/` but miss `.claude/adr/`, constraints, patterns, skill mappings, INDEX files, and root CLAUDE.md references.
+
+---
+
+## When to Use
+
+Invoke this skill when:
+- Creating a new ADR
+- Adding a new constraint file
+- Creating a new pattern file
+- Adding a new protocol (AIP)
+- Creating or significantly modifying a skill
+- Updating root CLAUDE.md with new procedures
+- Discovering that existing files have inconsistent references
+
+**Trigger Phrases**:
+- "update AI procedures for new ADR"
+- "add new pattern to the system"
+- "maintain AI coding procedures"
+- "propagate ADR changes"
+
+---
+
+## Maintenance Checklists by Element Type
+
+### Checklist A: New ADR
+
+When creating a new Architecture Decision Record:
+
+```
+□ 1. CREATE full ADR
+   Location: docs/adr/ADR-{NNN}-{slug}.md
+   Follow template in docs/adr/
+
+□ 2. CREATE concise ADR (AI-optimized version)
+   Location: .claude/adr/ADR-{NNN}-{slug}.md
+   Target: 100-150 lines
+   Focus: MUST/MUST NOT rules, code examples
+   Remove: Historical context, alternatives considered (keep in full version)
+
+□ 3. UPDATE ADR indexes
+   - docs/adr/INDEX.md - Add row to ADR table
+   - .claude/adr/INDEX.md - Add row to concise ADR table
+
+□ 4. UPDATE relevant constraint file
+   Location: .claude/constraints/{domain}.md
+   Action: Add constraint rules derived from ADR
+
+   Domain mapping:
+   - API/endpoints → api.md
+   - PCF/frontend → pcf.md
+   - Plugins → plugins.md
+   - Auth → auth.md
+   - Caching → data.md
+   - AI features → ai.md
+   - Background jobs → jobs.md
+   - Testing → testing.md
+
+□ 5. UPDATE constraint INDEX
+   Location: .claude/constraints/INDEX.md
+   Action: Update line count, add ADR reference if new file created
+
+□ 6. CREATE pattern file (if ADR introduces code patterns)
+   Location: .claude/patterns/{domain}/{pattern-name}.md
+   Content: Copy-paste-ready code examples
+
+□ 7. UPDATE pattern INDEX
+   Location: .claude/patterns/{domain}/INDEX.md
+   Action: Add new pattern to table
+
+□ 8. UPDATE skill mappings (CRITICAL)
+   Files to update:
+   - .claude/skills/adr-aware/SKILL.md
+     → Rule 1 table: Add resource type → ADR mapping
+     → Resource Type to Context Files Mapping table
+   - .claude/skills/task-execute/SKILL.md
+     → Step 4a: Tag → constraint mapping
+     → Step 4b: Tag → pattern mapping
+     → Step 5: ADR loading section
+   - .claude/skills/task-create/SKILL.md
+     → Step 3.4: Tag-to-Knowledge Mapping table
+     → Step 3.5: ADR mapping section
+
+□ 9. UPDATE root CLAUDE.md (if ADR adds critical constraint)
+   Location: /CLAUDE.md
+   Section: "Architecture Decision Records (ADRs)" table
+   Action: Add summary row for high-impact ADRs
+
+□ 10. UPDATE CROSS-REFERENCE-MAP.md
+   Location: /CROSS-REFERENCE-MAP.md
+   Action: Add entries showing ADR → files relationship
+
+□ 11. VERIFY consistency
+   Run: grep for ADR number across all .claude/ and CLAUDE.md files
+   Ensure: All references use correct paths
+```
+
+### Checklist B: New Constraint File
+
+When creating a new constraint file for a domain:
+
+```
+□ 1. CREATE constraint file
+   Location: .claude/constraints/{domain}.md
+   Structure:
+   - Purpose section
+   - MUST rules (positive constraints)
+   - MUST NOT rules (negative constraints)
+   - Quick reference table
+   - ADR references
+
+□ 2. UPDATE constraint INDEX
+   Location: .claude/constraints/INDEX.md
+   Add: New row with file, ADRs covered, line count
+
+□ 3. CREATE corresponding pattern directory
+   Location: .claude/patterns/{domain}/
+   Add: INDEX.md listing available patterns
+
+□ 4. UPDATE skill mappings
+   - .claude/skills/adr-aware/SKILL.md → Rule 2, Resource Type table
+   - .claude/skills/task-execute/SKILL.md → Step 4a table
+   - .claude/skills/task-create/SKILL.md → Step 3.4 table
+
+□ 5. ADD standard tag for domain
+   Location: .claude/skills/INDEX.md (Standard Tag Vocabulary)
+   Location: .claude/TAGGING-EXAMPLES.md (if applicable)
+
+□ 6. VERIFY pattern INDEX exists
+   Location: .claude/patterns/INDEX.md
+   Add: New domain pattern directory reference
+```
+
+### Checklist C: New Pattern File
+
+When adding a code pattern:
+
+```
+□ 1. CREATE pattern file
+   Location: .claude/patterns/{domain}/{pattern-name}.md
+   Content:
+   - Brief description
+   - When to use
+   - Code example (copy-paste ready)
+   - ADR references
+   - Related patterns
+
+□ 2. UPDATE domain pattern INDEX
+   Location: .claude/patterns/{domain}/INDEX.md
+   Add: New row with pattern name, purpose, ADR refs
+
+□ 3. UPDATE root pattern INDEX
+   Location: .claude/patterns/INDEX.md
+   Verify: Domain directory is listed
+
+□ 4. UPDATE skill mappings (if pattern should be auto-loaded)
+   - .claude/skills/adr-aware/SKILL.md → Rule 2c pattern loading
+   - .claude/skills/task-execute/SKILL.md → Step 4b table
+   - .claude/skills/task-create/SKILL.md → Step 3.4 Patterns column
+
+□ 5. ADD to CROSS-REFERENCE-MAP.md
+   Location: /CROSS-REFERENCE-MAP.md
+   Add: Pattern file with ADR relationships
+```
+
+### Checklist D: New Protocol (AIP)
+
+When creating a new AI Interaction Protocol:
+
+```
+□ 1. CREATE protocol file
+   Location: .claude/protocols/AIP-{NNN}-{slug}.md
+   Follow template in .claude/protocols/INDEX.md
+
+□ 2. UPDATE protocol INDEX
+   Location: .claude/protocols/INDEX.md
+   Add: New row with AIP number, title, purpose
+
+□ 3. EMBED critical rules in root CLAUDE.md
+   Location: /CLAUDE.md
+   Section: Appropriate section based on protocol topic
+   Action: Add summary of critical rules with reference to full AIP
+
+□ 4. UPDATE skill files (if protocol affects skill behavior)
+   Identify: Which skills should follow this protocol
+   Add: Reference to protocol in skill's "Related" section
+```
+
+### Checklist E: New Skill
+
+When creating a new skill:
+
+```
+□ 1. CREATE skill directory and files
+   Location: .claude/skills/{skill-name}/
+   Files:
+   - SKILL.md (required)
+   - references/ (optional)
+   - scripts/ (optional)
+   - assets/ (optional)
+
+□ 2. ADD YAML frontmatter to SKILL.md
+   Required fields:
+   - description: Brief phrase (5-10 words)
+   - tags: [tag1, tag2, ...]
+   - techStack: [tech1, tech2, ...]
+   - appliesTo: [patterns or scenarios]
+   - alwaysApply: true/false
+
+□ 3. UPDATE skills INDEX
+   Location: .claude/skills/INDEX.md
+   Add: Row to Available Skills table
+   Add: Entry in appropriate category section
+   Update: Skill Flow diagram if orchestrator/component
+
+□ 4. UPDATE SKILL-INTERACTION-GUIDE.md (if skill changes workflow)
+   Location: .claude/skills/SKILL-INTERACTION-GUIDE.md
+   Add: Skill to interaction matrix
+   Update: Workflow diagrams if needed
+
+□ 5. UPDATE root CLAUDE.md
+   Location: /CLAUDE.md
+   Section: "AI Agent Skills" → Trigger Phrases table
+   Add: Trigger phrase → skill mapping
+
+□ 6. ADD slash command (if user-invocable)
+   Location: /CLAUDE.md → Slash Commands table
+   Add: /{skill-name} with description
+
+□ 7. VERIFY tags use standard vocabulary
+   Reference: .claude/skills/INDEX.md → Standard Tag Vocabulary
+   Reference: .claude/TAGGING-EXAMPLES.md
+```
+
+### Checklist F: Update Root CLAUDE.md
+
+When modifying the main instruction file:
+
+```
+□ 1. IDENTIFY all places that might need parallel updates
+   - .claude/skills/INDEX.md (if skill-related)
+   - .claude/skills/SKILL-INTERACTION-GUIDE.md (if workflow)
+   - docs/CLAUDE.md (if documentation-related)
+   - Project-specific CLAUDE.md files
+
+□ 2. VERIFY path references are correct
+   - Use .claude/protocols/ (not docs/reference/protocols/)
+   - Use .claude/adr/ for concise ADRs
+   - Use docs/adr/ for full ADRs
+
+□ 3. UPDATE "Last Updated" dates
+   All affected files should have current date
+
+□ 4. RUN consistency check
+   Grep for old paths that might have been left behind
+```
+
+---
+
+## Cross-Reference Verification
+
+After completing any checklist, run these verification steps:
+
+```
+1. PATH CONSISTENCY CHECK
+   Search for old/wrong paths:
+   - "docs/reference/adr" → Should be ".claude/adr/" or "docs/adr/"
+   - "docs/ai-knowledge" → Directory removed; content in .claude/
+   - "docs/reference/protocols" → Should be ".claude/protocols/"
+
+2. INDEX COMPLETENESS CHECK
+   Verify each INDEX.md includes all files in directory:
+   - .claude/adr/INDEX.md vs actual ADR files
+   - .claude/constraints/INDEX.md vs actual constraint files
+   - .claude/patterns/*/INDEX.md vs actual pattern files
+   - .claude/skills/INDEX.md vs actual skill directories
+
+3. MAPPING CONSISTENCY CHECK
+   Verify skill mappings are consistent:
+   - adr-aware Rule 1 table matches task-execute Step 4a
+   - adr-aware Resource Type table matches task-create Step 3.4
+   - All constraint files are referenced in at least one skill
+
+4. DATE CONSISTENCY CHECK
+   All modified files should have "Last Updated" matching today's date
+```
+
+---
+
+## Quick Reference: File Locations
+
+| Element Type | Primary Location | Index File | Skills to Update |
+|--------------|------------------|------------|------------------|
+| ADR (Full) | `docs/adr/` | `docs/adr/INDEX.md` | — |
+| ADR (Concise) | `.claude/adr/` | `.claude/adr/INDEX.md` | adr-aware, task-execute, task-create |
+| Constraint | `.claude/constraints/` | `.claude/constraints/INDEX.md` | adr-aware, task-execute, task-create |
+| Pattern | `.claude/patterns/{domain}/` | `.claude/patterns/{domain}/INDEX.md` | adr-aware, task-execute, task-create |
+| Protocol | `.claude/protocols/` | `.claude/protocols/INDEX.md` | (varies by protocol) |
+| Skill | `.claude/skills/{name}/` | `.claude/skills/INDEX.md` | SKILL-INTERACTION-GUIDE, root CLAUDE.md |
+
+---
+
+## Example: Adding ADR-023
+
+**Scenario**: Adding a new ADR for "API Rate Limiting"
+
+```
+Step 1: Create docs/adr/ADR-023-api-rate-limiting.md (full version)
+Step 2: Create .claude/adr/ADR-023-api-rate-limiting.md (concise, ~120 lines)
+Step 3: Add to docs/adr/INDEX.md and .claude/adr/INDEX.md
+Step 4: Add rules to .claude/constraints/api.md:
+        - "MUST implement rate limiting on public endpoints"
+        - "MUST use sliding window algorithm"
+Step 5: Update .claude/constraints/INDEX.md (update api.md line count)
+Step 6: Create .claude/patterns/api/rate-limiting.md with code example
+Step 7: Add to .claude/patterns/api/INDEX.md
+Step 8: Update skill mappings:
+        - adr-aware: Add "Rate Limiting" → ADR-023 to Rule 1
+        - task-execute: Add rate-limiting pattern to Step 4b
+        - task-create: Add to Step 3.4 api row
+Step 9: Add to CLAUDE.md ADR table (if high-impact)
+Step 10: Add to CROSS-REFERENCE-MAP.md
+Step 11: Grep verify: Search "ADR-023" appears consistently
+```
+
+---
+
+## Automation Opportunity
+
+**Future Enhancement**: Create a script that:
+1. Scans all INDEX.md files for completeness
+2. Checks path references for correctness
+3. Validates skill mapping consistency
+4. Reports missing cross-references
+
+Location: `scripts/Validate-AIProcedures.ps1` (to be created)
+
+---
+
+## Related Skills
+
+- **adr-aware**: Consumes ADR mappings this skill maintains
+- **task-execute**: Uses constraint/pattern mappings
+- **task-create**: Uses knowledge mapping tables
+- **repo-cleanup**: Can validate procedure file structure
+
+---
+
+*Last updated: December 25, 2025*

--- a/.claude/skills/project-pipeline/SKILL.md
+++ b/.claude/skills/project-pipeline/SKILL.md
@@ -138,11 +138,21 @@ DISCOVER RESOURCES (Comprehensive):
      - Identify canonical implementations to follow
      - Example: Existing PCF controls for reference
 
+  6. DISCOVER applicable scripts (via script-aware)
+     - READ scripts/README.md for script registry
+     - Match spec keywords to script purposes:
+       - PCF deployment → Deploy-PCFWebResources.ps1
+       - API testing → Test-SdapBffApi.ps1
+       - Custom pages → Deploy-CustomPage.ps1
+       - Ribbon work → Export-EntityRibbon.ps1
+     - Note scripts for inclusion in task files
+
 OUTPUT: Comprehensive resource discovery summary
   - X ADRs loaded (with full content)
   - Y skills applicable (with file paths)
   - Z knowledge docs found (guides + patterns)
   - N code examples identified
+  - M scripts available (for deployment/testing steps)
 
 ⚠️ **DIFFERENCE from design-to-spec Step 3**:
 - design-to-spec: Preliminary (ADR constraints only for spec enrichment)
@@ -183,6 +193,7 @@ ENHANCE CLAUDE.md with discovered resources:
    - 4 ADRs identified (ADR-001, ADR-007, ADR-008, ADR-010)
    - 2 skills applicable (dataverse-deploy, adr-aware)
    - 3 knowledge docs found (SPAARKE-ARCHITECTURE.md, ...)
+   - 2 scripts available (Deploy-PCFWebResources.ps1, Test-SdapBffApi.ps1)
 
 ✅ Artifacts generated:
    - README.md (project overview, graduation criteria)

--- a/.claude/skills/script-aware/SKILL.md
+++ b/.claude/skills/script-aware/SKILL.md
@@ -1,0 +1,301 @@
+---
+description: Discover and use existing scripts from the script library before writing new code
+tags: [scripts, reuse, deployment, testing, automation]
+techStack: [powershell, javascript, dotnet]
+appliesTo: ["deploy", "test", "validate", "diagnose", "setup"]
+alwaysApply: true
+---
+
+# script-aware
+
+> **Category**: Context Loading (Always-Apply)
+> **Last Updated**: December 2025
+
+---
+
+## Purpose
+
+Prevent Claude Code from re-engineering or rewriting commonly reused scripts by proactively checking the script library before implementation.
+
+**Problem this solves**: Claude Code often writes new scripts for tasks that already have tested, working scripts in `scripts/`.
+
+**Solution**: Load script registry context before coding tasks that involve deployment, testing, validation, or automation.
+
+---
+
+## When to Apply
+
+This skill is **always-apply** and triggers when:
+
+1. **Task tags include**: `deploy`, `test`, `validate`, `diagnose`, `setup`, `automation`
+2. **Task steps mention**: deployment, testing, validation, health checks, diagnostics
+3. **User requests**: "deploy to...", "test the...", "validate...", "check..."
+4. **Creating new scripts**: Before writing any `.ps1`, `.js`, or automation script
+
+---
+
+## Script Discovery Protocol
+
+### Step 1: Load Script Registry
+
+```
+READ scripts/README.md
+
+EXTRACT:
+  - Script categories (Deployment, Testing, Setup, Diagnostics)
+  - Script names and purposes
+  - Usage frequency (Active/Occasional/Archive)
+  - Dependencies and prerequisites
+```
+
+### Step 2: Match Task to Scripts
+
+```
+FOR current task/request:
+  IDENTIFY keywords: deploy, test, validate, PCF, API, Dataverse, SPE, etc.
+
+  SEARCH scripts/README.md for matching scripts:
+    - By category (Deployment, Testing, etc.)
+    - By target (PCF, API, custom page, etc.)
+    - By action (deploy, test, validate, export, import)
+
+IF matching script found:
+  → USE existing script (invoke or reference)
+  → DO NOT rewrite equivalent functionality
+
+IF no matching script:
+  → PROCEED with implementation
+  → CONSIDER creating new script (see Script Creation below)
+```
+
+### Step 3: Script Invocation
+
+```
+WHEN invoking a script:
+  1. READ the script file to understand parameters
+  2. CHECK prerequisites (PAC CLI auth, az login, etc.)
+  3. INVOKE with appropriate parameters
+  4. HANDLE output and errors
+
+COMMON PATTERNS:
+  - PCF deployment: .\Deploy-PCFWebResources.ps1 -ControlName "X"
+  - API testing: .\Test-SdapBffApi.ps1 -Environment "dev"
+  - Health check: node test-sdap-api-health.js <url>
+```
+
+---
+
+## Script Categories Quick Reference
+
+### Deployment Scripts (Use for: PCF, Custom Pages, Web Resources)
+
+| Script | Purpose | When to Use |
+|--------|---------|-------------|
+| `Deploy-PCFWebResources.ps1` | Deploy PCF to Dataverse | After `npm run build` |
+| `Deploy-CustomPage.ps1` | Deploy custom pages | After custom page changes |
+| `Deploy-ThemeIcons.ps1` | Deploy theme icons | After icon updates |
+| `Deploy-SubgridCommands.ps1` | Deploy subgrid commands | After ribbon changes |
+
+### Testing Scripts (Use for: API validation, Health checks)
+
+| Script | Purpose | When to Use |
+|--------|---------|-------------|
+| `Test-SdapBffApi.ps1` | Comprehensive API test | After API deployment |
+| `test-sdap-api-health.js` | Quick health check | Quick validation |
+| `test-dataverse-connection.cs` | Test Dataverse connectivity | Connection issues |
+
+### Diagnostic Scripts (Use for: Troubleshooting)
+
+| Script | Purpose | When to Use |
+|--------|---------|-------------|
+| `Diagnose-AiSummaryService.ps1` | Debug AI summary issues | AI feature problems |
+| `Debug-RegistrationFailure.ps1` | Debug SPE registration | SPE setup issues |
+| `Check-ContainerType-Registration.ps1` | Verify CT registration | SPE validation |
+
+### Export/Import Scripts (Use for: Ribbon, Solution work)
+
+| Script | Purpose | When to Use |
+|--------|---------|-------------|
+| `Export-EntityRibbon.ps1` | Export entity ribbon XML | Before ribbon edits |
+| `Export-ThemeRibbon.ps1` | Export theme ribbon | Theme customization |
+
+---
+
+## Script Creation Protocol
+
+### When to Create a New Script
+
+Create a new script when:
+
+1. **Repeated task**: Same sequence of commands used 3+ times
+2. **Complex automation**: Multi-step process that benefits from encapsulation
+3. **Reusable utility**: Functionality useful across multiple projects/tasks
+4. **No existing script**: Checked registry, nothing matches
+
+### Script Creation Checklist
+
+```
+BEFORE creating new script:
+  [ ] Searched scripts/README.md - no existing match
+  [ ] Task is repeatable (not one-time)
+  [ ] Script adds value over inline commands
+
+WHEN creating new script:
+  1. Follow naming convention: Action-Target-Method.ps1
+  2. Add inline documentation (synopsis, parameters, examples)
+  3. Add entry to scripts/README.md with:
+     - Purpose
+     - Usage frequency (likely: Active/Occasional)
+     - Lifecycle status (Maintained)
+     - Dependencies
+     - When to use
+     - Command example
+  4. Place in appropriate location:
+     - General: scripts/
+     - Project-specific: projects/{name}/scripts/
+     - Module-specific: src/{module}/scripts/
+
+AFTER creating new script:
+  [ ] README.md entry added
+  [ ] Script tested and working
+  [ ] Dependencies documented
+```
+
+### Script Template
+
+```powershell
+<#
+.SYNOPSIS
+    Brief description of what this script does
+
+.DESCRIPTION
+    Detailed description including:
+    - What problem it solves
+    - Prerequisites
+    - Expected outcomes
+
+.PARAMETER ParameterName
+    Description of the parameter
+
+.EXAMPLE
+    .\Script-Name.ps1 -Parameter "value"
+    Description of what this example does
+
+.NOTES
+    Author: Claude Code
+    Created: YYYY-MM-DD
+    Dependencies: List any required tools (PAC CLI, az, etc.)
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$RequiredParam,
+
+    [Parameter(Mandatory=$false)]
+    [string]$OptionalParam = "default"
+)
+
+# Implementation
+```
+
+---
+
+## Script Maintenance Protocol
+
+### After Task Completion
+
+```
+IF task involved using a script:
+  VERIFY script still works as expected
+  IF script needed modifications:
+    UPDATE the script file
+    UPDATE scripts/README.md if behavior changed
+
+IF task created reusable automation:
+  EVALUATE: Should this become a script?
+  IF yes: Follow Script Creation Protocol
+```
+
+### Script Registry Maintenance
+
+```
+WHEN working with scripts:
+  CHECK scripts/README.md is accurate:
+    - Last Used dates current
+    - Usage frequency reflects reality
+    - Deprecated scripts marked
+
+  UPDATE if needed:
+    - Add new scripts created
+    - Mark unused scripts as Archive
+    - Update dependencies if changed
+```
+
+---
+
+## Integration with Other Skills
+
+### task-execute Integration
+
+The `task-execute` skill should:
+1. Load this skill's context for tasks with deployment/testing tags
+2. Check script registry before coding automation steps
+3. Update script registry after task completion if scripts were created/modified
+
+### project-pipeline Integration
+
+The `project-pipeline` skill should:
+1. Discover relevant scripts during resource discovery (Step 1)
+2. Include applicable scripts in PLAN.md "Discovered Resources"
+3. Reference scripts in generated task files where applicable
+
+### dataverse-deploy Integration
+
+The `dataverse-deploy` skill should:
+1. Reference deployment scripts rather than inline commands
+2. Use `Deploy-PCFWebResources.ps1` for PCF deployment
+3. Use `Test-SdapBffApi.ps1` for post-deployment validation
+
+---
+
+## Example: Task with Script Awareness
+
+**Task**: Deploy updated AISummaryPanel PCF control
+
+**Without script-aware**:
+```
+Claude writes new deployment commands inline...
+```
+
+**With script-aware**:
+```
+1. CHECK scripts/README.md for deployment scripts
+2. FIND: Deploy-PCFWebResources.ps1 matches "PCF deployment"
+3. READ script to understand parameters
+4. INVOKE: .\scripts\Deploy-PCFWebResources.ps1 -ControlName "AISummaryPanel"
+5. VERIFY deployment with Test-SdapBffApi.ps1
+```
+
+---
+
+## Failure Modes to Avoid
+
+| Failure | Cause | Prevention |
+|---------|-------|------------|
+| Rewrote existing script | Didn't check registry | ALWAYS read scripts/README.md first |
+| Script not found | Registry out of date | Keep README.md updated |
+| Wrong script used | Misunderstood purpose | READ script file, not just name |
+| Script failed | Missing prerequisites | CHECK dependencies before invoking |
+
+---
+
+## Related Files
+
+- **Script Registry**: `scripts/README.md`
+- **Script Location**: `scripts/` (general), `projects/*/scripts/` (project-specific)
+- **task-execute**: `.claude/skills/task-execute/SKILL.md`
+- **dataverse-deploy**: `.claude/skills/dataverse-deploy/SKILL.md`
+
+---
+
+*This skill ensures Claude Code reuses existing automation rather than reinventing it, and maintains the script library for future use.*

--- a/.claude/skills/task-create/SKILL.md
+++ b/.claude/skills/task-create/SKILL.md
@@ -79,14 +79,17 @@ FOR each WBS phase:
 
 When a task has these tags, ALWAYS include these knowledge files:
 
-| Tag | Required Knowledge Files |
-|-----|-------------------------|
-| `pcf`, `react`, `fluent-ui`, `frontend` | `src/client/pcf/CLAUDE.md`, `docs/ai-knowledge/guides/PCF-V9-PACKAGING.md`, `.claude/skills/dataverse-deploy/SKILL.md` |
-| `bff-api`, `api`, `minimal-api`, `endpoints` | `src/server/api/CLAUDE.md` (if exists), `docs/reference/adr/ADR-001-minimal-api-endpoints.md` |
-| `dataverse`, `solution`, `fields` | `.claude/skills/dataverse-deploy/SKILL.md`, `infrastructure/dataverse/CLAUDE.md` (if exists) |
-| `deploy` | `.claude/skills/dataverse-deploy/SKILL.md`, `docs/ai-knowledge/guides/PCF-V9-PACKAGING.md` |
-| `azure`, `azure-search`, `azure-openai` | `docs/reference/adr/ADR-013-ai-architecture.md` |
-| `testing`, `unit-test`, `integration-test` | `tests/CLAUDE.md` |
+| Tag | Constraints | Patterns | Additional Files |
+|-----|-------------|----------|------------------|
+| `pcf`, `react`, `fluent-ui`, `frontend` | `.claude/constraints/pcf.md` | `.claude/patterns/pcf/control-initialization.md`, `.claude/patterns/pcf/theme-management.md` | `src/client/pcf/CLAUDE.md`, `docs/guides/PCF-V9-PACKAGING.md` |
+| `bff-api`, `api`, `minimal-api`, `endpoints` | `.claude/constraints/api.md` | `.claude/patterns/api/endpoint-definition.md`, `.claude/patterns/api/endpoint-filters.md` | `src/server/api/CLAUDE.md` (if exists) |
+| `dataverse`, `solution`, `fields`, `plugin` | `.claude/constraints/plugins.md` | `.claude/patterns/dataverse/plugin-structure.md` | `.claude/skills/dataverse-deploy/SKILL.md` |
+| `auth`, `oauth`, `authorization` | `.claude/constraints/auth.md` | `.claude/patterns/auth/obo-flow.md`, `.claude/patterns/auth/oauth-scopes.md` | — |
+| `cache`, `redis`, `caching` | `.claude/constraints/data.md` | `.claude/patterns/caching/distributed-cache.md` | — |
+| `ai`, `azure-openai`, `document-intelligence` | `.claude/constraints/ai.md` | `.claude/patterns/ai/streaming-endpoints.md` | — |
+| `deploy` | — | — | `.claude/skills/dataverse-deploy/SKILL.md`, `docs/guides/PCF-V9-PACKAGING.md` |
+| `testing`, `unit-test`, `integration-test` | `.claude/constraints/testing.md` | `.claude/patterns/testing/unit-test-structure.md`, `.claude/patterns/testing/mocking-patterns.md` | — |
+| `worker`, `job`, `background` | `.claude/constraints/jobs.md` | — | — |
 
 **Critical: PCF tasks MUST reference PCF-V9-PACKAGING.md**
 
@@ -100,8 +103,10 @@ FOR each task:
   EXTRACT tags from <metadata><tags>
   FOR each tag:
     LOOKUP in Tag-to-Knowledge Mapping
-    ADD all matching files to <knowledge><files>
-  
+    ADD matching constraint file to <knowledge><files>
+    ADD matching pattern files to <knowledge><files>
+    ADD matching additional files to <knowledge><files>
+
   ENSURE <knowledge> section is NOT empty
   IF no matches found:
     ADD at minimum: relevant CLAUDE.md for the module being modified
@@ -117,13 +122,17 @@ FOR each task identified:
     - Caching → ADR-009
     - Dataverse Plugin → ADR-002
     - Graph/SPE Integration → ADR-007
-    - PCF Control → ADR-006, ADR-011, ADR-012
+    - PCF Control → ADR-006, ADR-011, ADR-012, ADR-021
     - Background Worker → ADR-001, ADR-004
     - DI Registration → ADR-010
-  
+    - AI Features → ADR-013, ADR-014, ADR-015, ADR-016
+    - Testing → ADR-022
+
   ADD to task:
     - <constraints> with source="ADR-XXX" for each applicable ADR
-    - <knowledge><files> including relevant ADR paths
+    - <knowledge><files> include CONCISE ADR paths:
+      - Use .claude/adr/ADR-XXX-*.md (100-150 lines, AI-optimized)
+      - NOT docs/adr/ADR-XXX-*.md (full version, load only if needed)
 
 REFERENCE: See adr-aware skill for full mapping table
 ```

--- a/.claude/skills/task-execute/SKILL.md
+++ b/.claude/skills/task-execute/SKILL.md
@@ -116,24 +116,68 @@ FOR each file in <knowledge><files>:
 FOR each pattern in <knowledge><patterns>:
   READ the referenced file
   UNDERSTAND the pattern to follow
+```
 
-COMMON KNOWLEDGE FILES BY TAG:
+#### 4a. Load Constraints by Tag (MANDATORY)
+
+**Based on task tags, load the appropriate constraint files:**
+
+| Task Tags | Load Constraints File |
+|-----------|----------------------|
+| `bff-api`, `api`, `minimal-api`, `endpoints` | `.claude/constraints/api.md` |
+| `pcf`, `react`, `fluent-ui`, `frontend` | `.claude/constraints/pcf.md` |
+| `dataverse`, `plugin`, `solution` | `.claude/constraints/plugins.md` |
+| `auth`, `oauth`, `authorization` | `.claude/constraints/auth.md` |
+| `cache`, `redis`, `data` | `.claude/constraints/data.md` |
+| `ai`, `azure-openai`, `document-intelligence` | `.claude/constraints/ai.md` |
+| `worker`, `job`, `background` | `.claude/constraints/jobs.md` |
+| `testing`, `unit-test`, `integration-test` | `.claude/constraints/testing.md` |
+| `config`, `feature-flag` | `.claude/constraints/config.md` |
+
+#### 4b. Load Patterns by Tag (RECOMMENDED)
+
+**Based on task tags, load relevant pattern files:**
+
+| Task Tags | Load Pattern Files |
+|-----------|-------------------|
+| `bff-api`, `api` | `.claude/patterns/api/endpoint-definition.md`, `.claude/patterns/api/endpoint-filters.md` |
+| `pcf`, `react` | `.claude/patterns/pcf/control-initialization.md`, `.claude/patterns/pcf/theme-management.md` |
+| `auth`, `oauth` | `.claude/patterns/auth/obo-flow.md`, `.claude/patterns/auth/oauth-scopes.md` |
+| `dataverse`, `plugin` | `.claude/patterns/dataverse/plugin-structure.md` |
+| `cache` | `.claude/patterns/caching/distributed-cache.md` |
+| `testing` | `.claude/patterns/testing/unit-test-structure.md`, `.claude/patterns/testing/mocking-patterns.md` |
+
+#### 4c. Common Knowledge Files by Tag
+
+```
+ADDITIONAL MODULE-SPECIFIC FILES:
   - pcf tags → READ src/client/pcf/CLAUDE.md
-  - pcf tags → READ docs/ai-knowledge/guides/PCF-V9-PACKAGING.md
+  - pcf tags → READ docs/guides/PCF-V9-PACKAGING.md
   - bff-api tags → READ src/server/api/CLAUDE.md (if exists)
   - dataverse tags → READ .claude/skills/dataverse-deploy/SKILL.md
   - deploy tags → READ .claude/skills/dataverse-deploy/SKILL.md
 
 UPDATE current-task.md:
   - Add "Knowledge Files Loaded" section with paths
+  - Add "Constraints Loaded" section with constraint file names
+  - Add "Patterns Loaded" section with pattern file names
 ```
 
-### Step 5: Load ADR Constraints
+### Step 5: Load ADR Constraints (Two-Tier)
 
 ```
 FOR each <constraint source="ADR-XXX">:
-  READ docs/adr/ADR-XXX-*.md
-  NOTE specific requirements that apply
+
+  TIER 1 (Default - Concise):
+    READ .claude/adr/ADR-XXX-*.md
+    - These are 100-150 line AI-optimized versions
+    - Contain MUST/MUST NOT rules
+    - Sufficient for most implementation tasks
+
+  TIER 2 (If Needed - Full Context):
+    IF constraint is unclear or need historical rationale:
+      READ docs/adr/ADR-XXX-*.md
+      - Full version with history, alternatives considered, consequences
 
 UPDATE current-task.md:
   - Add "Applicable ADRs" section with ADR numbers and relevance
@@ -144,6 +188,29 @@ UPDATE current-task.md:
 ```
 LOAD .claude/skills/adr-aware/SKILL.md
 LOAD .claude/skills/spaarke-conventions/SKILL.md
+LOAD .claude/skills/script-aware/SKILL.md
+```
+
+### Step 6.5: Load Script Context (for deployment/testing tasks)
+
+```
+IF task tags include: deploy, test, validate, automation, setup
+  OR task steps mention: deployment, testing, validation, health check
+
+THEN:
+  READ scripts/README.md
+  IDENTIFY relevant scripts for this task
+  NOTE scripts to use instead of writing new automation
+
+COMMON SCRIPT MATCHES:
+  - PCF deployment → Deploy-PCFWebResources.ps1
+  - API testing → Test-SdapBffApi.ps1
+  - Health checks → test-sdap-api-health.js
+  - Custom page deploy → Deploy-CustomPage.ps1
+  - Ribbon export → Export-EntityRibbon.ps1
+
+UPDATE current-task.md:
+  - Add "Available Scripts" section with matched scripts
 ```
 
 ### Step 7: Review Relevant CLAUDE.md Files
@@ -209,6 +276,33 @@ UPDATE task file <metadata><status> to "completed"
 ADD <notes> section with completion summary
 
 UPDATE TASK-INDEX.md with ✅ completed status
+```
+
+### Step 10.5: Script Library Maintenance
+
+```
+AFTER task completion, EVALUATE script library updates:
+
+IF task USED existing scripts:
+  VERIFY scripts still work as expected
+  IF script needed modifications:
+    UPDATE script file
+    UPDATE scripts/README.md (Last Used, any behavior changes)
+
+IF task CREATED reusable automation (commands used 3+ times):
+  EVALUATE: Should this become a script?
+
+  IF yes (repeatable, complex, multi-step):
+    1. CREATE new script following naming convention
+    2. ADD inline documentation (synopsis, parameters, examples)
+    3. ADD entry to scripts/README.md with:
+       - Purpose, Usage frequency, Lifecycle status
+       - Dependencies, When to use, Command example
+    4. Place in: scripts/ (general) or projects/{name}/scripts/ (project-specific)
+
+IF task DEPRECATED script functionality:
+  UPDATE scripts/README.md to mark as ⚠️ Deprecated
+  NOTE replacement approach
 ```
 
 ### Step 11: Transition to Next Task
@@ -438,6 +532,7 @@ When task has `deploy` tag:
 
 - **task-create**: Creates the task files this skill executes
 - **adr-aware**: Proactive ADR loading (always-apply)
+- **script-aware**: Script library discovery and maintenance (always-apply)
 - **dataverse-deploy**: Deployment operations
 - **code-review**: Post-implementation review
 - **project-pipeline**: Initializes current-task.md for projects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - Spaarke Repository Instructions
 
-> **Last Updated**: December 24, 2025
+> **Last Updated**: December 25, 2025
 >
 > **Purpose**: This file provides repository-wide context and instructions for Claude Code when working in this codebase.
 
@@ -121,6 +121,7 @@ These skills are **called BY orchestrators** and should NOT be invoked directly 
 | `project-setup` | Generate artifacts only (README, PLAN, CLAUDE.md) | `project-pipeline` (Step 2) |
 | `task-create` | Decompose plan.md into task files | `project-pipeline` (Step 3) |
 | `adr-aware` | Load applicable ADRs based on resource types | Multiple skills (auto) |
+| `script-aware` | Discover and reuse scripts from library | Multiple skills (auto) |
 
 **Exception**: `task-execute` is also a skill, but it **IS developer-facing** for daily task work:
 - Used in Step 3 above: `work on task 001` invokes `task-execute`
@@ -187,7 +188,7 @@ After completing any task:
 
 **Important**: `current-task.md` tracks only the **active task**, not history. Task history is preserved in TASK-INDEX.md and individual .poml files.
 
-**Full protocols**: `docs/reference/protocols/` (AIP-001, AIP-002, AIP-003)
+**Full protocols**: `.claude/protocols/` (AIP-001, AIP-002, AIP-003)
 
 ---
 
@@ -217,6 +218,7 @@ When these phrases are detected, **STOP** and load the corresponding skill:
 | "edit ribbon", "add ribbon button", "ribbon customization", "command bar button" | `ribbon-edit` | Load `.claude/skills/ribbon-edit/SKILL.md` and follow procedure |
 | "pull from github", "update from remote", "sync with github", "git pull", "get latest" | `pull-from-github` | Load `.claude/skills/pull-from-github/SKILL.md` and follow procedure |
 | "push to github", "create PR", "commit and push", "ready to merge", "submit changes" | `push-to-github` | Load `.claude/skills/push-to-github/SKILL.md` and follow procedure |
+| "update AI procedures", "add new ADR", "propagate changes", "maintain procedures" | `ai-procedure-maintenance` | Load `.claude/skills/ai-procedure-maintenance/SKILL.md` and follow checklists |
 
 ### Auto-Detection Rules
 
@@ -237,6 +239,7 @@ These skills are **automatically active** during all coding work:
 | Skill | Purpose |
 |-------|---------|
 | `adr-aware` | Proactively load relevant ADRs before creating resources |
+| `script-aware` | Discover and reuse scripts from library before writing new automation |
 | `spaarke-conventions` | Apply naming conventions and code patterns |
 
 ### Slash Commands
@@ -257,28 +260,48 @@ Use these commands to explicitly invoke skills:
 | `/ribbon-edit` | Edit Dataverse ribbon via solution export/import |
 | `/pull-from-github` | Pull latest changes from GitHub |
 | `/push-to-github` | Commit changes and push to GitHub |
+| `/ai-procedure-maintenance` | Propagate updates when adding ADRs, patterns, constraints, skills |
 
 ---
 
 ## Documentation
 
-Coding-relevant documentation is in `/docs/ai-knowledge/`. Reference these documents for architecture, standards, and workflow guidance.
+### AI-Optimized Context (Load First)
 
-**Do not reference `/docs/reference/` unless explicitly directed**—it contains background material not relevant to most coding tasks.
+`.claude/` contains **concise, AI-optimized** content for efficient context loading:
+
+```
+.claude/
+├── adr/                      # Concise ADRs (~100-150 lines each)
+├── constraints/              # MUST/MUST NOT rules by topic
+├── patterns/                 # Code patterns and examples
+├── protocols/                # AI behavior protocols
+├── skills/                   # Skill definitions and workflows
+└── templates/                # Project/task templates
+```
+
+### Full Reference Documentation (Load When Needed)
+
+`docs/` contains **complete documentation** for deep dives:
 
 ```
 docs/
-├── ai-knowledge/             # ✅ REFERENCE for coding tasks
-│   ├── architecture/         # System patterns (SDAP, auth boundaries)
-│   ├── standards/            # OAuth/OBO, Dataverse auth patterns
-│   ├── guides/               # How-to procedures
-│   └── templates/            # Project/task scaffolding
-└── reference/                # ⚠️ DO NOT LOAD unless asked
-    ├── adr/                  # Architecture Decision Records (system principles)
-    ├── protocols/            # AI Protocols (AI behavior principles)
-    ├── procedures/           # Full process documentation
-    └── research/             # Verbose KM-* articles
+├── adr/                      # Full ADRs with history and rationale
+├── architecture/             # System architecture docs
+├── guides/                   # How-to guides and procedures
+├── procedures/               # Process documentation
+├── standards/                # Coding and auth standards
+└── product-documentation/    # User-facing docs
 ```
+
+### Loading Strategy
+
+| Need | Location | Action |
+|------|----------|--------|
+| Constraints, patterns | `.claude/` | ✅ Load by default |
+| Full rationale, history | `docs/` | ⚠️ Load when deep dive needed |
+| ADR constraints | `.claude/adr/ADR-XXX.md` | ✅ Use for implementation |
+| ADR full context | `docs/adr/ADR-XXX-*.md` | ⚠️ Use for architectural decisions |
 
 ---
 
@@ -540,4 +563,4 @@ See `CLAUDE.md` files in subdirectories for module-specific guidance:
 
 ---
 
-*Last updated: December 2025*
+*Last updated: December 25, 2025*

--- a/CROSS-REFERENCE-MAP.md
+++ b/CROSS-REFERENCE-MAP.md
@@ -23,27 +23,26 @@
 | ADR # | AI Context File | Full Documentation | Constraints | Patterns |
 |-------|----------------|-------------------|-------------|----------|
 | 001 | `.claude/adr/ADR-001-minimal-api.md` | [docs/adr/ADR-001-minimal-api-and-workers.md](docs/adr/ADR-001-minimal-api-and-workers.md) | [api.md](.claude/constraints/api.md) | [api/endpoint-definition.md](.claude/patterns/api/endpoint-definition.md) |
-| 002 | `.claude/adr/ADR-002-thin-plugins.md` | [docs/adr/ADR-002-thin-plugins.md](docs/adr/ADR-002-thin-plugins.md) | [plugins.md](.claude/constraints/plugins.md) | [dataverse/plugin-structure.md](.claude/patterns/dataverse/plugin-structure.md) |
-| 003 | `.claude/adr/ADR-003-entity-data-contract.md` | [docs/adr/ADR-003-entity-data-contract-spe-link.md](docs/adr/ADR-003-entity-data-contract-spe-link.md) | [data.md](.claude/constraints/data.md) | - |
-| 004 | `.claude/adr/ADR-004-bff-authorization.md` | [docs/adr/ADR-004-bff-api-authorization.md](docs/adr/ADR-004-bff-api-authorization.md) | [auth.md](.claude/constraints/auth.md), [api.md](.claude/constraints/api.md) | [auth/oauth-scopes.md](.claude/patterns/auth/oauth-scopes.md), [api/endpoint-filters.md](.claude/patterns/api/endpoint-filters.md) |
-| 005 | `.claude/adr/ADR-005-graph-api-usage.md` | [docs/adr/ADR-005-graph-api-usage-in-bff.md](docs/adr/ADR-005-graph-api-usage-in-bff.md) | [data.md](.claude/constraints/data.md) | - |
-| 006 | `.claude/adr/ADR-006-pcf-over-webresources.md` | [docs/adr/ADR-006-pcf-over-webresources.md](docs/adr/ADR-006-pcf-over-webresources.md) | [pcf.md](.claude/constraints/pcf.md) | [pcf/control-initialization.md](.claude/patterns/pcf/control-initialization.md) |
-| 007 | `.claude/adr/ADR-007-spefilestore-facade.md` | [docs/adr/ADR-007-spefilestore-facade.md](docs/adr/ADR-007-spefilestore-facade.md) | [data.md](.claude/constraints/data.md) | - |
-| 008 | `.claude/adr/ADR-008-endpoint-filters.md` | [docs/adr/ADR-008-endpoint-filters.md](docs/adr/ADR-008-endpoint-filters.md) | [api.md](.claude/constraints/api.md), [auth.md](.claude/constraints/auth.md) | [api/endpoint-filters.md](.claude/patterns/api/endpoint-filters.md) |
-| 009 | `.claude/adr/ADR-009-redis-caching.md` | [docs/adr/ADR-009-redis-first-caching.md](docs/adr/ADR-009-redis-first-caching.md) | [data.md](.claude/constraints/data.md) | - |
+| 002 | `.claude/adr/ADR-002-thin-plugins.md` | [docs/adr/ADR-002-no-heavy-plugins.md](docs/adr/ADR-002-no-heavy-plugins.md) | [plugins.md](.claude/constraints/plugins.md) | [dataverse/plugin-structure.md](.claude/patterns/dataverse/plugin-structure.md) |
+| 003 | `.claude/adr/ADR-003-authorization-seams.md` | [docs/adr/ADR-003-lean-authorization-seams.md](docs/adr/ADR-003-lean-authorization-seams.md) | [auth.md](.claude/constraints/auth.md) | - |
+| 004 | `.claude/adr/ADR-004-job-contract.md` | [docs/adr/ADR-004-async-job-contract.md](docs/adr/ADR-004-async-job-contract.md) | [jobs.md](.claude/constraints/jobs.md) | - |
+| 005 | `.claude/adr/ADR-005-flat-storage.md` | [docs/adr/ADR-005-flat-storage-spe.md](docs/adr/ADR-005-flat-storage-spe.md) | [data.md](.claude/constraints/data.md) | - |
+| 006 | `.claude/adr/ADR-006-pcf-over-webresources.md` | [docs/adr/ADR-006-prefer-pcf-over-webresources.md](docs/adr/ADR-006-prefer-pcf-over-webresources.md) | [pcf.md](.claude/constraints/pcf.md) | [pcf/control-initialization.md](.claude/patterns/pcf/control-initialization.md) |
+| 007 | `.claude/adr/ADR-007-spefilestore.md` | [docs/adr/ADR-007-spe-storage-seam-minimalism.md](docs/adr/ADR-007-spe-storage-seam-minimalism.md) | [data.md](.claude/constraints/data.md) | - |
+| 008 | `.claude/adr/ADR-008-endpoint-filters.md` | [docs/adr/ADR-008-authorization-endpoint-filters.md](docs/adr/ADR-008-authorization-endpoint-filters.md) | [api.md](.claude/constraints/api.md), [auth.md](.claude/constraints/auth.md) | [api/endpoint-filters.md](.claude/patterns/api/endpoint-filters.md) |
+| 009 | `.claude/adr/ADR-009-redis-caching.md` | [docs/adr/ADR-009-caching-redis-first.md](docs/adr/ADR-009-caching-redis-first.md) | [data.md](.claude/constraints/data.md) | [caching/distributed-cache.md](.claude/patterns/caching/distributed-cache.md) |
 | 010 | `.claude/adr/ADR-010-di-minimalism.md` | [docs/adr/ADR-010-di-minimalism.md](docs/adr/ADR-010-di-minimalism.md) | [api.md](.claude/constraints/api.md) | [api/service-registration.md](.claude/patterns/api/service-registration.md) |
-| 011 | `.claude/adr/ADR-011-serverless-rejection.md` | [docs/adr/ADR-011-serverless-function-rejection.md](docs/adr/ADR-011-serverless-function-rejection.md) | [api.md](.claude/constraints/api.md) | - |
+| 011 | `.claude/adr/ADR-011-dataset-pcf.md` | [docs/adr/ADR-011-dataset-pcf-over-subgrids.md](docs/adr/ADR-011-dataset-pcf-over-subgrids.md) | [pcf.md](.claude/constraints/pcf.md) | - |
 | 012 | `.claude/adr/ADR-012-shared-components.md` | [docs/adr/ADR-012-shared-component-library.md](docs/adr/ADR-012-shared-component-library.md) | [pcf.md](.claude/constraints/pcf.md) | [pcf/theme-management.md](.claude/patterns/pcf/theme-management.md) |
-| 013 | `.claude/adr/ADR-013-ai-architecture.md` | [docs/adr/ADR-013-ai-architecture.md](docs/adr/ADR-013-ai-architecture.md) | [ai.md](.claude/constraints/ai.md) | - |
-| 014 | `.claude/adr/ADR-014-pcf-metadata-caching.md` | [docs/adr/ADR-014-pcf-metadata-caching.md](docs/adr/ADR-014-pcf-metadata-caching.md) | [pcf.md](.claude/constraints/pcf.md) | [pcf/dataverse-queries.md](.claude/patterns/pcf/dataverse-queries.md) |
-| 015 | `.claude/adr/ADR-015-pcf-module-structure.md` | [docs/adr/ADR-015-pcf-module-structure.md](docs/adr/ADR-015-pcf-module-structure.md) | [pcf.md](.claude/constraints/pcf.md) | [pcf/control-initialization.md](.claude/patterns/pcf/control-initialization.md) |
-| 016 | `.claude/adr/ADR-016-dataverse-auth.md` | [docs/adr/ADR-016-dataverse-auth-patterns.md](docs/adr/ADR-016-dataverse-auth-patterns.md) | [auth.md](.claude/constraints/auth.md) | [auth/service-principal.md](.claude/patterns/auth/service-principal.md) |
-| 017 | `.claude/adr/ADR-017-bff-resiliency.md` | [docs/adr/ADR-017-bff-resiliency.md](docs/adr/ADR-017-bff-resiliency.md) | [api.md](.claude/constraints/api.md) | [api/resilience.md](.claude/patterns/api/resilience.md) |
-| 018 | `.claude/adr/ADR-018-pcf-error-handling.md` | [docs/adr/ADR-018-pcf-error-handling.md](docs/adr/ADR-018-pcf-error-handling.md) | [pcf.md](.claude/constraints/pcf.md) | [pcf/error-handling.md](.claude/patterns/pcf/error-handling.md) |
-| 019 | `.claude/adr/ADR-019-spe-container-lifecycle.md` | [docs/adr/ADR-019-spe-container-lifecycle.md](docs/adr/ADR-019-spe-container-lifecycle.md) | [data.md](.claude/constraints/data.md) | - |
-| 020 | `.claude/adr/ADR-020-telemetry.md` | [docs/adr/ADR-020-telemetry-strategy.md](docs/adr/ADR-020-telemetry-strategy.md) | [config.md](.claude/constraints/config.md) | - |
-| 021 | `.claude/adr/ADR-021-configuration.md` | [docs/adr/ADR-021-configuration-management.md](docs/adr/ADR-021-configuration-management.md) | [config.md](.claude/constraints/config.md) | - |
-| 022 | `.claude/adr/ADR-022-testing.md` | [docs/adr/ADR-022-testing-strategy.md](docs/adr/ADR-022-testing-strategy.md) | [testing.md](.claude/constraints/testing.md) | [testing/unit-test-structure.md](.claude/patterns/testing/unit-test-structure.md) |
+| 013 | `.claude/adr/ADR-013-ai-architecture.md` | [docs/adr/ADR-013-ai-architecture.md](docs/adr/ADR-013-ai-architecture.md) | [ai.md](.claude/constraints/ai.md) | [ai/streaming-endpoints.md](.claude/patterns/ai/streaming-endpoints.md) |
+| 014 | `.claude/adr/ADR-014-ai-caching.md` | [docs/adr/ADR-014-ai-caching-and-reuse-policy.md](docs/adr/ADR-014-ai-caching-and-reuse-policy.md) | [ai.md](.claude/constraints/ai.md) | - |
+| 015 | `.claude/adr/ADR-015-ai-data-governance.md` | [docs/adr/ADR-015-ai-data-governance.md](docs/adr/ADR-015-ai-data-governance.md) | [ai.md](.claude/constraints/ai.md) | - |
+| 016 | `.claude/adr/ADR-016-ai-rate-limits.md` | [docs/adr/ADR-016-ai-cost-rate-limit-and-backpressure.md](docs/adr/ADR-016-ai-cost-rate-limit-and-backpressure.md) | [ai.md](.claude/constraints/ai.md) | - |
+| 017 | `.claude/adr/ADR-017-job-status.md` | [docs/adr/ADR-017-async-job-status-and-persistence.md](docs/adr/ADR-017-async-job-status-and-persistence.md) | [jobs.md](.claude/constraints/jobs.md) | - |
+| 018 | `.claude/adr/ADR-018-feature-flags.md` | [docs/adr/ADR-018-feature-flags-and-kill-switches.md](docs/adr/ADR-018-feature-flags-and-kill-switches.md) | [config.md](.claude/constraints/config.md) | - |
+| 019 | `.claude/adr/ADR-019-problemdetails.md` | [docs/adr/ADR-019-api-errors-and-problemdetails.md](docs/adr/ADR-019-api-errors-and-problemdetails.md) | [api.md](.claude/constraints/api.md) | [api/error-handling.md](.claude/patterns/api/error-handling.md) |
+| 020 | `.claude/adr/ADR-020-versioning.md` | [docs/adr/ADR-020-versioning-strategy-apis-jobs-client-packages.md](docs/adr/ADR-020-versioning-strategy-apis-jobs-client-packages.md) | [api.md](.claude/constraints/api.md) | - |
+| 021 | `.claude/adr/ADR-021-fluent-design-system.md` | [docs/adr/ADR-021-fluent-ui-design-system.md](docs/adr/ADR-021-fluent-ui-design-system.md) | [pcf.md](.claude/constraints/pcf.md) | [pcf/theme-management.md](.claude/patterns/pcf/theme-management.md) |
 
 ---
 
@@ -92,6 +91,7 @@
 | OBO Flow | [.claude/patterns/auth/obo-flow.md](.claude/patterns/auth/obo-flow.md) | ADR-004, ADR-009 | `src/server/api/Sprk.Bff.Api/Infrastructure/Graph/GraphClientFactory.cs` |
 | Token Caching | [.claude/patterns/auth/token-caching.md](.claude/patterns/auth/token-caching.md) | ADR-009 | `src/server/api/Sprk.Bff.Api/Services/GraphTokenCache.cs` |
 | MSAL Client | [.claude/patterns/auth/msal-client.md](.claude/patterns/auth/msal-client.md) | ADR-006 | `src/client/pcf/UniversalQuickCreate/control/services/auth/MsalAuthProvider.ts` |
+| Service Principal | [.claude/patterns/auth/service-principal.md](.claude/patterns/auth/service-principal.md) | ADR-004, ADR-016 | `src/server/api/Sprk.Bff.Api/Infrastructure/Auth/ServiceCredentialFactory.cs` |
 
 ### Dataverse Patterns
 
@@ -184,15 +184,31 @@
 | 2025-12-19 | Added AI patterns (streaming-endpoints, text-extraction, analysis-scopes) | Phase 3 batch |
 | 2025-12-19 | Added Testing patterns (unit-test-structure, mocking-patterns, integration-tests) | Phase 3 batch |
 | 2025-12-24 | Consolidated AI playbooks - SKILL-INTERACTION-GUIDE.md is authoritative | Doc consolidation |
+| 2025-12-25 | Fixed ADR table entries to match actual file names; added service-principal.md to Auth patterns | Phase 3 completion |
 
 ---
 
 ## Maintenance Instructions
 
+**For complete maintenance procedures, use the `ai-procedure-maintenance` skill:**
+- Location: [.claude/skills/ai-procedure-maintenance/SKILL.md](.claude/skills/ai-procedure-maintenance/SKILL.md)
+- Trigger: "update AI procedures", "add new ADR", "propagate changes"
+
+The skill provides checklists for:
+- **Checklist A**: New ADR (11 steps)
+- **Checklist B**: New constraint file (6 steps)
+- **Checklist C**: New pattern file (5 steps)
+- **Checklist D**: New protocol/AIP (4 steps)
+- **Checklist E**: New skill (7 steps)
+- **Checklist F**: Root CLAUDE.md updates (4 steps)
+
+**Quick Reference (simplified)**:
+
 **When creating new AI context**:
 1. Add entry to appropriate section in this map
 2. Include source documentation links
 3. Add reverse reference in source doc
+4. **Run skill mappings update** (adr-aware, task-execute, task-create)
 
 **When updating full documentation**:
 1. Check this map for related AI context files

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - Documentation Traffic Controller
 
-> **Last Updated**: December 4, 2025
+> **Last Updated**: December 25, 2025
 >
 > **Purpose**: Direct AI to appropriate documentation based on task type.
 
@@ -10,79 +10,97 @@
 
 | Need | Location | Action |
 |------|----------|--------|
-| **Coding patterns, standards, guides** | `/docs/ai-knowledge/` | ✅ Reference freely |
-| **Historical decisions, deep research** | `/docs/reference/` | ⚠️ Ask before loading |
+| **Constraints, patterns, skills** | `/.claude/` | ✅ Load by default |
+| **Full rationale, procedures, guides** | `/docs/` | ⚠️ Load when deep dive needed |
 
 ---
 
-## Documentation Structure
+## Two-Tier Documentation Strategy
+
+### Tier 1: AI-Optimized Context (`/.claude/`)
+
+The `/.claude/` folder contains **concise, AI-optimized** content for efficient context loading:
+
+```
+.claude/
+├── adr/                      # Concise ADRs (~100-150 lines each)
+├── constraints/              # MUST/MUST NOT rules by topic
+├── patterns/                 # Code patterns and examples
+├── protocols/                # AI behavior protocols
+├── skills/                   # Skill definitions and workflows
+└── templates/                # Project/task templates
+```
+
+**Why use `.claude/` first?**
+- Optimized for context efficiency
+- Contains actionable constraints (what to do)
+- Skills provide step-by-step workflows
+- Concise ADRs focus on MUST/MUST NOT rules
+
+### Tier 2: Full Reference (`/docs/`)
+
+The `/docs/` folder contains **complete documentation** for deep dives:
 
 ```
 docs/
-├── CLAUDE.md                     # This file - traffic controller
-├── ai-knowledge/                 # ✅ ACTIVELY REFERENCE
-│   ├── CLAUDE.md                 # Index of coding-relevant content
-│   ├── architecture/             # System patterns and boundaries
-│   ├── standards/                # Coding standards and auth patterns
-│   ├── guides/                   # How-to guides
-│   └── templates/                # Project and task templates
-└── reference/                    # ⚠️ DO NOT LOAD UNLESS ASKED
-    ├── CLAUDE.md                 # "Stay out" instructions
-    ├── adr/                      # Architecture Decision Records
-    ├── research/                 # KM-* knowledge management articles
-    └── articles/                 # Full architecture guides (verbose)
+├── adr/                      # Full ADRs with history and rationale
+├── architecture/             # System architecture docs
+├── guides/                   # How-to guides and procedures
+├── procedures/               # Process documentation
+├── standards/                # Coding and auth standards
+└── product-documentation/    # User-facing docs
 ```
+
+**When to load from `docs/`:**
+- Need full rationale behind an architectural decision
+- Debugging requires detailed procedure steps
+- Evaluating changes to architecture
+- User explicitly asks for historical context
 
 ---
 
-## Rules for AI-Directed Coding
+## Loading Strategy by Task Type
 
-### ✅ DO Reference `/docs/ai-knowledge/`
+| Task Type | Primary Source | Secondary Source |
+|-----------|----------------|------------------|
+| Implement feature | `.claude/adr/`, `.claude/patterns/` | `docs/guides/` if stuck |
+| Follow a skill | `.claude/skills/{skill}/SKILL.md` | — |
+| Understand ADR | `.claude/adr/ADR-XXX.md` | `docs/adr/ADR-XXX-*.md` for full context |
+| Debug issue | `docs/procedures/`, `docs/guides/` | — |
+| Architecture change | `docs/adr/` (full versions) | — |
 
-This directory contains **condensed, actionable content** optimized for coding tasks:
+---
 
-- **Architecture patterns** - Security boundaries, API patterns, SDAP overview
-- **Coding standards** - OAuth/OBO patterns, Dataverse authentication
-- **How-to guides** - Step-by-step procedures for common tasks
-- **Templates** - Project plans, task execution, knowledge articles
+## ADR Loading Pattern
 
-**Load these documents proactively** when working on related features.
+**For implementation** (constraints):
+```
+READ .claude/adr/ADR-001-minimal-api.md  # ~100 lines, MUST/MUST NOT rules
+```
 
-### ⚠️ DO NOT Reference `/docs/reference/` Unless Asked
-
-This directory contains **background material** not needed for most coding tasks:
-
-- **ADRs** - Historical decisions (the *why*, not the *what*)
-- **KM-* articles** - Verbose reference documentation
-- **Full architecture guides** - Comprehensive but context-heavy
-
-**Why avoid?**
-1. Consumes context window unnecessarily
-2. May contain outdated details
-3. Duplicates content already condensed in `ai-knowledge/`
-
-**When to reference:**
-- Developer explicitly asks for historical context
-- Debugging requires deep-dive into specific technology
-- Evaluating architectural changes
+**For architectural decisions** (full context):
+```
+READ docs/adr/ADR-001-minimal-api-and-workers.md  # Full history and rationale
+```
 
 ---
 
 ## When Starting a Task
 
-1. **Check `/docs/ai-knowledge/CLAUDE.md`** for relevant articles
-2. **Load applicable architecture/standards/guides** into context
-3. **Proceed with implementation** using patterns from loaded docs
-4. **Only reference `/docs/reference/`** if explicitly directed
+1. **Check `.claude/skills/INDEX.md`** for applicable workflows
+2. **Load applicable `.claude/adr/`** files for constraints
+3. **Load `.claude/patterns/`** for code examples
+4. **Only load `docs/`** if you need full procedures or historical context
 
 ---
 
 ## See Also
 
-- `/docs/ai-knowledge/CLAUDE.md` - Index of coding-relevant content
-- `/docs/reference/CLAUDE.md` - Instructions for reference material
-- Root `/CLAUDE.md` - Repository-wide coding standards
+- `/.claude/skills/INDEX.md` - Skill registry and workflows
+- `/.claude/adr/` - Concise ADR constraints
+- `/docs/adr/INDEX.md` - Full ADR index
+- Root `/CLAUDE.md` - Repository-wide instructions
 
 ---
 
-*This structure separates actionable coding context from historical reference material.*
+*This structure separates actionable AI context from comprehensive reference material.*

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -2,7 +2,7 @@
 
 > **Purpose**: Documents architectural decisions for the Spaarke platform
 > **Audience**: Developers, architects, AI coding agents
-> **Last Updated**: 2025-12-22
+> **Last Updated**: 2025-12-25
 
 ## About ADRs
 


### PR DESCRIPTION
## Summary

- Add `ai-procedure-maintenance` skill with checklists for maintaining ADRs, constraints, patterns, protocols, and skills
- Add `/ai-procedure-maintenance` slash command for invoking the skill
- Update skills (adr-aware, task-execute, task-create) with explicit two-tier context loading
- Add new constraint and pattern files (testing.md, resilience.md, service-principal.md)
- Add script-aware skill for script library discovery

## Changes

### New Files
- `.claude/commands/ai-procedure-maintenance.md` - Slash command
- `.claude/skills/ai-procedure-maintenance/SKILL.md` - Maintenance skill with 6 checklists
- `.claude/skills/script-aware/SKILL.md` - Script library discovery (always-apply)
- `.claude/constraints/testing.md` - Testing constraints (ADR-022)
- `.claude/patterns/api/resilience.md` - Resilience patterns
- `.claude/patterns/auth/service-principal.md` - Service principal auth patterns

### Updated Skills
- `adr-aware`: Added Rule 2 (Two-Tier Context Loading Strategy) with explicit constraint/pattern loading
- `task-execute`: Added Steps 4a, 4b, 4c with tag-to-constraint/pattern mappings
- `task-create`: Expanded Tag-to-Knowledge Mapping table with Constraints, Patterns, Additional Files columns

### Updated References
- All INDEX files updated with new entries
- CROSS-REFERENCE-MAP.md updated with maintenance instructions
- Root CLAUDE.md updated with trigger phrases and slash command
- Fixed path references to use `.claude/` instead of `docs/reference/`

## Test plan

- [x] New skill files are valid markdown with proper YAML frontmatter
- [x] Slash command file follows existing command format
- [x] INDEX files include all new entries
- [x] Cross-references are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)