### PR TITLE
deps: Bump MsgReader from 5.2.0 to 6.0.6

### DIFF
--- a/src/server/api/Sprk.Bff.Api/Services/Ai/TextExtractorService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/TextExtractorService.cs
@@ -317,7 +317,7 @@ public class TextExtractorService : ITextExtractor
             From = msg.Sender?.Email ?? msg.Sender?.DisplayName,
             To = recipients,
             Cc = null, // MsgReader Recipients includes all; To/CC not easily distinguishable
-            Date = msg.SentOn,
+            Date = msg.SentOn?.DateTime, // MsgReader 6.x returns DateTimeOffset?
             Body = body,
             Attachments = attachments
         };

--- a/src/server/api/Sprk.Bff.Api/Sprk.Bff.Api.csproj
+++ b/src/server/api/Sprk.Bff.Api/Sprk.Bff.Api.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="4.2.0" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="4.2.0" />
     <PackageReference Include="MimeKit" Version="4.14.0" />
-    <PackageReference Include="MsgReader" Version="5.2.0" />
+    <PackageReference Include="MsgReader" Version="6.0.6" />
 
     <!-- Observability -->
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />


### PR DESCRIPTION
## Summary

Upgrades MsgReader to 6.0.6 with required code fix for breaking API change.

This replaces the auto-closed Dependabot PR #120 which could not pass CI due to a breaking change.

## Breaking Change Details

| Property | Old Type (v5.2.0) | New Type (v6.0.6) |
|----------|-------------------|-------------------|
| `Message.SentOn` | `DateTime?` | `DateTimeOffset?` |

## Fix Applied

```csharp
// Before (v5.2.0):
Date = msg.SentOn,

// After (v6.0.6):
Date = msg.SentOn?.DateTime,
```

## Why This Approach

The `EmailMetadata.Date` property remains `DateTime?` because:
- Timezone offset is not required for email date display
- Minimal code change (single line)
- Downstream consumers don't need updates

## Testing

- [x] All 72 TextExtractor tests pass
- [x] Build succeeds with `-warnaserror`

## Related

- Closes: N/A (replaces Dependabot PR #120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)