### PR TITLE
feat(office): UI simplification - remove entity picker, update form fields

### DIFF
--- a/src/client/office-addins/shared/taskpane/App.tsx
+++ b/src/client/office-addins/shared/taskpane/App.tsx
@@ -180,7 +180,7 @@ export const App: React.FC<AppProps> = ({
 
   // Determine title and host type
   const hostType: HostType = hostAdapter.getHostType() === 'outlook' ? 'outlook' : 'word';
-  const displayTitle = title || (hostType === 'outlook' ? 'Spaarke for Outlook' : 'Spaarke for Word');
+  const displayTitle = title || 'Spaarke Add-in';
 
   // Get user info
   const account = authService.getAccount();

--- a/src/client/office-addins/shared/taskpane/components/SaveFlow.tsx
+++ b/src/client/office-addins/shared/taskpane/components/SaveFlow.tsx
@@ -18,7 +18,6 @@ import {
   Divider,
   Link,
   mergeClasses,
-  Input,
   Textarea,
   Label,
 } from '@fluentui/react-components';
@@ -351,13 +350,6 @@ export function SaveFlow(props: SaveFlowProps): React.ReactElement {
   const [documentName, setDocumentName] = useState<string>('');
   const [documentDescription, setDocumentDescription] = useState<string>('');
 
-  // Initialize document name from item name when it changes
-  useEffect(() => {
-    if (itemName && !documentName) {
-      setDocumentName(itemName);
-    }
-  }, [itemName, documentName]);
-
   // Build save context
   const buildSaveContext = useCallback((): SaveFlowContext => ({
     hostType,
@@ -645,13 +637,14 @@ export function SaveFlow(props: SaveFlowProps): React.ReactElement {
             <Label htmlFor="document-name" className={styles.fieldLabel}>
               Document Name
             </Label>
-            <Input
+            <Textarea
               id="document-name"
               value={documentName}
               onChange={(e, data) => setDocumentName(data.value)}
               placeholder="Enter document name"
               disabled={isSaving}
               aria-label="Document name"
+              rows={2}
             />
           </div>
           <div className={styles.fieldContainer} style={{ marginTop: tokens.spacingVerticalM }}>
@@ -665,31 +658,10 @@ export function SaveFlow(props: SaveFlowProps): React.ReactElement {
               placeholder="Enter document description (optional)"
               disabled={isSaving}
               aria-label="Document description"
-              rows={3}
+              rows={6}
             />
           </div>
         </Card>
-      </div>
-
-      {/* Entity Picker */}
-      <div className={styles.section}>
-        <EntityPicker
-          value={selectedEntity}
-          onChange={handleEntitySelect}
-          onQuickCreate={onQuickCreate}
-          placeholder="Search for Matter, Project, Account... (optional)"
-          allowedTypes={allowedEntityTypes}
-          showTypeFilter
-          showRecent
-          showQuickCreate={!!onQuickCreate}
-          disabled={isSaving}
-          required={false}
-          label="Associate With (optional)"
-          searchOptions={{
-            apiBaseUrl,
-            getAccessToken,
-          }}
-        />
       </div>
 
       {/* Attachment Selector (Outlook only) */}

--- a/src/client/office-addins/shared/taskpane/components/TaskPaneHeader.tsx
+++ b/src/client/office-addins/shared/taskpane/components/TaskPaneHeader.tsx
@@ -61,9 +61,9 @@ const useStyles = makeStyles({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    fontSize: tokens.fontSizeBase300,
-    fontWeight: tokens.fontWeightSemibold,
-    color: tokens.colorNeutralForeground1,
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightRegular,
+    color: tokens.colorNeutralForeground2,
   },
   actions: {
     display: 'flex',


### PR DESCRIPTION
## Summary
- Change app title to "Spaarke Add-in" with smaller font styling
- Make Document Name field blank by default (removed auto-populate from email subject)
- Change Document Name to multi-line textarea (2 rows)
- Increase Description field height to 6 rows (+3 lines)
- Remove "Associate With" (Entity Picker) section entirely

## Test plan
- [ ] Verify title shows "Spaarke Add-in" in smaller font
- [ ] Verify Document Name field is blank on load
- [ ] Verify Document Name accepts multiple lines
- [ ] Verify Description field is taller (6 rows)
- [ ] Verify Associate With section is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)