### PR TITLE
feat(pcf): EventsPage v3.0.1 — embedded mode for entity form tabs

### DIFF
--- a/projects/events-record-direct-embed/CLAUDE.md
+++ b/projects/events-record-direct-embed/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md — events-record-direct-embed
+
+## Project Context
+
+This project adds **embedded mode** to the existing `EventsPage.html` web resource so it can serve as a context-aware Events tab inside any Dataverse entity form (Matter, Project, Invoice, etc.).
+
+## Key Decisions
+
+- **Not a fork**: The existing EventsPage gains an embedded mode — one codebase, three modes (system/dialog/embedded)
+- **Entity-agnostic**: Adding support for a new entity requires only form tab configuration + optional views
+- **View discovery by naming convention**: `{EntityPrefix}-{ViewName}` pattern, queried from `savedquery` at runtime
+- **Side pane cleanup via reusable hook**: `useSidePaneLifecycle` handles tab-switch detection for any web resource
+- **`sprk_regardingrecordid`**: Polymorphic lookup field already exists on `sprk_event` — filters to any parent entity
+
+## Existing Code to Reuse
+
+| Code | Location | How It's Reused |
+|------|----------|-----------------|
+| `parseDrillThroughParams()` | `EventsPage/src/App.tsx:113-156` | Extended with `entityName`, `recordId` params |
+| `ContextFilter` interface | `GridSection.tsx:113-118` | Passed from App.tsx with parent record ID |
+| FetchXML context injection | `GridSection.tsx:790-801` | No changes — already injects `<condition>` |
+| OData context filter | `GridSection.tsx:840-843` | No changes — already appends filter |
+| `IEventViewConfig` interface | `eventConfig.ts:137-141` | Discovery returns same shape |
+| `EVENT_VIEWS` static config | `eventConfig.ts:147-165` | Used as fallback when no entity views found |
+| Navigation cleanup | `App.tsx:1239-1307` | Extracted into `useSidePaneLifecycle` hook |
+| BroadcastChannel | `broadcastChannel.ts` | Unchanged — same-origin messaging works |
+| Session persistence | `sessionPersistence.ts` | Unchanged — survives tab switches |
+
+## ADRs to Follow
+
+- **ADR-021**: Fluent UI v9 exclusively, semantic tokens, dark mode support
+- **ADR-022**: React 16 APIs only in PCF (but EventsPage is a web resource — React 18 OK)
+- **ADR-006**: No new legacy webresources (we're enhancing an existing React web resource)
+
+## Testing Checklist
+
+- [ ] System Events page — no regression
+- [ ] Dialog drill-through — no regression
+- [ ] Embedded in Matter — grid filters, views discovered, +New pre-fills
+- [ ] Tab switch cleanup — panes close when leaving Events tab
+- [ ] Calendar side pane — additive filtering in embedded mode
+- [ ] Event detail side pane — edit/save in embedded mode
+- [ ] Dark mode — renders correctly in embedded context
+- [ ] No entity views — falls back to system views

--- a/projects/events-record-direct-embed/README.md
+++ b/projects/events-record-direct-embed/README.md
@@ -1,0 +1,48 @@
+# Events Record Direct Embed
+
+Adapt the existing `EventsPage.html` web resource to serve as a context-aware, embedded Events tab inside any Dataverse entity form (Matter, Project, Invoice, Work Assignment, etc.).
+
+## Quick Links
+
+| Document | Purpose |
+|----------|---------|
+| [spec.md](spec.md) | Full specification |
+| [plan.md](plan.md) | Implementation plan (8 tasks) |
+
+## What This Does
+
+When `sprk_eventspage.html` is added as a web resource tab on an entity form with `data=mode=embedded&entityName=sprk_matter&recordId={!entityid}`:
+
+1. **Grid auto-filters** to events related to the current record
+2. **View selector** shows entity-specific views (e.g., `Matter-All Tasks`, `Matter-Active Events`)
+3. **+New Event** pre-fills the parent record as the regarding record
+4. **Calendar side pane** works (additive date filtering)
+5. **Event detail side pane** works (edit/save events)
+6. **Tab-switch cleanup** — side panes close when user navigates to another tab
+
+## Adding to a New Entity
+
+No code changes required:
+
+1. **Form tab**: Add `sprk_eventspage.html` web resource tab to the entity form
+   - Data: `mode=embedded&entityName={entity_logical_name}&recordId={!entityid}`
+   - Uncheck "Restrict cross-frame scripting"
+2. **Views** (optional): Create entity-specific views with prefix naming convention
+   - Example: `Invoice-All Events`, `Invoice-All Deadlines`
+   - Falls back to system views if none found
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/solutions/EventsPage/src/App.tsx` | Main page — mode detection, context filter, view discovery |
+| `src/solutions/EventsPage/src/config/eventConfig.ts` | View config + entity view discovery |
+| `src/solutions/EventsPage/src/hooks/useSidePaneLifecycle.ts` | Reusable tab-switch pane cleanup |
+
+## Modes
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **system** | No `mode` param | Full system Events page (entity view) |
+| **dialog** | `mode=dialog` | Drill-through popup — no side panes |
+| **embedded** | `mode=embedded` | Context-aware tab in entity form |

--- a/projects/events-record-direct-embed/plan.md
+++ b/projects/events-record-direct-embed/plan.md
@@ -1,0 +1,254 @@
+# Implementation Plan: Context-Aware Events Page Embed
+
+> **Project**: events-record-direct-embed
+> **Spec**: [spec.md](spec.md)
+> **Estimated Tasks**: 8 implementation + 1 build/deploy
+
+---
+
+## Phase 1: Core Infrastructure (Tasks 001-003)
+
+### Task 001: Extend Context Parsing for Embedded Mode
+
+**Goal**: Parse `mode=embedded`, `entityName`, and `recordId` from URL data parameter.
+
+**Files**:
+- `EventsPage/src/App.tsx` — extend `parseDrillThroughParams()` and add `IS_EMBEDDED_MODE`
+
+**Steps**:
+1. Extend `DrillThroughParams` interface with `entityName: string | null` and `recordId: string | null`
+2. Update `parseDrillThroughParams()` to extract `entityName` and `recordId` keys
+3. Add `IS_EMBEDDED_MODE = DRILL_THROUGH_PARAMS.mode === "embedded"` constant
+4. When `IS_EMBEDDED_MODE` is true, auto-set `contextFilter`:
+   - `fieldName = "sprk_regardingrecordid"`
+   - `value = recordId`
+5. Verify existing `IS_DIALOG_MODE` still works (no regression)
+
+**Acceptance**:
+- `?data=mode=embedded&entityName=sprk_matter&recordId=abc-123` correctly populates params
+- GridSection receives contextFilter and filters events
+
+---
+
+### Task 002: Entity-Specific View Discovery
+
+**Goal**: Replace hardcoded view list with dynamic discovery based on entity prefix naming convention.
+
+**Files**:
+- `EventsPage/src/config/eventConfig.ts` — add `discoverEntityViews()` function
+- `EventsPage/src/App.tsx` — call discovery on mount in embedded mode, pass dynamic views to ViewToolbar
+
+**Steps**:
+1. Add `discoverEntityViews(entityName: string): Promise<IEventViewConfig[]>` to eventConfig.ts:
+   - Query `savedqueries` filtered by `returnedtypecode eq 'sprk_event'` and `startswith(name, '{Prefix}-')`
+   - Map entity logical name to display prefix (e.g., `sprk_matter` → `Matter`)
+   - Parse results into `IEventViewConfig[]`
+   - Strip prefix from display name (e.g., `Matter-All Tasks` → `All Tasks`)
+2. Add state for dynamic views in App.tsx: `const [availableViews, setAvailableViews] = useState(EVENT_VIEWS)`
+3. On mount in embedded mode, call `discoverEntityViews()` and update state
+4. If no entity views found, fall back to `EVENT_VIEWS` (system defaults)
+5. Pass `availableViews` to ViewToolbar instead of static `EVENT_VIEWS`
+
+**Acceptance**:
+- Embedded in Matter with `Matter-All Events` view in Dataverse → view selector shows it
+- Embedded in entity with no custom views → falls back to system views
+- System page → still shows hardcoded 4 views (no discovery query)
+
+---
+
+### Task 003: +New Event Pre-Fill Parent Context
+
+**Goal**: When user clicks +New Event in embedded mode, pre-fill `sprk_regardingrecordid` with the parent record.
+
+**Files**:
+- `EventsPage/src/App.tsx` — modify `handleNewEvent()` / quick create call
+
+**Steps**:
+1. In embedded mode, fetch parent record display name on mount:
+   - `Xrm.WebApi.retrieveRecord(entityName, recordId, "?$select=...name...")`
+   - Cache in ref: `parentRecordNameRef.current = result[nameField]`
+   - Name field mapping: `sprk_matter` → `sprk_name`, `sprk_project` → `sprk_name`, etc.
+   - Generic fallback: try common name fields (`name`, `sprk_name`, `subject`)
+2. Modify `openQuickCreate()` to include `createFromEntity` when in embedded mode:
+   ```typescript
+   createFromEntity: {
+     entityType: entityName,
+     id: recordId,
+     name: parentRecordNameRef.current
+   }
+   ```
+3. After quick create success, refresh grid (existing pattern)
+
+**Acceptance**:
+- Click +New Event in Matter → quick create form has matter pre-filled in regarding field
+- Click +New Event in system page → no pre-fill (current behavior)
+
+---
+
+## Phase 2: Side Pane Lifecycle (Tasks 004-005)
+
+### Task 004: Create `useSidePaneLifecycle` Hook
+
+**Goal**: Extract side pane cleanup into a reusable hook that detects tab switches and closes panes.
+
+**Files**:
+- *New*: `EventsPage/src/hooks/useSidePaneLifecycle.ts`
+- `EventsPage/src/App.tsx` — refactor existing cleanup to use the hook
+
+**Steps**:
+1. Create `useSidePaneLifecycle` hook with options:
+   ```typescript
+   interface SidePaneLifecycleOptions {
+     paneIds: string[];
+     onCleanup?: () => void;
+     enableVisibilityDetection?: boolean;  // default: true when embedded
+     enableUrlPolling?: boolean;            // default: true
+     pollingIntervalMs?: number;            // default: 200
+     isEmbedded: boolean;
+   }
+   ```
+2. Move existing cleanup logic from App.tsx into the hook:
+   - `checkForNavigation()` URL polling
+   - `beforeunload` / `pagehide` handlers
+   - `closeAllSidePanes()` function
+3. Add `visibilitychange` detection (new for embedded mode):
+   - When `document.visibilityState === "hidden"` AND `isEmbedded === true`, close panes
+   - Debounce 100ms to avoid false positives from transient visibility changes
+4. Hook returns `{ closeAllPanes: () => void }` for imperative use
+5. Wire up in App.tsx — replace inline cleanup with hook call
+
+**Acceptance**:
+- Embedded: switch from Events tab to Overview → all side panes close
+- Embedded: click within Events tab (column sort, filter) → panes stay open
+- System page: navigate away → panes close (existing behavior preserved)
+
+---
+
+### Task 005: Side Pane Registration in Embedded Mode
+
+**Goal**: Ensure Calendar and Event Detail side panes register and function correctly in embedded mode.
+
+**Files**:
+- `EventsPage/src/App.tsx` — adjust `registerCalendarPane()` and `openEventDetailPane()` for embedded context
+
+**Steps**:
+1. In embedded mode, register Calendar pane on mount (same as system mode)
+2. Verify BroadcastChannel messages work across iframes in embedded context:
+   - CalendarSidePane sends `CALENDAR_FILTER_CHANGED` → EventsPage receives and filters grid
+   - EventsPage sends `CALENDAR_EVENTS_UPDATE` → CalendarSidePane receives and highlights dates
+   - EventDetailSidePane sends `EVENT_DETAIL_SAVED` → EventsPage refreshes grid
+3. Calendar filter is **additive** to context filter:
+   - Context filter: `sprk_regardingrecordid eq '{recordId}'`
+   - Calendar filter: `AND sprk_duedate ge '2026-03-01' AND sprk_duedate le '2026-03-31'`
+4. Verify Event Detail side pane opens and saves correctly when parent is embedded
+5. Test side pane mutual exclusivity still works
+
+**Acceptance**:
+- Calendar filter narrows embedded grid (context + date range)
+- Event detail opens on row click, saves, grid refreshes
+- Opening event detail selects it, calendar becomes deselected (menu item persists)
+
+---
+
+## Phase 3: UI Polish (Tasks 006-007)
+
+### Task 006: UI Adjustments for Embedded Mode
+
+**Goal**: Small UI tweaks that make the embedded experience feel native to the host form.
+
+**Files**:
+- `EventsPage/src/App.tsx` — conditional rendering based on `IS_EMBEDDED_MODE`
+
+**Steps**:
+1. Hide page-level title/header in embedded mode (the form tab provides the title)
+2. Verify command bar works correctly (New, Refresh, Views, Excel Templates)
+3. Ensure grid fills available tab space (no double scrollbars)
+4. Test with different form tab heights (short Matter forms vs. tall Project forms)
+5. Verify dark mode works in embedded context (inherits from Dataverse theme)
+
+**Acceptance**:
+- No redundant title in embedded mode
+- Grid fills tab area cleanly
+- Dark mode renders correctly
+
+---
+
+### Task 007: Entity Display Name Resolution
+
+**Goal**: Show meaningful labels for the parent context (e.g., "Events for REAL-2026-123456.02").
+
+**Files**:
+- `EventsPage/src/App.tsx` — fetch and display parent record name
+
+**Steps**:
+1. On mount in embedded mode, resolve parent record display name
+2. Show in ViewToolbar subtitle or grid header: "Filtered to: {parentDisplayName}"
+3. Fallback: show entity display name if record name fetch fails (e.g., "Filtered to: Matter")
+4. System mode: no subtitle (current behavior)
+
+**Acceptance**:
+- Embedded in Matter → "Filtered to: REAL-2026-123456.02" shown near view selector
+- System page → no filter subtitle
+
+---
+
+## Phase 4: Build & Deploy (Task 008)
+
+### Task 008: Build, Test, and Deploy
+
+**Goal**: Build the updated EventsPage, deploy to dev, configure a test form tab.
+
+**Steps**:
+1. Run `npx tsc --noEmit` — verify no TypeScript errors
+2. Run `npm run build` — produce updated `dist/index.html`
+3. Deploy web resource to Dataverse dev environment
+4. Configure Matter form:
+   - Add web resource tab `sprk_eventspage.html`
+   - Data: `mode=embedded&entityName=sprk_matter&recordId={!entityid}`
+   - Uncheck "Restrict cross-frame scripting"
+5. Create test views: `Matter-All Events`, `Matter-All Tasks`, `Matter-Active Events`
+6. Test end-to-end:
+   - Open a Matter record → Events tab
+   - Verify grid shows only that matter's events
+   - Verify view selector shows Matter-specific views
+   - Click +New → verify matter pre-fills
+   - Open event in side pane → verify edit/save works
+   - Switch to Overview tab → verify side panes close
+   - Return to Events tab → verify panes can re-register
+
+**Acceptance**:
+- All 9 success criteria from spec.md pass
+- System Events page unchanged (regression check)
+- Dialog drill-through unchanged (regression check)
+
+---
+
+## Dependency Graph
+
+```
+Task 001 (Context Parsing)
+  ├── Task 002 (View Discovery) — needs entityName from 001
+  ├── Task 003 (+New Pre-Fill) — needs entityName + recordId from 001
+  └── Task 005 (Side Pane Registration) — needs IS_EMBEDDED_MODE from 001
+
+Task 004 (useSidePaneLifecycle Hook) — independent, can run parallel with 001
+
+Task 006 (UI Polish) — after 001 + 002
+Task 007 (Display Name) — after 001
+
+Task 008 (Build/Deploy) — after all others
+```
+
+**Parallel opportunities**: Tasks 001 and 004 can run in parallel. Tasks 002, 003, and 005 can run in parallel after 001 completes.
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| `visibilitychange` fires on side pane menu click (false positive) | Debounce 100ms; only act when `isEmbedded && hidden`; test thoroughly |
+| `savedquery` API returns no entity views | Graceful fallback to system views (already built) |
+| `createFromEntity` doesn't populate polymorphic lookup | Test with `sprk_regardingrecordid`; fall back to manual field set if needed |
+| Cross-origin iframe restrictions block Xrm access | Ensure "Restrict cross-frame scripting" is unchecked on form tab |
+| Calendar filter + context filter interaction | Filters are additive — FetchXML injection supports multiple conditions |

--- a/projects/events-record-direct-embed/spec.md
+++ b/projects/events-record-direct-embed/spec.md
@@ -1,0 +1,272 @@
+# Context-Aware Events Page Embed
+
+> **Project**: events-record-direct-embed
+> **Date**: 2026-02-24
+> **Status**: Specification
+> **Branch**: work/events-workspace-apps-UX-r1
+
+---
+
+## Executive Summary
+
+Adapt the existing `EventsPage.html` web resource to serve as a **context-aware, embedded Events tab** inside any Dataverse entity form — Matter, Project, Invoice, Work Assignment, or any future entity. When embedded, the grid auto-filters to events related to the current record, the view selector shows entity-specific views, side panes (Calendar + Event Detail) function correctly, and +New pre-fills the parent context. Side panes must close when the user navigates to a different tab in the host form.
+
+This is **not a fork** — the existing EventsPage gains an "embedded mode" that activates when it detects parent-record context in its URL parameters.
+
+---
+
+## Requirements
+
+### R1: Parse Embedded Context from URL
+
+When EventsPage.html is placed on a form tab, Dataverse passes the record ID via the `data` parameter using the `{!entityid}` placeholder.
+
+**Data parameter format** (configured on the web resource tab properties):
+
+```
+mode=embedded&entityName=sprk_matter&recordId={!entityid}
+```
+
+At runtime Dataverse replaces `{!entityid}` with the actual GUID, e.g.:
+
+```
+mode=embedded&entityName=sprk_matter&recordId=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+**Parsed context:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `mode` | `"embedded"` | Distinguishes from system-level Events page and drill-through dialog |
+| `entityName` | `string` | Dataverse logical name of the host entity (e.g., `sprk_matter`) |
+| `recordId` | `string` | GUID of the current record |
+
+**Compatibility**: Existing modes (`dialog` for drill-through, absent for system page) continue to work unchanged.
+
+### R2: Auto-Apply Context Filter
+
+When `mode=embedded` and `recordId` is present:
+
+- GridSection receives a `contextFilter` with `fieldName = "sprk_regardingrecordid"` and `value = recordId`
+- FetchXML injection adds `<condition attribute="sprk_regardingrecordid" operator="eq" value="{recordId}" />`
+- OData fallback adds `sprk_regardingrecordid eq '{recordId}'`
+
+This reuses the existing `ContextFilter` interface and injection logic already built for drill-through.
+
+### R3: Entity-Specific View Filtering
+
+Instead of hardcoded view GUIDs, the ViewSelector discovers views dynamically based on a **naming convention**:
+
+**Convention**: `{EntityPrefix}-{ViewName}`
+
+| Entity | Prefix | Example Views |
+|--------|--------|---------------|
+| Matter | `Matter` | `Matter-All Events`, `Matter-All Tasks`, `Matter-All Tasks Open`, `Matter-Active Events` |
+| Project | `Project` | `Project-All Events`, `Project-All Tasks` |
+| Invoice | `Invoice` | `Invoice-All Events`, `Invoice-All Deadlines` |
+| *(system)* | *(none)* | `Active Events`, `All Events`, `All Tasks`, `All Tasks Open` |
+
+**Discovery mechanism**:
+
+1. On mount (embedded mode), query Dataverse `savedquery` entity:
+   ```
+   GET /api/data/v9.2/savedqueries?$filter=returnedtypecode eq 'sprk_event'
+     and startswith(name, '{EntityPrefix}-')
+     and statecode eq 0
+   &$select=savedqueryid,name,isdefault
+   &$orderby=name
+   ```
+2. Map results to `IEventViewConfig[]` (same interface as static config)
+3. If no entity-specific views found, fall back to the 4 system views from `eventConfig.ts`
+
+**View creation** is a Dataverse admin task — no code needed. The naming convention is the contract.
+
+### R4: Pre-Fill Parent Context on +New
+
+When the user clicks "+New Event" in embedded mode:
+
+- The `openQuickCreate()` call includes a `parentetwname` (parent entity name) and pre-filled lookup field:
+  ```typescript
+  Xrm.Navigation.openForm({
+    entityName: "sprk_event",
+    useQuickCreateForm: true,
+    createFromEntity: {
+      entityType: entityName,    // e.g., "sprk_matter"
+      id: recordId,
+      name: recordDisplayName    // fetched once on mount
+    }
+  });
+  ```
+- The `sprk_regardingrecordid` (polymorphic lookup) auto-populates with the parent record
+- After creation, the grid refreshes (existing BroadcastChannel pattern)
+
+### R5: Side Panes in Embedded Mode
+
+Both Calendar and Event Detail side panes **work in embedded mode** (this reverses the earlier assessment that suggested skipping them).
+
+**Behavior**:
+- Calendar side pane registers as collapsible menu item (existing pattern)
+- Event Detail side pane opens when user clicks a row (existing pattern)
+- Calendar filter applies to the already-context-filtered grid (additive filtering)
+- BroadcastChannel communication works across iframes (same origin)
+
+### R6: Side Pane Tab-Switch Cleanup (System-Wide Feature)
+
+**Critical requirement**: When a user clicks away from the Events tab to another tab in the host form (e.g., Overview, Contacts, Documents), all side panes opened by EventsPage must close.
+
+**Detection strategy** (extends existing v2.17.0 navigation detection):
+
+The existing `checkForNavigation()` URL-polling pattern (200ms interval) already watches for parent URL changes. For embedded mode, we extend this:
+
+1. **Primary: `visibilitychange` on the web resource iframe** — when Dataverse hides the tab's iframe, the document fires `visibilitychange` with `document.visibilityState === "hidden"`. Close all side panes.
+
+2. **Secondary: Parent URL polling** — the existing 200ms interval catches SPA-style navigation that doesn't trigger visibility events.
+
+3. **Tertiary: `pagehide` / `beforeunload`** — existing handlers remain as safety net for hard navigation.
+
+**Implementation**: Extract the cleanup logic into a reusable `useSidePaneLifecycle` hook that any web resource can use:
+
+```typescript
+interface SidePaneLifecycleOptions {
+  paneIds: string[];           // IDs of panes to close
+  onCleanup?: () => void;      // Additional cleanup callback
+  enableVisibilityDetection?: boolean;  // Default: true in embedded mode
+  enableUrlPolling?: boolean;   // Default: true
+  pollingIntervalMs?: number;   // Default: 200
+}
+
+function useSidePaneLifecycle(options: SidePaneLifecycleOptions): void;
+```
+
+**Reuse**: This hook lives in a shared location so CalendarSidePane, EventDetailSidePane, and future side pane components can all use it. When EventsPage is embedded in Matter, Project, Invoice, or any other entity form, the hook automatically handles tab-switch cleanup.
+
+### R7: Dataverse Form Tab Configuration
+
+For each entity that embeds the Events page, an admin adds a **web resource tab** to the form:
+
+| Setting | Value |
+|---------|-------|
+| Web Resource | `sprk_eventspage.html` |
+| Name | `Events` (or `Calendar` — admin's choice) |
+| Data | `mode=embedded&entityName=sprk_matter&recordId={!entityid}` |
+| Restrict cross-frame scripting | **Unchecked** (required for Xrm access) |
+
+This is a one-time configuration per entity form. No code deployment needed to add a new entity — only a form customization with the correct `entityName` value in the data parameter.
+
+### R8: Flexible Entity Design
+
+The entire system is entity-agnostic:
+
+| Concern | How It's Entity-Agnostic |
+|---------|--------------------------|
+| Context parsing | `entityName` + `recordId` from URL — any entity works |
+| Grid filtering | `sprk_regardingrecordid` is a polymorphic lookup — accepts any entity |
+| View discovery | Name prefix convention — admin creates views per entity |
+| +New pre-fill | `createFromEntity` API accepts any entity type |
+| Side pane cleanup | Tab-switch detection is DOM/URL-based — entity-independent |
+
+**Adding a new entity** requires only:
+1. Add a web resource tab to the entity's form (R7)
+2. Create entity-specific views with the naming prefix (optional — falls back to system views)
+
+No code changes needed.
+
+---
+
+## Technical Approach
+
+### Mode Detection
+
+Extend `parseDrillThroughParams()` to recognize three modes:
+
+| Mode | Condition | Behavior |
+|------|-----------|----------|
+| **system** | No `mode` param (or `mode` absent) | Full system Events page — current behavior |
+| **dialog** | `mode=dialog` | Drill-through popup — no side panes, no calendar |
+| **embedded** | `mode=embedded` | Context-aware tab — filtered grid, entity views, side pane cleanup |
+
+### Data Flow (Embedded Mode)
+
+```
+Dataverse Form Tab
+  └─ sprk_eventspage.html?data=mode=embedded&entityName=sprk_matter&recordId={!entityid}
+       │
+       ├─ parseDrillThroughParams()
+       │    → mode: "embedded"
+       │    → entityName: "sprk_matter"
+       │    → recordId: "a1b2c3d4..."
+       │
+       ├─ IS_EMBEDDED_MODE = true
+       │
+       ├─ Context filter applied to GridSection
+       │    → sprk_regardingrecordid eq 'a1b2c3d4...'
+       │
+       ├─ View discovery
+       │    → Query savedquery WHERE name LIKE 'Matter-%'
+       │    → Fall back to system views if none found
+       │
+       ├─ +New Event pre-fills sprk_regardingrecordid
+       │
+       ├─ Calendar side pane registers (collapsible)
+       │
+       ├─ Event detail side pane opens on row click
+       │
+       └─ useSidePaneLifecycle()
+            → visibilitychange → close panes
+            → URL polling → close panes
+            → beforeunload → close panes
+```
+
+### UI Adjustments in Embedded Mode
+
+| Element | System Mode | Embedded Mode |
+|---------|------------|---------------|
+| Command bar | Full (New, Refresh, Views, Excel) | Same — all actions available |
+| View selector | 4 hardcoded system views | Entity-specific views (discovered) + system fallback |
+| Calendar side pane | Always registered | Registered (collapsible) |
+| Grid columns | Full column set | Same (view-driven) |
+| Page title | "Events" | Hidden (form tab provides title) |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `EventsPage/src/App.tsx` | Add embedded mode detection, context filter wiring, view discovery, +New pre-fill, `useSidePaneLifecycle` |
+| `EventsPage/src/config/eventConfig.ts` | Add `discoverEntityViews()` function, entity prefix mapping |
+| `EventsPage/src/components/GridSection.tsx` | No changes (contextFilter already supported) |
+| `EventsPage/src/components/ViewToolbar.tsx` | Accept dynamic views array instead of static config |
+| *New*: `shared/hooks/useSidePaneLifecycle.ts` | Reusable hook for tab-switch pane cleanup |
+
+### Files NOT Changed
+
+| File | Why |
+|------|-----|
+| `CalendarSidePane/` | Works as-is — receives filter messages from parent |
+| `EventDetailSidePane/` | Works as-is — opens event by ID from parent |
+| `GridSection.tsx` | ContextFilter interface + injection already built |
+| `broadcastChannel.ts` | Message protocol unchanged |
+| `sessionPersistence.ts` | Tab-switch persistence already works |
+
+---
+
+## Success Criteria
+
+1. **Embedded in Matter form**: Events tab shows only events where `sprk_regardingrecordid = {matterId}`
+2. **View selector**: Shows `Matter-*` views when available, falls back to system views
+3. **+New Event**: Pre-fills `sprk_regardingrecordid` with current matter
+4. **Calendar side pane**: Filters embedded grid by date range (additive)
+5. **Event detail side pane**: Opens on row click, saves correctly
+6. **Tab switch**: All side panes close when user clicks Overview, Contacts, etc.
+7. **System page unchanged**: Events entity page continues to work as before
+8. **Dialog mode unchanged**: Drill-through popup continues to work
+9. **New entity in <5 min**: Adding Events tab to a new entity requires only form customization + optional views
+
+---
+
+## Out of Scope
+
+- Creating the actual Dataverse system views (admin task)
+- Modifying the `sprk_regardingrecordid` field schema (already exists as polymorphic lookup)
+- Changes to CalendarSidePane or EventDetailSidePane codebases
+- Mobile layout adaptations
+- Row-level security (handled by Dataverse)

--- a/projects/events-record-direct-embed/tasks/TASK-INDEX.md
+++ b/projects/events-record-direct-embed/tasks/TASK-INDEX.md
@@ -1,0 +1,11 @@
+# Task Index: events-record-direct-embed
+
+| # | Task | Status |
+|---|------|--------|
+| 001 | Extend context parsing for embedded mode | ✅ |
+| 002 | Entity-specific view discovery | ✅ |
+| 003 | +New event pre-fill parent context | ✅ |
+| 004 | Side pane visibility cleanup for embedded mode | ✅ |
+| 005 | Wire dynamic views + context filter in EventsPageContent | ✅ |
+| 006 | UI adjustments for embedded mode | ✅ |
+| 007 | Build and type-check | ✅ |

--- a/projects/events-workspace-apps-UX-r1/notes/design/event-detail-sidepane-rebuild.md
+++ b/projects/events-workspace-apps-UX-r1/notes/design/event-detail-sidepane-rebuild.md
@@ -1,4 +1,4 @@
-# EventDetailSidePane Rebuild: HTML Web Resource Approach
+ # EventDetailSidePane Rebuild: HTML Web Resource Approach
 
 > **Date**: 2026-02-19
 > **Status**: Implementation Complete

--- a/src/solutions/EventsPage/src/components/GridSection.tsx
+++ b/src/solutions/EventsPage/src/components/GridSection.tsx
@@ -787,17 +787,14 @@ export const GridSection: React.FC<GridSectionProps> = ({
 
         fetchXml = mergeDateFilterIntoFetchXml(fetchXml, dateFilterInput);
 
-        // v2.16.0: Merge context filter (drill-through) into FetchXML
+        // v3.0.1: Merge context filter as a separate <filter> at entity level.
+        // Always adds a NEW filter before </entity> instead of injecting into
+        // existing filters — avoids misplacement when date/link-entity filters
+        // create nested </filter> tags (replace only matches the first occurrence).
         if (contextFilter) {
           console.log("[GridSection] Applying context filter:", contextFilter);
-          const conditionXml = `<condition attribute="${contextFilter.fieldName}" operator="eq" value="${contextFilter.value}" />`;
-          // Insert into existing <filter> element
-          if (fetchXml.includes("</filter>")) {
-            fetchXml = fetchXml.replace("</filter>", `${conditionXml}</filter>`);
-          } else {
-            // No filter element — add one before </entity>
-            fetchXml = fetchXml.replace("</entity>", `<filter type="and">${conditionXml}</filter></entity>`);
-          }
+          const contextFilterXml = `<filter type="and"><condition attribute="${contextFilter.fieldName}" operator="eq" value="${contextFilter.value}" /></filter>`;
+          fetchXml = fetchXml.replace("</entity>", `${contextFilterXml}</entity>`);
         }
 
         console.log("[GridSection] Final FetchXML:", fetchXml);

--- a/src/solutions/EventsPage/src/config/index.ts
+++ b/src/solutions/EventsPage/src/config/index.ts
@@ -13,6 +13,8 @@ export {
   getFormGuidForEventType,
   EVENT_VIEWS,
   getDefaultEventViewId,
+  discoverEntityViews,
+  getEntityViewPrefix,
   EVENT_DETAIL_PANE_ID,
   CALENDAR_PANE_ID,
   PANE_WIDTH,


### PR DESCRIPTION
## Summary
- Add **embedded mode** so EventsPage runs as a tab inside any Dataverse entity form (Matter, Project, Invoice, Work Assignment)
- Grid auto-filters events by parent record via `sprk_regardingrecordid` context filter
- Entity-specific views discovered by naming convention (e.g., "Matter-All Tasks")
- +New Event pre-fills parent record context via `createFromEntity`
- Iframe visibility polling (300ms) closes side panes when user switches form tabs
- Fixed FetchXML context filter injection — uses separate `<filter>` at entity level to survive nested date/link-entity filters
- Resilient URL param parsing handles typos like `mode-embedded` (hyphen vs equals)

## Changes
- `App.tsx` — Three-mode architecture (system/dialog/embedded), `parseDrillThroughParams()` rewrite, iframe visibility polling, parent context pre-fill
- `GridSection.tsx` — Context filter now injects as separate `<filter type="and">` before `</entity>` instead of replacing first `</filter>`
- `eventConfig.ts` — `discoverEntityViews()`, `ENTITY_VIEW_PREFIXES` map, `getEntityViewPrefix()` helper
- `config/index.ts` — Barrel exports for new functions
- `projects/events-record-direct-embed/` — Project artifacts (spec, plan, README, CLAUDE.md, tasks)

## Test plan
- [ ] Deploy `index.html` as web resource on Dataverse entity form tab
- [ ] Set Data field to `mode=embedded`, enable "Pass record object-type code..." checkbox
- [ ] Verify grid shows only events for the parent record (not all events)
- [ ] Apply calendar date filter — verify record filter is preserved
- [ ] Click an event row — verify side pane opens
- [ ] Switch to another form tab — verify side pane closes automatically
- [ ] Click +New — verify parent record is pre-filled in new event form

🤖 Generated with [Claude Code](https://claude.com/claude-code)