### PR TITLE
feat(workspace): Documents tab + To Do Detail enhancements

### DIFF
--- a/src/solutions/LegalWorkspace/src/utils/navigation.ts
+++ b/src/solutions/LegalWorkspace/src/utils/navigation.ts
@@ -72,14 +72,14 @@ export function openRecordDialog(entityName: string, entityId: string): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const xrm = getXrm() as any;
 
-  if (!xrm?.Navigation?.openForm) {
-    console.error("[navigation] openRecordDialog: Xrm.Navigation.openForm is not available");
+  if (!xrm?.Navigation?.navigateTo) {
+    console.error("[navigation] openRecordDialog: Xrm.Navigation.navigateTo is not available");
     return;
   }
 
   try {
-    xrm.Navigation.openForm(
-      { entityName, entityId },
+    xrm.Navigation.navigateTo(
+      { pageType: "entityrecord", entityName, entityId },
       {
         target: 2,
         width: { value: 80, unit: "%" },


### PR DESCRIPTION
## Summary
- Add 6th **Documents** tab to the Activity section with dynamic file-type icons, BFF API preview/open links, Find Similar, and Summary actions
- Enhance **To Do Detail** side pane with dual-entity architecture (sprk_event + sprk_eventtodo), Record Type/Record link, To Do Notes, and green Completed button
- Fix To Do card to show Event Type tag; fix Assigned To lookup to use standard contact table

## Changes

### LegalWorkspace — Documents Tab
- **DocumentCard.tsx** — Document-specific card with dynamic file icon, preview button, overflow menu (Open Web/Desktop/Record, Find Similar, Summary)
- **DocumentsTab.tsx** — Tab wrapper following MattersTab pattern
- **useDocumentsTabList.ts** — Data hook with module-level cache, 2-min TTL, abort controller
- **DocumentApiService.ts** — BFF API calls for preview URLs and open links
- **fileIconMap.ts** — File type → Fluent icon resolver
- **UpdatesTodoSection.tsx** — Wire Documents as 6th tab
- **queryHelpers.ts** — Documents tab OData select/filter/query builders
- **DataverseService.ts** — getDocumentsForTab() method
- **entities.ts** — Extended IDocument with new fields
- **bffAuthProvider.ts** — Added getTenantId() helper for Find Similar
- **DocumentItem.tsx** — Fixed sprk_name → sprk_documentname bug

### TodoDetailSidePane — To Do Detail
- **TodoRecord.ts** — Split into ITodoRecord (sprk_event) + ITodoExtension (sprk_eventtodo)
- **todoService.ts** — Dual-entity load/save: loadTodoExtension(), saveTodoExtensionFields(), contact table fix
- **App.tsx** — Parallel loading of both entities, separate save handlers
- **TodoDetail.tsx** — Record Type badge, Record link, To Do Notes section, Completed button, UI tweaks (25px dividers, 8-line textareas, removed Urgency slider)
- **TodoItem.tsx** — Event Type tag on To Do card

## Test plan
- [ ] Verify 6 tabs visible: Latest Updates, To Do List, Matters, Projects, Invoices, Documents
- [ ] Document cards show dynamic file-type icons and correct metadata
- [ ] Preview button triggers BFF API and opens preview
- [ ] Find Similar opens sprk_documentrelationshipviewer with correct theme
- [ ] To Do Detail side pane loads without 400 error (dual-entity query)
- [ ] To Do Notes save to sprk_eventtodo entity
- [ ] Completed button sets sprk_completed, sprk_completeddate, statuscode=2 on sprk_eventtodo
- [ ] Assigned To search queries standard contact table (fullname)
- [ ] Record Type badge and Record link display correctly in Details section

🤖 Generated with [Claude Code](https://claude.com/claude-code)