### PR TITLE
docs(communication): update architecture, patterns, and admin guide for R2

### DIFF
--- a/.claude/constraints/jobs.md
+++ b/.claude/constraints/jobs.md
@@ -2,7 +2,7 @@
 
 > **Domain**: Async Processing, Background Workers
 > **Source ADRs**: ADR-004, ADR-017
-> **Last Updated**: 2025-12-18
+> **Last Updated**: 2026-03-12
 
 ---
 
@@ -23,6 +23,8 @@ Load when:
 - ✅ **MUST** use Job Contract schema for all async work
 - ✅ **MUST** implement handlers as idempotent (safe under at-least-once)
 - ✅ **MUST** use deterministic IdempotencyKey patterns
+- ✅ **MUST** set Service Bus `MessageId` = `IdempotencyKey` for cross-instance deduplication
+- ✅ **MUST** SHA-256 hash IdempotencyKey values exceeding 128 characters (Service Bus MessageId limit)
 - ✅ **MUST** propagate CorrelationId from original request
 - ✅ **MUST** emit JobOutcome events (Completed, Failed, Poisoned)
 
@@ -123,7 +125,21 @@ public class AnalysisJobHandler : IJobHandler<AnalysisJob>
 |----------|-------------|
 | Document indexing | `doc-{docId}-v{rowVersion}` |
 | AI analysis | `analysis-{docId}-{analysisType}` |
-| Email processing | `email-{messageId}` |
+| Email processing | `Communication:{messageId}:Process` |
+
+### Service Bus Deduplication
+
+Service Bus provides cross-instance duplicate detection when `MessageId` is set. The BFF sets `MessageId = IdempotencyKey` on every enqueued message.
+
+**SHA-256 hashing rule**: Service Bus limits `MessageId` to 128 characters. If the IdempotencyKey exceeds this, hash it:
+
+```csharp
+var messageId = idempotencyKey.Length > 128
+    ? Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(idempotencyKey)))
+    : idempotencyKey;
+```
+
+This ensures deterministic deduplication even for long keys (e.g., email message IDs with long domains).
 
 ---
 

--- a/.claude/patterns/api/INDEX.md
+++ b/.claude/patterns/api/INDEX.md
@@ -1,7 +1,7 @@
 # API/BFF Patterns Index
 
 > **Domain**: BFF API / .NET Minimal API
-> **Last Updated**: 2025-12-19
+> **Last Updated**: 2026-03-12
 
 ---
 
@@ -14,6 +14,7 @@
 | [service-registration.md](service-registration.md) | DI configuration (ADR-010) | ~115 |
 | [error-handling.md](error-handling.md) | ProblemDetails (ADR-019) | ~145 |
 | [background-workers.md](background-workers.md) | Job processing (ADR-004) | ~175 |
+| [send-email-integration.md](send-email-integration.md) | Email send integration patterns (UI, AI, server-side) | ~200 |
 
 ---
 
@@ -26,6 +27,7 @@
 | Register new service | `service-registration.md` |
 | Add background job | `background-workers.md` |
 | Handle errors | `error-handling.md` |
+| Send email from module | `send-email-integration.md` |
 
 ---
 

--- a/.claude/patterns/api/send-email-integration.md
+++ b/.claude/patterns/api/send-email-integration.md
@@ -1,0 +1,277 @@
+# Send Email Integration Pattern
+
+> **Domain**: Communication Service — Email Send Integration
+> **Last Validated**: 2026-03-12
+> **Source ADRs**: ADR-001, ADR-008, ADR-010, ADR-013
+
+---
+
+## Purpose
+
+Standardized patterns for sending email from any module in Spaarke. All email goes through the Communication Service (`CommunicationService.SendAsync()`), ensuring consistent sender resolution, archival, tracking, and telemetry.
+
+---
+
+## Three Integration Patterns
+
+| Pattern | When to Use | Integration Point |
+|---------|-------------|-------------------|
+| **UI Module → API** | Code pages, wizards, PCF controls sending email | `POST /api/communications/send` |
+| **AI Playbook → Tool** | AI-initiated email via playbook actions | `send_communication` tool handler |
+| **Server-Side → Direct** | New BFF services needing to send email programmatically | Inject `CommunicationService` directly |
+
+---
+
+## Pattern 1: UI Module → POST /api/communications/send
+
+For any UI component (Code Page, wizard step, PCF control) that needs to send email.
+
+### Frontend (TypeScript)
+
+```typescript
+// 1. Build the request
+const request: SendCommunicationRequest = {
+  to: ["recipient@example.com"],
+  cc: ["cc@example.com"],         // optional
+  subject: "Subject line",
+  body: "<p>HTML body content</p>",
+  bodyFormat: "HTML",              // or "PlainText"
+  fromMailbox: null,               // null = default shared mailbox
+  sendMode: "SharedMailbox",       // or "User" for OBO
+  associations: [{
+    entityType: "sprk_matter",
+    entityId: matterId,
+    entityName: matterName,
+  }],
+  archiveToSpe: true,             // archive .eml to SharePoint Embedded
+  attachmentDocumentIds: ["guid1", "guid2"],  // optional SPE document IDs
+};
+
+// 2. Send via BFF API
+const response = await fetch(`${bffBaseUrl}/api/communications/send`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${token}`,
+  },
+  body: JSON.stringify(request),
+});
+
+// 3. Handle response
+if (response.ok) {
+  const result = await response.json();
+  // result.communicationId — Dataverse record GUID
+  // result.status — "Send" or "Delivered"
+  // result.warnings — array of non-fatal issues (archival, attachment records)
+} else {
+  const problem = await response.json(); // ProblemDetails (RFC 7807)
+  // problem.detail — human-readable error
+  // problem.extensions.errorCode — machine-readable code (e.g., "DAILY_SEND_LIMIT_REACHED")
+}
+```
+
+### Wizard Step Integration (SendEmailStep)
+
+For wizards using the shared `@spaarke/ui-components` library, use the `SendEmailStep` component:
+
+```typescript
+import { SendEmailStep } from "@spaarke/ui-components";
+
+// In your wizard step configuration:
+{
+  label: "Send Email",
+  component: SendEmailStep,
+  props: {
+    defaultRecipients: contacts.map(c => c.email),
+    defaultSubject: `RE: ${matterName}`,
+    fromMailbox: null,  // default shared mailbox
+    associations: [{ entityType: "sprk_matter", entityId: matterId }],
+    onSendComplete: (result) => {
+      // Handle success — advance wizard, show confirmation
+    },
+    onSendError: (problem) => {
+      // Handle error — show inline error, allow retry
+    },
+  },
+}
+```
+
+### BFF URL Resolution
+
+UI components resolve the BFF API base URL in this order:
+1. Dataverse environment variable `sprk_BffApiBaseUrl`
+2. Hardcoded default: `https://spe-api-dev-67e2xz.azurewebsites.net`
+
+### Auth Token Acquisition
+
+```typescript
+// For Dataverse-hosted UI (PCF, Code Pages)
+const token = await Xrm.Utility.getGlobalContext()
+  .getCurrentAppUrl()  // Get auth context
+  // OR use MSAL.js for standalone apps
+```
+
+---
+
+## Pattern 2: AI Playbook → send_communication Tool
+
+For AI playbooks that need to send email as part of an automated workflow.
+
+### JPS Definition
+
+Add `send_communication` to the playbook's tool list:
+
+```json
+{
+  "tools": [
+    {
+      "name": "send_communication",
+      "description": "Send an email via the Communication Service",
+      "parameters": {
+        "to": { "type": "string", "description": "Comma-separated recipient emails", "required": true },
+        "cc": { "type": "string", "description": "Comma-separated CC emails" },
+        "subject": { "type": "string", "description": "Email subject", "required": true },
+        "body": { "type": "string", "description": "Email body (HTML)", "required": true },
+        "fromMailbox": { "type": "string", "description": "Sender mailbox (null = default)" },
+        "regardingEntity": { "type": "string", "description": "Dataverse entity logical name" },
+        "regardingId": { "type": "string", "description": "Dataverse record GUID" }
+      }
+    }
+  ]
+}
+```
+
+### How It Works
+
+1. AI model decides to send email based on playbook instructions
+2. Model invokes `send_communication` tool with parameters
+3. `SendCommunicationToolHandler.HandleAsync()` is called
+4. Handler parses parameters into `SendCommunicationRequest`
+5. Delegates to `CommunicationService.SendAsync()` (same pipeline as UI)
+6. Returns structured result to AI model
+
+### Registration
+
+`SendCommunicationToolHandler` is registered in `CommunicationModule` as a singleton:
+
+```csharp
+services.AddSingleton<SendCommunicationToolHandler>();
+```
+
+It is NOT auto-discovered — it must be explicitly registered.
+
+---
+
+## Pattern 3: Server-Side → Inject CommunicationService
+
+For new BFF services that need to send email programmatically (e.g., scheduled notifications, event-driven emails).
+
+### Implementation
+
+```csharp
+public class NotificationService
+{
+    private readonly CommunicationService _communicationService;
+
+    public NotificationService(CommunicationService communicationService)
+    {
+        _communicationService = communicationService;
+    }
+
+    public async Task SendMatterUpdateNotificationAsync(
+        Guid matterId, string matterName, string recipientEmail, CancellationToken ct)
+    {
+        var request = new SendCommunicationRequest
+        {
+            To = [recipientEmail],
+            Subject = $"Matter Update: {matterName}",
+            Body = $"<p>Matter <b>{matterName}</b> has been updated.</p>",
+            BodyFormat = BodyFormat.HTML,
+            SendMode = SendMode.SharedMailbox,  // App-only auth
+            Associations =
+            [
+                new CommunicationAssociation
+                {
+                    EntityType = "sprk_matter",
+                    EntityId = matterId.ToString(),
+                    EntityName = matterName,
+                }
+            ],
+            ArchiveToSpe = true,
+            CorrelationId = Guid.NewGuid().ToString(),
+        };
+
+        var response = await _communicationService.SendAsync(request, httpContext: null, ct);
+        // response.CommunicationId, response.Status, response.Warnings
+    }
+}
+```
+
+### DI Registration
+
+Register the new service in its feature module (NOT in CommunicationModule):
+
+```csharp
+// In your module's DI registration
+services.AddSingleton<NotificationService>();
+```
+
+`CommunicationService` is already registered as a singleton by `CommunicationModule`.
+
+---
+
+## Common Parameters Reference
+
+### SendCommunicationRequest
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `to` | `string[]` | Yes | — | Recipient email addresses (>=1) |
+| `cc` | `string[]` | No | null | CC recipients |
+| `bcc` | `string[]` | No | null | BCC recipients |
+| `subject` | `string` | Yes | — | Email subject line |
+| `body` | `string` | Yes | — | Email body content |
+| `bodyFormat` | `BodyFormat` | No | `HTML` | `HTML` or `PlainText` |
+| `fromMailbox` | `string` | No | null | Sender mailbox (null = default) |
+| `sendMode` | `SendMode` | No | `SharedMailbox` | `SharedMailbox` or `User` |
+| `associations` | `CommunicationAssociation[]` | No | null | Entity associations |
+| `archiveToSpe` | `bool` | No | `false` | Archive .eml to SPE |
+| `attachmentDocumentIds` | `string[]` | No | null | SPE document IDs to attach |
+| `correlationId` | `string` | No | auto | Tracing correlation ID |
+
+### Error Codes
+
+| Code | HTTP | When |
+|------|------|------|
+| `VALIDATION_ERROR` | 400 | Missing To, Subject, or Body |
+| `INVALID_SENDER` | 400 | Sender not in approved list |
+| `NO_DEFAULT_SENDER` | 400 | No sender configured |
+| `DAILY_SEND_LIMIT_REACHED` | 429 | Account hit daily quota |
+| `ATTACHMENT_LIMIT_EXCEEDED` | 400 | >150 attachments or >35MB |
+| `GRAPH_SEND_FAILED` | 502 | Graph API error |
+
+---
+
+## Checklist for Adding Email to a New Module
+
+1. **Choose the pattern** — UI (Pattern 1), AI Playbook (Pattern 2), or Server-Side (Pattern 3)
+2. **Determine sender** — `fromMailbox: null` for default shared mailbox, or specify a configured account
+3. **Determine send mode** — `SharedMailbox` (most common) or `User` (for "send as me")
+4. **Set associations** — Link email to the relevant entity (matter, account, contact, etc.)
+5. **Handle errors** — Parse `ProblemDetails` responses; handle `429` (daily limit) gracefully
+6. **Test with verification** — Run `POST /api/communications/accounts/{id}/verify` to confirm mailbox connectivity
+7. **Monitor** — Check `CommunicationTelemetry` metrics for send success/failure rates
+
+---
+
+## Related Patterns
+
+- [Endpoint Definition](endpoint-definition.md) — API endpoint conventions
+- [Error Handling](error-handling.md) — ProblemDetails error format
+- [Graph Webhooks](../auth/graph-webhooks.md) — Inbound email webhook subscriptions
+- [Service Registration](service-registration.md) — DI registration patterns
+
+---
+
+**Lines**: ~200
+**Purpose**: Repeatable email integration guide for all Spaarke modules

--- a/.claude/patterns/auth/graph-webhooks.md
+++ b/.claude/patterns/auth/graph-webhooks.md
@@ -1,7 +1,7 @@
 # Graph Webhook / Subscription Pattern
 
 > **Domain**: Microsoft Graph Change Notifications / Webhooks
-> **Last Validated**: 2026-03-09
+> **Last Validated**: 2026-03-12
 > **Source ADRs**: ADR-001 (BackgroundService pattern)
 
 ---
@@ -49,20 +49,34 @@ The BFF manages subscriptions as a `BackgroundService` with a `PeriodicTimer`.
 | Max subscription lifetime | 3 days | Graph API limit for mail subscriptions |
 | Renewal threshold | 24 hours before expiry | Ensures renewal before expiration |
 | Check interval | 30 minutes | `PeriodicTimer` frequency |
-| Notification URL | `{BFF_BASE_URL}/api/webhooks/mail` | Endpoint receiving change notifications |
+| Startup delay | 10 seconds | Allows Dataverse/Graph to warm up before first cycle |
+| Notification URL | `{BFF_BASE_URL}/api/communications/incoming-webhook` | Endpoint receiving change notifications |
 
 ### Lifecycle Decision Tree
 
-On each 30-minute timer tick, for each monitored account:
+On each 30-minute timer tick:
 
 ```
-Is subscription ID stored in Dataverse?
-├── NO → CREATE new subscription
-└── YES → Is expiry < 24 hours away?
-    ├── NO → SKIP (subscription still valid)
-    └── YES → RENEW subscription
-              └── 404 error? → RECREATE (delete record + create new)
+Phase 1: Orphan Cleanup
+  List ALL Graph subscriptions via graphClient.Subscriptions.GetAsync()
+  For each subscription:
+    Does NotificationUrl match configured webhook URL?
+    ├── NO → SKIP (belongs to another application)
+    └── YES → Is subscription ID tracked in any Dataverse account?
+        ├── YES → SKIP (managed subscription)
+        └── NO → DELETE orphan subscription from Graph
+
+Phase 2: Per-Account Lifecycle
+  For each receive-enabled account:
+    Is subscription ID stored in Dataverse?
+    ├── NO → CREATE new subscription
+    └── YES → Is expiry < 24 hours away?
+        ├── NO → SKIP (subscription still valid)
+        └── YES → RENEW subscription
+                  └── 404 error? → RECREATE (delete record + create new)
 ```
+
+**Why orphan cleanup matters**: Deployments, multi-instance race conditions, and failed deletions can leave accumulated subscriptions in Graph. Each orphan subscription generates duplicate webhook notifications for the same email, causing unnecessary processing. The NotificationUrl safety filter ensures only subscriptions belonging to this BFF instance are cleaned up.
 
 ### Create Subscription
 
@@ -71,13 +85,15 @@ var subscription = new Subscription
 {
     ChangeType = "created",           // Only new messages
     NotificationUrl = notificationUrl, // BFF webhook endpoint
-    Resource = $"users/{mailbox}/mailFolders/Inbox/messages",
+    Resource = $"users/{mailbox}/mailFolders/{monitorFolder}/messages",
     ExpirationDateTime = DateTimeOffset.UtcNow.AddDays(3),
     ClientState = clientStateSecret,   // Validates incoming notifications
 };
 
 var created = await graphClient.Subscriptions.PostAsync(subscription);
 ```
+
+The `monitorFolder` defaults to `"Inbox"` but is configurable per account via `sprk_monitorfolder`.
 
 ### Renew Subscription
 
@@ -119,9 +135,37 @@ Subscription state is persisted in Dataverse `sprk_communicationaccount` records
 |-------|---------|
 | `sprk_subscriptionid` | Graph subscription ID (GUID) |
 | `sprk_subscriptionexpiry` | Subscription expiration (DateTimeOffset) |
-| `sprk_email` | Monitored mailbox address |
+| `sprk_subscriptionstatus` | Active, Expired, or Failed |
+| `sprk_emailaddress` | Monitored mailbox address |
+| `sprk_monitorfolder` | Mail folder to monitor (default: "Inbox") |
 
 This allows the subscription manager to survive BFF restarts — it reads existing subscription state from Dataverse on startup rather than recreating all subscriptions.
+
+---
+
+## Startup Resilience
+
+The `GraphSubscriptionManager` follows the BackgroundService startup resilience pattern:
+
+```csharp
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    _logger.LogInformation("GraphSubscriptionManager starting...");
+    await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken); // Warm-up delay
+
+    try { await RunCycleAsync(stoppingToken); }       // Initial cycle wrapped
+    catch (OperationCanceledException) { return; }
+    catch (Exception ex) { _logger.LogError(ex, "Initial cycle failed, will retry on next tick"); }
+
+    while (await _timer.WaitForNextTickAsync(stoppingToken))
+    {
+        try { await RunCycleAsync(stoppingToken); }
+        catch (Exception ex) { _logger.LogError(ex, "Cycle failed"); }
+    }
+}
+```
+
+**Why**: If the initial cycle throws (e.g., Dataverse/Graph not ready during app startup), an unhandled exception from `ExecuteAsync` triggers .NET 8's `BackgroundServiceExceptionBehavior.StopHost`, silently killing the host. Wrapping in try-catch ensures the service survives and retries on the next timer tick.
 
 ---
 
@@ -133,6 +177,8 @@ This allows the subscription manager to survive BFF restarts — it reads existi
 | 403 on create | Missing `Mail.Read` permission — log error, skip account |
 | Network timeout | Polly retry handles via `GraphHttpMessageHandler` |
 | Graph throttling (429) | Polly retry with `Retry-After` header |
+| Initial cycle failure | Log error, continue to timer loop (startup resilience) |
+| Orphan deletion failure | Log warning, skip orphan (non-fatal) |
 
 ---
 
@@ -156,4 +202,4 @@ To add Graph subscriptions for other resources (e.g., calendar events, Teams mes
 
 ---
 
-**Lines**: ~140
+**Lines**: ~200

--- a/docs/architecture/communication-service-architecture.md
+++ b/docs/architecture/communication-service-architecture.md
@@ -1,6 +1,6 @@
 # Communication Service Architecture
 
-> **Last Updated**: March 9, 2026
+> **Last Updated**: March 12, 2026
 > **Purpose**: Architecture documentation for the Communication Service module — outbound/inbound email via Microsoft Graph, Dataverse-managed mailbox accounts, SPE archival, and AI playbook integration.
 > **Status**: Implemented (R2 Complete)
 > **Branch**: `work/email-communication-solution-r2`
@@ -59,7 +59,7 @@ The Communication Service provides unified email send and receive via Microsoft 
 | Send modes | Shared mailbox only | Shared mailbox + individual user (OBO) |
 | EML for inbound | N/A | `GraphMessageToEmlConverter` (pure transformation, no I/O) |
 | Attachment adapter | N/A | `GraphAttachmentAdapter` maps Graph → existing `EmailAttachmentInfo` |
-| Association resolution | Manual (outbound only) | Automatic 4-level cascade for inbound via `IncomingAssociationResolver` |
+| Association resolution | Manual (outbound only) | Automatic 3-level cascade for inbound via `IncomingAssociationResolver` |
 | Mailbox verification | N/A | `MailboxVerificationService` tests send/read capabilities |
 | Daily send limits | N/A | `DailySendCountResetService` + quota check before send |
 | Telemetry | `EmailTelemetry` | `CommunicationTelemetry` (renamed, expanded metrics) |
@@ -72,7 +72,7 @@ The Communication Service provides unified email send and receive via Microsoft 
 1. **Graph Send is Critical Path**: If Graph `sendMail` fails, the entire operation fails with `SdapProblemException`. No partial success.
 2. **Best-Effort Tracking**: Dataverse record creation, SPE archival, attachment records, and AI analysis are wrapped in try/catch. Failures are logged as warnings.
 3. **No Retry Logic**: Failures are immediate. Callers (UI or AI playbook) handle retry decisions.
-4. **Multi-Layer Deduplication**: Inbound emails are deduplicated at four levels: in-memory webhook cache → ServiceBus idempotency key → Dataverse `sprk_graphmessageid` query → Dataverse duplicate detection rule.
+4. **Multi-Layer Deduplication**: Inbound emails are deduplicated at four levels: in-memory webhook cache (keyed by message ID, not subscription ID) → Service Bus `MessageId` set to `IdempotencyKey` (with SHA-256 hashing for keys >128 chars) → Dataverse `sprk_graphmessageid` query → Dataverse duplicate detection rule.
 5. **Sender Validation Before Send**: The approved sender list is validated synchronously before any Graph call.
 6. **Correlation ID Tracing**: Every operation is tagged with a `correlationId` for end-to-end tracing.
 
@@ -115,8 +115,8 @@ The Communication Service provides unified email send and receive via Microsoft 
 │  │Graph │ │Dv Svc│ │SpeFile   │                 ▼                         │
 │  │Client│ │      │ │Store     │  ┌──────────────────────────────────┐     │
 │  │Factry│ │      │ │(ADR-007) │  │ IncomingAssociationResolver     │     │
-│  └──────┘ └──────┘ └──────────┘  │ Thread > Sender > Subject >    │     │
-│                                   │ Mailbox context (4-level)      │     │
+│  └──────┘ └──────┘ └──────────┘  │ Thread > Sender > Subject      │     │
+│                                   │ (3-level cascade)              │     │
 │  ┌─── Background Services ────┐  └──────────────────────────────────┘     │
 │  │ GraphSubscriptionManager   │                                           │
 │  │   (30-min cycle)           │  ┌──────────────────────────────────┐     │
@@ -157,7 +157,7 @@ The Communication Service provides unified email send and receive via Microsoft 
 | `Services/Communication/CommunicationAccountService.cs` | Service | `sprk_communicationaccount` CRUD with Redis caching |
 | `Services/Communication/ApprovedSenderValidator.cs` | Service | Two-tier sender resolution (config + Dataverse accounts) |
 | `Services/Communication/IncomingCommunicationProcessor.cs` | Service | Inbound email processing pipeline |
-| `Services/Communication/IncomingAssociationResolver.cs` | Service | 4-level association cascade for inbound |
+| `Services/Communication/IncomingAssociationResolver.cs` | Service | 3-level association cascade for inbound |
 | `Services/Communication/GraphMessageToEmlConverter.cs` | Service | Pure transformation: Graph Message → RFC 2822 .eml (inbound) |
 | `Services/Communication/GraphAttachmentAdapter.cs` | Static | Maps Graph `FileAttachment` → `EmailAttachmentInfo` |
 | `Services/Communication/EmlGenerationService.cs` | Service | RFC 2822 .eml generation from request data (outbound) |
@@ -306,32 +306,39 @@ CommunicationEndpoints.HandleIncomingWebhookAsync()
   ├── 2. Parse GraphChangeNotificationCollection
   ├── 3. Validate clientState on each notification
   ├── 4. Deduplicate (in-memory ConcurrentDictionary, 10-min window)
-  │       Key: {subscriptionId}:{resource}:{resourceDataId}
+  │       Key: msg:{messageId}:{changeType}
+  │       (Keyed by message ID to catch duplicates from multiple subscriptions)
   ├── 5. Extract mailbox + messageId from resource path
   ├── 6. Enqueue IncomingCommunication job via ServiceBus
   │       IdempotencyKey: Communication:{messageId}:Process
+  │       Service Bus MessageId = IdempotencyKey (SHA-256 hashed if >128 chars)
+  │       Payload includes subscriptionId for GUID→email resolution
   └── 7. Return 202 Accepted
 ```
 
 ### Processing Pipeline
 
-`IncomingCommunicationProcessor.ProcessAsync(mailboxEmail, graphMessageId)`:
+`IncomingCommunicationProcessor.ProcessAsync(mailboxEmail, graphMessageId, subscriptionId?, ct)`:
 
 ```
 Step 1: Deduplication check
   └── Query sprk_communication by sprk_graphmessageid
   ↓ (skip if already exists)
 
-Step 2: Get account details
-  ├── QueryReceiveEnabledAccountsAsync()
+Step 2: Resolve account from mailbox identifier
+  ├── Direct email match against receive-enabled accounts
+  ├── If GUID (shared mailbox): 3-tier resolution:
+  │   ├── 1. Query Graph subscription → extract email from resource path
+  │   ├── 2. Match by stored subscriptionId on Dataverse accounts
+  │   └── 3. Single-account fallback (if only one receive-enabled)
   └── Check AutoCreateRecords flag
   ↓
 
 Step 3: Fetch full message from Graph
   ├── GraphClientFactory.ForApp()
   ├── Users[email].Messages[messageId].GetAsync()
-  ├── Select: id, from, toRecipients, ccRecipients, subject, body, uniqueBody,
-  │           receivedDateTime, hasAttachments
+  ├── Select: id, internetMessageId, from, toRecipients, ccRecipients, subject,
+  │           body, uniqueBody, receivedDateTime, hasAttachments
   └── Expand: attachments
   ↓
 
@@ -339,24 +346,36 @@ Step 4: Create sprk_communication record
   ├── Direction = Incoming (100000000)
   ├── CommunicationType = Email (100000000)
   ├── StatusCode = Delivered (659490003)
+  ├── sprk_internetmessageid = message.InternetMessageId
   └── Prefer uniqueBody over full body (strips reply chains)
   ↓
 
 Step 4.5: Resolve associations  ◄── BEST-EFFORT
-  └── Delegate to IncomingAssociationResolver (4-level cascade)
+  └── Delegate to IncomingAssociationResolver (3-level cascade)
   ↓
 
-Step 5: Process attachments  ◄── BEST-EFFORT (if AutoCreateRecords=true)
+Step 5: Process attachments  ◄── BEST-EFFORT (if AutoCreateRecords=true or account unresolved)
   ├── GraphAttachmentAdapter.ToAttachmentInfoList()
   ├── Filter signature images via AttachmentFilterService
   ├── Upload to SPE: /communications/{id}/attachments/{fileName}
-  └── Create sprk_communicationattachment records
+  ├── Create sprk_document record per attachment
+  │   ├── sprk_documenttype = Email (100000006)
+  │   ├── sprk_sourcetype = Email Attachment (659490004)
+  │   └── sprk_filename = original filename (for AI file type detection)
+  ├── Enqueue AI analysis job per attachment (best-effort)
+  ├── Enqueue RAG indexing job per attachment (best-effort)
+  └── Create sprk_communicationattachment records (linked to sprk_document)
   ↓
 
 Step 6: Archive .eml to SPE  ◄── BEST-EFFORT (if ArchiveIncomingOptIn != false)
   ├── GraphMessageToEmlConverter.ConvertToEml(graphMessage)
   ├── Upload to SPE: /communications/{id}/{filename}.eml
-  └── Create sprk_document record
+  ├── Create sprk_document record
+  │   ├── sprk_documenttype = Email (100000006)
+  │   ├── sprk_sourcetype = Email Archive (659490003)
+  │   └── sprk_filename = .eml filename (for AI file type detection)
+  ├── Enqueue AI analysis job (best-effort)
+  └── Enqueue RAG indexing job (best-effort)
   ↓
 
 Step 7: Mark message as read in Graph  ◄── BEST-EFFORT
@@ -519,12 +538,12 @@ The `ApprovedSenderValidator` uses a two-tier model:
 
 ## Inbound Association Resolution
 
-`IncomingAssociationResolver` uses a 4-level priority cascade. First match wins.
+`IncomingAssociationResolver` uses a 3-level priority cascade. First match wins.
 
 ### Level 1: Thread Matching
 
 - Fetches `In-Reply-To` header from Graph internet message headers
-- Looks up parent `sprk_communication` by message ID
+- Searches `sprk_internetmessageid` first (exact RFC 2822 match), falls back to `sprk_graphmessageid`
 - Copies regarding fields from parent record
 
 ### Level 2: Sender Matching
@@ -543,9 +562,10 @@ Applies 4 regex patterns against subject line:
 | `SPRK-(\d+)` | `sprk_matter` by `sprk_referencenumber` |
 | `[MATTER:(\d+)]` | `sprk_matter` by `sprk_referencenumber` |
 
-### Level 4: Mailbox Context
+### No Default-Matter Fallback
 
-Falls back to `account.DefaultRegardingMatterId` if configured on the communication account.
+Shared mailboxes are not matter-specific, so there is no automatic default-matter assignment.
+Unassociated emails remain unassociated and surface for manual review via Pending Review status.
 
 ### Association Status
 
@@ -615,26 +635,50 @@ Create sprk_communicationattachment records in Dataverse
 ### Dataverse Linkage
 
 After upload, creates a `sprk_document` record:
-- `sprk_documenttype` = Communication (100000002)
-- `sprk_sourcetype` = CommunicationArchive (100000001)
+- `sprk_documentname` = "Archived: {subject}" (outbound) or "{filename}" (attachment)
+- `sprk_filename` = .eml filename or original attachment filename (used by AI analyzer for file type detection)
+- `sprk_documenttype` = Email (100000006)
+- `sprk_sourcetype` = Email Archive (659490003) for .eml, Email Attachment (659490004) for attachments
 - `sprk_communication` = EntityReference to the communication record
-- `sprk_speitemid` / `sprk_spedriveid` = SPE file identifiers
+- `sprk_graphitemid` / `sprk_graphdriveid` = SPE file identifiers
+- `sprk_isemailarchive` = true (for .eml files)
+- `sprk_emailsubject`, `sprk_emailfrom`, `sprk_emailto`, `sprk_emaildate`, `sprk_emaildirection` = email metadata
 
 ---
 
 ## Background Services
 
-Three `BackgroundService` implementations following ADR-001:
+Three `BackgroundService` implementations following ADR-001.
+
+### Startup Resilience Pattern (All Services)
+
+All communication BackgroundServices follow the same startup pattern:
+
+```
+ExecuteAsync(CancellationToken stoppingToken)
+  1. Log startup message
+  2. await Task.Delay(startup_delay, stoppingToken)  ◄── Dependency warm-up
+  3. try { await InitialCycleAsync(stoppingToken); }  ◄── Wrapped in try-catch
+     catch (OperationCanceledException) → return
+     catch (Exception) → log error, continue to loop
+  4. while (timer.WaitForNextTickAsync()) { ... }     ◄── Standard loop with try-catch
+```
+
+**Why**: If the initial cycle throws (e.g., Dataverse/Graph not ready during app startup), an unhandled exception propagates from `ExecuteAsync` and .NET 8's default `BackgroundServiceExceptionBehavior.StopHost` stops the host. Wrapping the initial call in try-catch ensures the service retries on the next timer tick instead of dying silently.
 
 ### GraphSubscriptionManager
 
 | Setting | Value |
 |---------|-------|
 | Tick interval | 30 minutes |
+| Startup delay | 10 seconds |
 | Renewal threshold | 24 hours before expiry |
 | Subscription lifetime | 3 days (Graph maximum for mail) |
 
-**Decision logic per account**:
+**Each cycle executes**:
+
+1. **Orphan cleanup** — Lists all Graph subscriptions, compares with Dataverse-managed IDs, deletes untracked orphans whose `NotificationUrl` matches the configured webhook URL (safety filter to avoid touching subscriptions managed by other applications)
+2. **Per-account lifecycle** — For each receive-enabled account:
 
 | Condition | Action |
 |-----------|--------|
@@ -645,11 +689,14 @@ Three `BackgroundService` implementations following ADR-001:
 
 Subscription resource: `users/{email}/mailFolders/{monitorFolder}/messages` with `changeType=created`.
 
+**Orphan cleanup** prevents duplicate webhook notifications caused by accumulated subscriptions from deployments or multi-instance race conditions. This was the root cause of duplicate email processing discovered in March 2026.
+
 ### InboundPollingBackupService
 
 | Setting | Value |
 |---------|-------|
 | Polling interval | 5 minutes |
+| Startup delay | 15 seconds |
 | Initial lookback window | 15 minutes (on startup/restart) |
 | Max messages per poll | 50 |
 
@@ -683,9 +730,10 @@ Queries `isRead eq false` messages filtered by `receivedDateTime`. Enqueues `Inc
 | `sprk_subject` | String | Email subject |
 | `sprk_body` | Multiline | Email body content |
 | `sprk_graphmessageid` | String | Graph message ID (used for deduplication) |
+| `sprk_internetmessageid` | String | RFC 2822 Internet Message-ID (for thread matching via In-Reply-To) |
 | `sprk_sentat` | DateTime | Send/receive timestamp |
 | `sprk_correlationid` | String | Tracing correlation ID |
-| `sprk_sentby` | String | OID of sending user (User mode only) |
+| `sprk_sentby` | Lookup (systemuser) | Resolved from Azure AD OID via `QuerySystemUserByAzureAdOidAsync` |
 | `sprk_hasattachments` | Boolean | Whether attachments were included |
 | `sprk_attachmentcount` | Integer | Number of attachments |
 | `sprk_associationcount` | Integer | Number of entity associations |
@@ -901,10 +949,22 @@ Registered explicitly in `CommunicationModule` as singleton (not auto-discovered
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | `string` | Yes | Comma-separated recipient emails |
+| `cc` | `string` | No | Comma-separated CC recipient emails |
 | `subject` | `string` | Yes | Email subject |
 | `body` | `string` | Yes | Email body (HTML) |
-| `fromMailbox` | `string` | No | Sender mailbox |
-| `associations` | `object[]` | No | Entity associations |
+| `fromMailbox` | `string` | No | Sender mailbox (null = default shared mailbox) |
+| `regardingEntity` | `string` | No | Dataverse entity logical name for primary association (e.g., `sprk_matter`) |
+| `regardingId` | `string` | No | Dataverse record GUID for primary association |
+| `associations` | `object[]` | No | Additional entity associations |
+
+### How AI Playbooks Send Email
+
+The AI tool framework invokes `SendCommunicationToolHandler.HandleAsync()` which:
+1. Parses tool parameters into a `SendCommunicationRequest`
+2. Delegates to `CommunicationService.SendAsync()` (same pipeline as UI sends)
+3. Returns a structured result with `communicationId`, `status`, and any warnings
+
+This ensures AI-sent emails go through the same validation, sender resolution, archival, and tracking as UI-initiated sends.
 
 ---
 

--- a/docs/guides/COMMUNICATION-ADMIN-GUIDE.md
+++ b/docs/guides/COMMUNICATION-ADMIN-GUIDE.md
@@ -1,6 +1,6 @@
 # Communication Account Administration Guide - Release 2
 
-> **Last Updated**: March 9, 2026
+> **Last Updated**: March 12, 2026
 > **Purpose**: Complete administrative guide for managing the Email Communication Service R2 in Dataverse — covering communication account management, send modes, inbound monitoring, document archival, verification, and troubleshooting.
 > **Applies To**: Dev environment (`spaarkedev1.crm.dynamics.com`, `spe-api-dev-67e2xz.azurewebsites.net`)
 > **Release**: R2 (replaces email activities, Server-Side Sync retirement)
@@ -323,20 +323,22 @@ Check the **My Communications** view (activity-based) or create a custom view to
 
 When incoming email arrives, the BFF API automatically attempts to link it to relevant Dataverse entities (matters, contacts, accounts, etc.) using a priority cascade:
 
-### Resolution Cascade (Priority Order)
+### Resolution Cascade (3-Level Priority)
 
-1. **Thread Match** — If In-Reply-To header references an existing `sprk_graphmessageid`, link to that communication's associated entity
-2. **Sender Match** — If email is from a contact/account already in Dataverse, auto-link to that entity
-3. **Subject Pattern** — If subject contains a known matter ID or pattern, auto-link
-4. **Mailbox Context** — If the account has default associations (rare), use those
+1. **Thread Match** — If `In-Reply-To` header references an existing `sprk_internetmessageid` (or fallback `sprk_graphmessageid`), copy the parent record's associations
+2. **Sender Match** — Query `contact` by sender email; query `account` by sender domain (skips common providers like gmail.com, outlook.com)
+3. **Subject Pattern** — Regex match against subject line for matter reference numbers (e.g., `MAT-123`, `Matter #123`, `SPRK-456`, `[MATTER:789]`)
+
+**No default-matter fallback**: Shared mailboxes are not matter-specific. Unassociated emails remain with `sprk_associationstatus = Pending Review` for manual triage.
 
 ### What Gets Linked
 
 The system populates association fields on the incoming `sprk_communication` record:
-- `sprk_regardingobjectid` — Primary associated entity (matter, contact, account, etc.)
-- `sprk_contactid` — If sender is a known contact
-- `sprk_accountid` — If sender is from a known account
-- Additional association fields as configured
+- `sprk_regarding{entity}` — Entity-specific lookup fields (8 supported entity types)
+- `sprk_regardingrecordname` — Denormalized display name of primary association
+- `sprk_regardingrecordid` — Denormalized GUID of primary association
+- `sprk_regardingrecordurl` — Denormalized URL for primary association
+- `sprk_associationstatus` — Resolved (100000000) or Pending Review (100000001)
 
 ### Limitations & Scope
 
@@ -482,13 +484,26 @@ Replace `{account-id}` with the `sprk_communicationaccountid` GUID.
 
 The `GraphSubscriptionManager` background service automatically handles the complete lifecycle:
 
-1. **On BFF Startup**: Queries all receive-enabled accounts and creates subscriptions for those without one
-2. **Every 30 Minutes**: Checks subscription status and:
-   - Creates new subscriptions for accounts without one
-   - Renews subscriptions when expiry < 24 hours away
-   - Recreates subscriptions that failed or expired
+1. **On BFF Startup**: Waits 10 seconds for dependencies to warm up, then runs the first cycle
+2. **Every 30 Minutes**: Runs two phases:
+   - **Phase 1 — Orphan Cleanup**: Lists ALL Graph subscriptions, identifies any whose `NotificationUrl` matches the configured webhook URL but are NOT tracked in any Dataverse account record, and deletes them. This prevents duplicate webhook notifications from accumulated orphan subscriptions.
+   - **Phase 2 — Per-Account Lifecycle**: For each receive-enabled account:
+     - Creates new subscriptions for accounts without one
+     - Renews subscriptions when expiry < 24 hours away
+     - Recreates subscriptions that failed or expired (404 on renewal → delete + recreate)
 3. **On Notification**: When an email arrives, Graph sends a change notification to `POST /api/communications/incoming-webhook`
 4. **Processing**: The webhook enqueues the message for processing (< 3 seconds response time required)
+
+### Diagnostic Endpoint
+
+To check the current state of Graph subscriptions, use the diagnostic endpoint:
+
+```bash
+curl "https://spe-api-dev-67e2xz.azurewebsites.net/api/diagnostics/graph-subscriptions" \
+  -H "Authorization: Bearer {token}"
+```
+
+This lists all active Graph subscriptions including their `NotificationUrl`, `Resource`, and `ExpirationDateTime`. Use this to verify orphan cleanup is working correctly — you should see exactly one subscription per receive-enabled account.
 
 ### Subscription Lifetime
 
@@ -717,6 +732,18 @@ The **Communication Account** form includes the following sections:
 | Mailbox does not exist in Azure AD | Verify mailbox exists: `Get-Mailbox -Identity "address@domain.com"` |
 | App registration missing permissions | Check `Mail.Send` (Application) and `Mail.Read` (Application) in Azure AD |
 
+### Duplicate Emails Being Processed
+
+**Symptom**: The same incoming email creates multiple `sprk_communication` records.
+
+**Possible Causes and Fixes**:
+
+| Cause | Fix |
+|-------|-----|
+| Orphan Graph subscriptions | Check diagnostic endpoint — should see exactly 1 subscription per account. If more, orphan cleanup will handle it on next 30-min cycle. Force by restarting the BFF API. |
+| Service Bus deduplication window expired | Default dedup window is set on the queue. Messages received outside the window are treated as new. |
+| Multiple BFF instances racing | The dedup key `msg:{messageId}:{changeType}` + Service Bus `MessageId` should prevent this. Check if IdempotencyKey is being set correctly. |
+
 ### Backup Polling Not Running
 
 **Symptom**: Incoming emails not being processed even when webhook subscription is down.
@@ -725,9 +752,22 @@ The **Communication Account** form includes the following sections:
 
 | Cause | Fix |
 |-------|-----|
-| `InboundPollingBackupService` not started | Check BFF API health via `/healthz`; review startup logs |
+| `InboundPollingBackupService` not started | Check BFF API health via `/healthz`; review startup logs for "InboundPollingBackupService starting" |
+| Startup failure killed the service | Check logs for errors within first 15 seconds of startup. The service has startup resilience (try-catch) but check for persistent errors. |
 | Account not receive-enabled | Set `sprk_receiveenabled` to Yes |
 | Redis cache stale | Clear Redis cache; service will re-query on next cycle |
+
+### BackgroundService Not Running (Silent Death)
+
+**Symptom**: Subscriptions not being renewed, polling not running, send counts not resetting — but `/healthz` returns healthy.
+
+**Possible Causes and Fixes**:
+
+| Cause | Fix |
+|-------|-----|
+| Unhandled exception in `ExecuteAsync` | .NET 8 default `BackgroundServiceExceptionBehavior.StopHost` stops the host on unhandled exceptions. All communication services now wrap initial execution in try-catch, but check for exceptions in startup logs. |
+| Dependency not available at startup | Services have startup delays (10s for GraphSubscriptionManager, 15s for InboundPollingBackupService) to allow dependencies to initialize. If Dataverse or Graph is slow, the first cycle may fail but the service will retry on next tick. |
+| App Service recycled | Check App Service logs for recycling events. Services auto-restart with the host. |
 
 ### OBO Token Errors (Individual User Send)
 


### PR DESCRIPTION
## Summary

- Update communication service documentation to reflect final R2 implementation
- Fix association cascade references from 4-level to 3-level throughout architecture doc
- Add AI Playbook tool parameters (`cc`, `regardingEntity`, `regardingId`) to architecture doc
- Update `graph-webhooks.md` pattern with orphan cleanup, startup resilience, and NotificationUrl safety filter
- Create new `send-email-integration.md` pattern with 3 repeatable email integration patterns (UI → API, AI Playbook → Tool, Server-Side → Direct)
- Update admin guide with orphan cleanup, diagnostic endpoint, and new troubleshooting sections
- Update jobs constraints with Service Bus `MessageId=IdempotencyKey` rule and SHA-256 hashing

## Changes

| File | What Changed |
|------|-------------|
| `docs/architecture/communication-service-architecture.md` | Fix 4→3-level cascade, add AI Playbook params |
| `.claude/patterns/auth/graph-webhooks.md` | Orphan cleanup, startup resilience, monitor folder |
| `.claude/patterns/api/send-email-integration.md` | **NEW** — 3 email integration patterns |
| `.claude/patterns/api/INDEX.md` | Add send-email-integration entry |
| `docs/guides/COMMUNICATION-ADMIN-GUIDE.md` | Orphan cleanup, diagnostics, new troubleshooting |
| `.claude/constraints/jobs.md` | MessageId=IdempotencyKey, SHA-256 hashing |

## Test plan

- [x] Documentation-only changes — no code modified
- [x] All markdown files render correctly
- [x] Cross-references between docs are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)