### PR TITLE
fix(ci): add id-token:write to claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write  # required by anthropics/claude-code-action@beta to fetch its OIDC token
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Adds `id-token: write` to the `claude-code-review.yml` workflow's `permissions` block.
- Root cause: `anthropics/claude-code-action@beta` uses GitHub's OIDC token endpoint, which requires `id-token: write` to be granted to the workflow. Without it, every PR fails the "Architecture Review (Advisory)" check with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`.
- Despite the job being marked `continue-on-error: true`, branch protection counts the failing check as a merge block, so this has been silently blocking PR merges since the workflow was introduced.

## Repro

PR #299 was blocked by this same failure. Failed run: https://github.com/spaarke-dev/spaarke/actions/runs/26466754309

## Test plan

- [ ] CI re-runs on this PR; the `Architecture Review (Advisory)` check now succeeds (the action can fetch its OIDC token and post a review comment).
- [ ] After this PR merges, re-trigger the check on PR #299 — should pass cleanly without `--admin`.
- [ ] No functional change to the workflow logic — only the permissions grant changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)