### PR TITLE
docs(bff-ai-architecture-audit): initiate r1 audit project — comprehensive AI infrastructure review

### DIFF
--- a/projects/bff-ai-architecture-audit-r1/CLAUDE.md
+++ b/projects/bff-ai-architecture-audit-r1/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md — BFF AI Architecture Audit r1 — project context
+
+> **Project-scoped instructions.** Loads when working in `projects/bff-ai-architecture-audit-r1/`.
+> **Status**: 🆕 initiated 2026-06-04. Audit methodology + scope pending owner discussion in `design.md`.
+
+---
+
+## What this project is
+
+A **dedicated architectural audit** of all AI infrastructure in `Sprk.Bff.Api`. Triggered by `ai-spaarke-insights-engine-r3` design discussion surfacing 4 parallel intent-classification systems + 4 near-identical lookup services + various other accumulated parallel infrastructure across 5+ project cycles.
+
+This is **NOT** a feature project. No code ships from this audit. Outputs are:
+1. Inventory (data)
+2. Canonical-architecture decisions (decisions)
+3. Migration plan for downstream projects (recommendations)
+
+Downstream projects (r3, R5, future r4) consume the audit's decisions and do the actual implementation work.
+
+---
+
+## Predecessor context
+
+| r2 closed | 2026-06-04 (Phase 1.5 ✅; 14/15 SCs met) |
+| r3 paused | 2026-06-04 (Option C choice: audit FIRST) — only Wave 2 paused; Wave 1 cleanup proceeds independently |
+| Primary input | [`notes/initial-findings.md`](notes/initial-findings.md) |
+
+---
+
+## 🚨 MANDATORY: Task Execution Protocol
+
+When the audit produces task POMLs, the `task-execute` skill applies per root CLAUDE.md §4. Until then, the work is methodology + discovery via grep/Read/Glob — main-session driven, not task-driven.
+
+---
+
+## What the audit is + isn't
+
+| IS | IS NOT |
+|---|---|
+| Systematic inventory of AI services | Refactoring work (that comes after, in downstream projects) |
+| Canonical-architecture decisions per category | Code changes |
+| Migration plan with effort estimates | Implementation of migrations |
+| r3 + r4 scope guidance | Lock-in for any downstream project (those still own their scope) |
+| Process recommendation re: future audits | Mandate for how downstream projects work |
+
+---
+
+## Audit categories (per `notes/initial-findings.md`)
+
+1. **Intent classification** — 4 parallel systems
+2. **Lookup services** — 4 near-identical DRY violations
+3. **Search services** — 4 distinct-but-uncoordinated
+4. **Cache patterns** — 11+ direct `IMemoryCache` usages, diverse TTL needs
+5. **Prompt builders** — 3+ patterns
+6. **Possibly more discovered during audit** — TBD
+
+For each category, audit decides: canonical service, deprecation candidates, migration plan, effort.
+
+---
+
+## Methodology (to be refined in design.md)
+
+Likely structure:
+
+1. **Inventory phase** (~3d) — systematic file-by-file walk of `Services/Ai/`; grep for each service's consumers; classify state (active / deprecated / unused)
+2. **Per-category analysis** (~3d) — for each of categories 1-6 above (and any newly discovered), apply: read code, identify canonical candidate, document tradeoffs
+3. **Owner review** (~0.5d total but spread across iterations) — present per-category findings; owner picks canonical
+4. **Migration planning** (~2d) — work-item sizing per service/category; identify cross-team coordination needs
+5. **Decision documentation** (~2d) — decision records (DR-###) in `decisions/`; final report in `notes/canonical-architecture-decisions.md`
+
+Total: ~2 weeks.
+
+---
+
+## Key principles (likely; refined in design.md)
+
+- **Honest assessment over scope minimization** — if a service is deprecated and nobody knows, surface it
+- **Don't propose deletion without consumer mapping** — empirical "no one uses this" before "delete this"
+- **Cross-project coordination is part of the work** — SprkChat, Insights, R5, playbook-builder teams may all have ownership
+- **Audit doesn't decide scope for downstream projects** — it gives them ground truth + recommendations; they own their roadmaps
+
+---
+
+## Predecessor artifacts to consult
+
+Before any audit work, READ:
+
+1. [`notes/initial-findings.md`](notes/initial-findings.md) — what we already know
+2. `projects/ai-spaarke-insights-engine-r3/design.md` §2 — what r3 was about to lock based on incomplete information
+3. `projects/spaarke-ai-platform-unification-r5/notes/insights-r2-coordination.md` §3.1 — R5↔Insights reuse mandate (the precedent for what this audit produces at BFF-wide scope)
+4. `projects/ai-sprk-chat-platform-enhancement-r2/` — completed SprkChat r2 project (shipped CapabilityRouter consumer, PlaybookDispatcher)
+
+---
+
+## Quick links
+
+- [README.md](README.md) — project overview
+- [notes/initial-findings.md](notes/initial-findings.md) — primary input
+- [design.md](design.md) — audit scope + methodology (pending)
+- [current-task.md](current-task.md) — active task tracker
+
+---
+
+*Skeleton authored 2026-06-04 by main session after Option C decision. Solidifies as design.md methodology firms up.*

--- a/projects/bff-ai-architecture-audit-r1/README.md
+++ b/projects/bff-ai-architecture-audit-r1/README.md
@@ -1,0 +1,75 @@
+# BFF AI Architecture Audit — r1
+
+> **Status**: 🆕 INITIATED (2026-06-04)
+> **Triggered by**: r3 design discussion of `ai-spaarke-insights-engine-r3` surfaced multiple parallel intent-classification systems
+> **Decision**: Owner chose "Option C — pause r3, do dedicated audit FIRST" rather than try to scope r3 reconciliation work without canonical architecture decisions
+> **Primary input**: [`notes/initial-findings.md`](notes/initial-findings.md) — captures discovery before context is lost
+> **Estimated effort**: ~2 weeks
+
+---
+
+## 1. Purpose
+
+The Spaarke BFF (`Sprk.Bff.Api`) has accumulated AI infrastructure across 5+ project cycles. Each project added what it needed; no holistic cleanup has happened. The result, documented in `notes/initial-findings.md`:
+
+- **4 parallel intent classification systems** (`CapabilityRouter`, `PlaybookDispatcher`, `IntentClassificationService`, `InsightsIntentClassifier`)
+- **4 near-identical lookup services** (`PlaybookLookupService`, `ActionLookupService`, `ToolLookupService`, `SkillLookupService`) — DRY violation
+- **4 distinct-but-uncoordinated search services** (`IRagService`, `SemanticSearchService`, `RecordSearchService`, `PlaybookEmbeddingService`)
+- **3+ prompt-builder patterns**
+- **11+ services rolling their own cache** with different TTL/eviction semantics
+- Possibly more (full inventory pending)
+
+r3 cannot responsibly scope reconciliation work without knowing the canonical answer. This audit project produces those answers.
+
+## 2. Deliverables
+
+Per [`notes/initial-findings.md`](notes/initial-findings.md) §8:
+
+1. **Comprehensive inventory** — every AI service + consumers + state (active/deprecated/unused) + originating project
+2. **Canonical-architecture decisions** per category (intent classification, lookup services, search services, cache patterns, prompt builders, …)
+3. **Migration plan** — per service/category: code paths, tests, deploy implications, coordination needs, effort estimate
+4. **r3 + r4 scope guidance** — what's safe to proceed now vs. what waits for audit findings
+5. **Process recommendation** — should periodic AI architecture review be institutionalized?
+
+## 3. Status
+
+| Phase | Status |
+|---|---|
+| Project initialization | ✅ 2026-06-04 |
+| Initial findings capture | ✅ [`notes/initial-findings.md`](notes/initial-findings.md) |
+| design.md (audit scope + methodology) | 🔄 owner-mediated discussion next |
+| spec.md | 🔲 derives from design |
+| plan.md (waves + task POMLs) | 🔲 derives from spec |
+| Implementation (the audit itself) | 🔲 starts after planning |
+| Final decisions + r3 unblock | 🔲 ~2 weeks from initiation |
+
+## 4. Downstream projects waiting on this
+
+| Project | Wave / item | Reason waiting |
+|---|---|---|
+| `ai-spaarke-insights-engine-r3` | Wave 2 (Tier 2.5 — Insights ↔ CapabilityRouter + PlaybookDispatcher reconciliation) | Cannot scope without canonical architecture decision |
+| `spaarke-ai-platform-unification-r5` | None explicitly blocked, but heads-up sent re: chat-agent intent layer parallel-build risk | Audit findings may surface R5-side duplications |
+
+r3 wave 1 (Tier 1 cleanup: `NullInsightsAi`, v1.2 `spe://` href, test-fixture hygiene, telemetry, index rename) is **safe to proceed** independent of audit — those items are infrastructure cleanup that doesn't depend on architecture decisions.
+
+## 5. Key references
+
+| Doc | Purpose |
+|---|---|
+| [`notes/initial-findings.md`](notes/initial-findings.md) | Captured discovery — primary audit input |
+| [`design.md`](design.md) | Audit methodology + scope (skeleton; pending discussion) |
+| [`CLAUDE.md`](CLAUDE.md) | Project-scoped Claude context |
+| [`current-task.md`](current-task.md) | Active task tracker |
+| `projects/ai-spaarke-insights-engine-r3/design.md` | The r3 project waiting on this audit |
+| `projects/spaarke-ai-platform-unification-r5/notes/insights-r2-coordination.md` §8.12-§8.16 | R5 heads-up about Insights duplication finding (the trigger) |
+
+## 6. Coordination
+
+- **r3 (Insights Engine Phase 2)** — paused on Wave 2 scope; will resume when audit produces canonical decisions
+- **R5 (Spaarke Assistant)** — heads-up sent; should also audit own chat-agent layer
+- **SprkChat platform team** — owns `CapabilityRouter` + `PlaybookDispatcher` + related infrastructure; reconciliation decisions need their sign-off
+- **Earlier playbook-builder project** — owner-identified as source of some accumulated services; may have ownership / deprecation decisions to make
+
+---
+
+*Created 2026-06-04 by main session at owner direction. Authored after r3 design discussion surfaced the underlying architectural debt pattern.*

--- a/projects/bff-ai-architecture-audit-r1/current-task.md
+++ b/projects/bff-ai-architecture-audit-r1/current-task.md
@@ -1,0 +1,46 @@
+# Current Task — BFF AI Architecture Audit r1
+
+> **Purpose**: Active task state tracker.
+> **Status**: Project initialized 2026-06-04; design phase.
+
+---
+
+## 🎯 Active task — none (design phase)
+
+Audit project is in **design phase** — no implementation tasks yet exist. Active work is the owner-mediated discussion of `design.md` audit methodology + scope.
+
+**Next action** (owner): refine [`design.md`](design.md) to lock the audit methodology + scope based on the [initial findings](notes/initial-findings.md). Specifically decide:
+
+1. Audit scope — categories 1-6 from initial-findings only, or broader (e.g., ADR audit, NuGet audit, configuration audit)?
+2. Methodology — single sequential pass, or per-category parallel?
+3. Owner-review cadence — per-category as decisions form, or one big review at end?
+4. Cross-team coordination — which teams need to be in the loop and when (SprkChat, R5, playbook-builder)?
+5. Output format — single canonical report, per-category decision records, or both?
+
+---
+
+## Status
+
+| Phase | Status |
+|---|---|
+| Project initialized | ✅ 2026-06-04 |
+| Initial findings captured | ✅ [`notes/initial-findings.md`](notes/initial-findings.md) |
+| Design discussion | 🔄 owner-mediated; pending |
+| Inventory phase | 🔲 |
+| Per-category analysis | 🔲 |
+| Canonical decisions | 🔲 |
+| Migration plan | 🔲 |
+| Downstream unblock | 🔲 |
+
+---
+
+## Downstream projects waiting on this audit
+
+| Project | What's blocked | What's NOT blocked |
+|---|---|---|
+| `ai-spaarke-insights-engine-r3` | Wave 2 (Tier 2.5 reconciliation scope) | Wave 1 cleanup (Tier 1 + Tier 1.5 index rename) safe to proceed |
+| `spaarke-ai-platform-unification-r5` | Nothing explicitly | Heads-up to audit own chat-agent layer for similar parallel-build risk |
+
+---
+
+*Initial state 2026-06-04 by main session post-r3-pause. Will update as design.md methodology + scope solidify.*

--- a/projects/bff-ai-architecture-audit-r1/design.md
+++ b/projects/bff-ai-architecture-audit-r1/design.md
@@ -1,0 +1,125 @@
+# BFF AI Architecture Audit — Design (Skeleton)
+
+> **Status**: 🆕 SKELETON — methodology + scope pending owner discussion
+> **Primary input**: [`notes/initial-findings.md`](notes/initial-findings.md)
+> **Created**: 2026-06-04
+> **Authored by**: Claude (main session) after Option C decision
+
+---
+
+## 1. Purpose
+
+Produce a comprehensive inventory + canonical-architecture decisions for AI infrastructure in `Sprk.Bff.Api`. Output guides scope of downstream projects (r3, R5, future r4).
+
+## 2. Audit scope (TBD)
+
+Scope to be locked by owner. Suggested anchor: categories surfaced in `notes/initial-findings.md` §2-§6 plus expansions discovered during audit.
+
+### 2.1 In-scope candidates (per initial findings)
+
+- **Category 1**: Intent classification systems (4 found)
+- **Category 2**: Lookup services (4 near-identical)
+- **Category 3**: Search services (4 distinct)
+- **Category 4**: Cache patterns (11+ direct usages)
+- **Category 5**: Prompt builders (3+ patterns)
+- **Category 6+**: Anything else discovered during audit
+
+### 2.2 Possible scope expansions (owner decides)
+
+- DI registration patterns — are services registered consistently?
+- NuGet package audit — duplicate / conflicting versions across projects?
+- Configuration / options pattern — consistent `IOptions<T>` usage?
+- Telemetry / observability — consistent OTEL spans, metric names?
+- ADR alignment — which existing ADRs are actually followed?
+
+### 2.3 Out of scope (likely)
+
+- Code changes / refactoring (audit produces recommendations; downstream projects do the work)
+- ADR creation (any new ADRs needed surface as audit output recommendations, not authored by audit)
+- Production deployment / migration (planning only)
+
+## 3. Methodology (TBD)
+
+### 3.1 Phase structure (likely; refined per owner discussion)
+
+| Phase | Effort | Output |
+|---|---|---|
+| Inventory | ~3d | Systematic file-by-file catalog of every AI service; consumer mapping via grep; state classification (active/deprecated/unused) |
+| Per-category analysis | ~3d | For each category: canonical candidate, tradeoffs, migration cost |
+| Owner review | iterative | Per-category decisions; signed off in `decisions/` |
+| Migration planning | ~2d | Work-item sizing per service; cross-team coordination needs |
+| Documentation | ~2d | Final report + decision records |
+
+### 3.2 Discovery techniques
+
+- `Grep` for service name across `src/` to find consumers
+- `Read` each service to understand contracts + behavior
+- `Glob` to enumerate service categories
+- Cross-reference against project READMEs to attribute origin
+- Cross-reference against R5 coord doc §3.1 to identify documented reuse intent
+
+### 3.3 Owner-review cadence (TBD)
+
+Options:
+- A) Per-category as decisions form (~5-6 owner touchpoints)
+- B) Single final review with all decisions packaged
+- C) Hybrid: review after inventory phase (course-correct), then per-category, then final
+
+## 4. Decisions framework
+
+For each category surfaced in `notes/initial-findings.md`, audit answers:
+
+1. **Canonical service** — which existing service is the "real one"
+2. **Deprecation candidates** — which services should be deprecated/deleted
+3. **Migration plan** — how downstream projects move to canonical
+4. **Effort estimate** — total work to migrate
+5. **Cross-team coordination** — which teams need to be involved
+6. **Rollback strategy** — what happens if canonical decision turns out wrong
+
+Each decision recorded as a decision record (`DR-###`) in [`decisions/`](decisions/).
+
+## 5. Cross-team coordination protocol (TBD)
+
+Likely teams to engage:
+
+- **SprkChat platform team** — owns `CapabilityRouter`, `PlaybookDispatcher`, `playbook-embeddings` infrastructure. Their sign-off needed if canonical decision changes their consumer code.
+- **R5 (Spaarke Assistant)** — primary downstream consumer; already heads-upped re: chat-agent audit. Their input needed re: which capabilities they actually consume.
+- **Playbook-builder project owner** — if `IntentClassificationService` + `AiPlaybookBuilderService` are still alive, owner sign-off on canonical decisions.
+- **Insights Engine r3 team** (us) — primary downstream consumer; audit findings unblock r3 wave 2 scope.
+
+## 6. Output documents
+
+| Document | Purpose | Status |
+|---|---|---|
+| `notes/inventory.md` | Every AI service + consumers + state + origin | 🔲 |
+| `notes/canonical-architecture-decisions.md` | Final canonical-architecture report (the audit's primary deliverable) | 🔲 |
+| `notes/migration-plan.md` | Per-service work-item sizing for downstream projects | 🔲 |
+| `decisions/DR-###-*.md` | Per-category decision records | 🔲 |
+| `notes/r3-scope-recommendations.md` | Specific guidance for r3 wave 2 | 🔲 |
+| `notes/r5-audit-recommendations.md` | Specific guidance for R5 chat-agent audit | 🔲 |
+| `notes/process-recommendation.md` | Should periodic AI architecture review be institutionalized? | 🔲 |
+
+## 7. Effort estimate
+
+Per `notes/initial-findings.md` §9:
+
+- Inventory: ~3d
+- Canonical-architecture decisions: ~3d
+- Migration plan: ~2d
+- Documentation + decision records: ~2d
+- **Total: ~2 weeks**
+
+After audit completes, r3 wave 1 has been proceeding independently; r3 wave 2 scope locked per audit findings.
+
+## 8. Open questions for owner
+
+- **Q-001**: Audit scope — categories 1-6 from initial findings only, or broader (DI patterns, NuGet, config, telemetry, ADRs)?
+- **Q-002**: Owner-review cadence — per-category, single final review, or hybrid?
+- **Q-003**: Cross-team coordination — sequential (Insights → SprkChat → R5 → playbook-builder) or parallel?
+- **Q-004**: Naming — should the canonical infrastructure get explicit names (e.g., "Spaarke Canonical AI Stack") to reduce future drift?
+- **Q-005**: Should audit recommend ADRs for canonical-architecture lock-ins, or just produce decision records?
+- **Q-006**: Process — institutionalize periodic AI architecture review? Per-quarter? Per-major-project-cycle?
+
+---
+
+*Skeleton authored 2026-06-04 by main session. Audit methodology + scope solidifies as owner-mediated discussion progresses.*

--- a/projects/bff-ai-architecture-audit-r1/notes/initial-findings.md
+++ b/projects/bff-ai-architecture-audit-r1/notes/initial-findings.md
@@ -1,0 +1,260 @@
+---
+title: BFF AI Architecture Audit — Initial Findings
+created: 2026-06-04
+authored-by: Claude (Anthropic AI agent) during r3 design discussion
+status: INPUT FOR AUDIT — captured before findings are lost to context
+trigger: r3 design discussion surfaced multiple parallel intent-classification systems; audit project initiated per Option C
+---
+
+# Initial Findings — BFF AI Infrastructure Catalog
+
+> **Critical preservation note**: These findings were surfaced during a focused ~30-minute investigation triggered by r3 design discussion. Owner explicitly chose Option C ("pause r3, do dedicated audit FIRST") based on these findings. This document is the primary input to the audit's actual work; do NOT lose context here.
+
+---
+
+## 1. Triggering observation
+
+During r3 design discussion (Tier 2.5 "embedding-based intent classifier"), Claude (main session) recommended building "playbook self-description schema + indexing substrate" from scratch — ~2-3 week effort. Owner pushed back: *"in AI Search the index we have is 'playbook-embeddings' and there are already playbooks in the index; including fields for 'trigger phrases'"*.
+
+Investigation confirmed: SprkChat Platform Enhancement R2 (completed 2026-03-17) had shipped exactly this infrastructure. Wave E2 of Insights Engine r2 built a parallel LLM-only classifier without leveraging it.
+
+That single discovery triggered the broader audit captured below.
+
+---
+
+## 2. Parallel intent-classification systems (4 found — REAL DUPLICATION)
+
+The BFF has accumulated FOUR independent intent-classification subsystems:
+
+### 2.1 `CapabilityRouter` (AIPU2-012/013/014)
+
+- **Path**: `src/server/api/Sprk.Bff.Api/Services/Ai/Capabilities/`
+- **Architecture**: Three-tier
+  - Layer 1 (AIPU2-012): Synchronous keyword classifier; <50ms; no LLM cost
+  - Layer 2 (AIPU2-013): LLM intent classifier; single gpt-4o-mini call
+  - Layer 3 (AIPU2-014): Broad superset fallback; synchronous; <1ms
+- **Manifest source**: Dataverse-backed via `DataverseCapabilityManifestLoader` + `ManifestRefreshService`
+- **Used by**: `SprkChatAgentFactory` (singleton)
+- **Maturity**: HIGH — has manifest, validation, refresh, telemetry, options class
+- **Files**: `CapabilityRouter`, `CapabilityManifest`, `CapabilityManifestEntry`, `CapabilityManifestInitializer`, `DataverseCapabilityManifestLoader`, `IManifestRefreshTrigger`, `ManifestRefreshService`, `CapabilityValidator`, `CapabilityClassificationPromptBuilder`, `CapabilityRouterOptions`, `CapabilityRoutingResult`
+
+### 2.2 `PlaybookDispatcher` (SprkChat r2-015)
+
+- **Path**: `src/server/api/Sprk.Bff.Api/Services/Ai/Chat/PlaybookDispatcher.cs`
+- **Architecture**: Two-stage
+  - Stage 1: Vector similarity over `playbook-embeddings` AI Search index (1.5s budget; ≥0.85 skips Stage 2)
+  - Stage 2: LLM refinement + parameter extraction (0.5s budget)
+- **Supports**: `PlaybookEmbeddingService`, `PlaybookIndexingService`, `PlaybookEmbeddingDocument`, scripts `Create-PlaybookEmbeddingsIndex.ps1`, `Index-ExistingPlaybooks.ps1`, `Seed-PlaybookTriggerMetadata.ps1`
+- **Used by**: `SprkChatAgentFactory` (factory-instantiated)
+- **Maturity**: HIGH — has full index, embedding pipeline, Redis cache, version key
+- **Origin**: `projects/ai-sprk-chat-platform-enhancement-r2/` (Complete 2026-03-17)
+
+### 2.3 `IntentClassificationService` (playbook-builder origin)
+
+- **Path**: `src/server/api/Sprk.Bff.Api/Services/Ai/IntentClassificationService.cs`
+- **Related**: `AiPlaybookBuilderService`, `BuilderAgentService`, `BuildPlanGenerationService`, `BuilderToolCall`, `PlaybookBuilderSystemPrompt`
+- **Origin**: Likely an earlier SprkChat AI assistant for playbook AUTHORING (not consumption)
+- **Maturity**: Unknown; needs investigation — may be deprecated path
+- **Used by**: Unknown; investigation needed
+
+### 2.4 `InsightsIntentClassifier` (Insights r2 Wave E2)
+
+- **Path**: `src/server/api/Sprk.Bff.Api/Services/Ai/Insights/Routing/InsightsIntentClassifier.cs`
+- **Architecture**: Single LLM call with hardcoded C# prompt (`BuildPrompt()` line ~230)
+- **Decides**: BOTH path (playbook vs RAG) AND which playbook in one call
+- **Used by**: `AssistantToolCallHandler` (post-Wave-E3)
+- **Maturity**: Wave E2 ship; code comment line ~226 admits hardcoded prompt is wrong long-term, defers to Phase 2
+- **Origin**: `projects/ai-spaarke-insights-engine-r2/` Wave E2
+
+### 2.5 Architectural insight
+
+These four systems serve DIFFERENT slices of similar problems:
+
+- `CapabilityRouter`: routes user message → which **CAPABILITY/PATH** (e.g., "use a playbook", "use RAG", "use a chat tool")
+- `PlaybookDispatcher`: once routed to "use a playbook", dispatches to **WHICH SPECIFIC PLAYBOOK**
+- `IntentClassificationService`: dedicated to playbook **AUTHORING-time** intent (separate from consumption)
+- `InsightsIntentClassifier`: combines capability routing + playbook dispatch into one LLM call for Insights consumers
+
+**Reconciliation question for audit**:
+- Should `InsightsIntentClassifier` be replaced by `CapabilityRouter.RouteAsync` (for path) + `PlaybookDispatcher` (for playbook selection)?
+- Is `IntentClassificationService` still active or deprecated?
+- Should the playbook-builder AI services be revived/extended/deprecated?
+
+---
+
+## 3. Lookup services (4 found — DRY VIOLATION, not duplication)
+
+Path: `src/server/api/Sprk.Bff.Api/Services/Ai/`
+
+| Service | Interface | Entity type |
+|---|---|---|
+| `PlaybookLookupService` | `IPlaybookLookupService` | Playbook |
+| `ActionLookupService` | `IActionLookupService` | Action |
+| `ToolLookupService` | `IToolLookupService` | Tool |
+| `SkillLookupService` | `ISkillLookupService` | Skill |
+
+**Observed identical structure** (verified via head -25 on all four):
+- Same XML docs (verbatim wording about cached lookup, alternate keys, multi-environment)
+- Same dependencies (`IGenericEntityService` + `IMemoryCache`)
+- Same TTL (1 hour)
+- Same SaaS multi-environment text
+- Same constructor signature
+
+**Refactoring opportunity**: replace with `CachedLookupService<TEntity>` generic — single implementation, type-parameterized. ~1-2 day refactor.
+
+**Origin**: likely shipped together with the playbook-builder project (they all serve playbook-building lookups).
+
+---
+
+## 4. Search services (4 found — DISTINCT but uncoordinated)
+
+| Service | Substrate / Index | Likely origin |
+|---|---|---|
+| `IRagService` / `RagService` / `NullRagService` | Multiple indexes (passes index name as parameter) | Generic RAG; shipped 2026-06-01 master refactor; used by Insights Wave E1 (`/api/insights/search`) |
+| `SemanticSearchService` | Generic AI Search hybrid | Likely playbook-builder: "find similar existing actions/playbooks to reuse" |
+| `RecordSearchService` | `spaarke-records-index` | Likely playbook-builder: "find Dataverse records to reference" |
+| `PlaybookEmbeddingService` | `playbook-embeddings` (→ `spaarke-playbook-index` per r3 Tier 1.5) | SprkChat r2 playbook discovery |
+
+**Not duplicates** — each has a distinct substrate for a distinct purpose. But the proliferation reflects accumulated investment without consolidation.
+
+**Audit question**: Are `SemanticSearchService` and `RecordSearchService` still used by current production paths, or are they vestiges of an abandoned playbook-builder project?
+
+---
+
+## 5. Cache patterns (~11+ services use `IMemoryCache` directly)
+
+Services that use `IMemoryCache` directly per grep:
+
+```
+NullInsightsIntentClassifier.cs
+InsightsIntentClassifier.cs
+InsightsActionRouter.cs
+ToolLookupService.cs
+SkillLookupService.cs
+Security/PrivilegeGroupResolver.cs
+IPrivilegeGroupResolver.cs
+PlaybookLookupService.cs
+Capabilities/CapabilityManifest.cs
+AiPlaybookBuilderService.cs
+ActionLookupService.cs
+```
+
+**Pattern observation**: each service rolls its own cache (custom TTL semantics, key derivation, eviction). TTLs vary:
+- Lookup services: 1 hour
+- `InsightsActionRouter`: 15-min sliding
+- `InsightsIntentClassifier`: 15-min sliding
+- `CapabilityManifest`: TBD (likely longer, manifest-bound)
+
+**Not necessarily duplication** — appropriate diversity. But could benefit from a shared `ICachedLookup<T>` abstraction that takes TTL as constructor parameter. Existing `EmbeddingCache` (Redis, shared per R5 coord doc §3.1) is the precedent for shared cache infrastructure.
+
+---
+
+## 6. Prompt builders (3+ found)
+
+| Builder | Purpose |
+|---|---|
+| `CapabilityClassificationPromptBuilder` | Builds prompts for `CapabilityRouter` Layer 2 |
+| `OrchestratorPromptBuilder` | Builds prompts for orchestration |
+| `InsightsIntentClassifier.BuildPrompt()` | Hardcoded C# string-builder; flagged for migration to JPS Action row |
+| `PlaybookBuilderSystemPrompt` | Builder system prompt (playbook-builder project) |
+| (likely others) | TBD |
+
+**Pattern**: each subsystem builds prompts its own way. Some hardcoded, some in classes, some as constants, some in Dataverse JPS rows.
+
+**Audit question**: Should there be an `IPromptBuilder<TContext>` pattern + a single source of truth for prompt content (likely Dataverse `sprk_analysisaction.sprk_systemprompt` rows per project's stated principle)?
+
+---
+
+## 7. Project origins inferred (5+ project accumulation pattern)
+
+Best-guess attribution of accumulated infrastructure to source projects:
+
+| Project | Likely BFF additions to audit |
+|---|---|
+| Earlier playbook-builder (SprkChat AI assistant for authoring) | `AiPlaybookBuilderService`, `IntentClassificationService`, `BuilderAgentService`, `BuildPlanGenerationService`, `BuilderToolCall`, `PlaybookBuilderSystemPrompt`, possibly `SemanticSearchService`, possibly the 4 lookup services |
+| Capability routing project (AIPU2-012/013/014) | `CapabilityRouter`, `CapabilityManifest`, `CapabilityManifestEntry`, `DataverseCapabilityManifestLoader`, `ManifestRefreshService`, `CapabilityValidator`, `CapabilityClassificationPromptBuilder`, `CapabilityRouterOptions`, `CapabilityRoutingResult` |
+| SprkChat r2 (March 2026; `ai-sprk-chat-platform-enhancement-r2`) | `PlaybookDispatcher`, `PlaybookEmbeddingService`, `PlaybookIndexingService`, `PlaybookEmbeddingDocument`, `PlaybookEmbeddingEndpoints`, `DynamicCommandResolver`, `playbook-embeddings` AI Search index, deploy scripts |
+| Insights r1 (predecessor; `ai-spaarke-insights-engine-r1`) | `InsightsOrchestrator`, `IInsightsAi` facade, ingest pipeline, Insights nodes |
+| Insights r2 (just shipped; `ai-spaarke-insights-engine-r2`) | `InsightsIntentClassifier`, `NullInsightsIntentClassifier`, `InsightsActionRouter`, `AssistantToolCallHandler`, `IInsightsAi.SearchAsync` + `AssistantQueryAsync` + `AssistantQueryStreamAsync`, RAG extension, citations href, SSE streaming, 3 `ILiveFactResolver` impls |
+| R5 (in flight; `spaarke-ai-platform-unification-r5`) | Builds on top; reuse mandate documented in `projects/spaarke-ai-platform-unification-r5/notes/insights-r2-coordination.md` §3.1 |
+
+**Pattern**: each project added what it needed. Nobody did holistic cleanup. R5 coord doc §3.1 documents the reuse mandate but ONLY for R5↔Insights — not cross-project for the BFF as a whole.
+
+---
+
+## 8. What the audit should produce
+
+Based on these findings, the audit's deliverables should be:
+
+### 8.1 Comprehensive inventory
+- Every AI service in `src/server/api/Sprk.Bff.Api/Services/Ai/`
+- Who uses each one (consumer mapping via grep)
+- Whether it's active in production / deprecated / unused
+- Originating project (best-guess)
+
+### 8.2 Canonical-architecture decisions per category
+For each category surfaced above (intent classification, lookup services, search services, cache patterns, prompt builders, possibly others discovered during audit):
+- Which existing service is canonical
+- Which should consume it
+- Which should be deprecated/deleted
+- Migration plan
+
+### 8.3 Migration plan
+Per service / category:
+- Code paths that need updating
+- Tests that need updating
+- Deploy / config implications (cross-environment)
+- R5 / SprkChat coordination required
+- Effort estimate
+
+### 8.4 r3 (and other downstream project) scope guidance
+What can r3 lock now vs. what must wait for audit findings:
+- r3 wave 1 (Tier 1 cleanup) — likely safe to proceed independent of audit (NullInsightsAi, test fixture hygiene, etc.)
+- r3 wave 2 (Tier 2.5 reconciliation) — BLOCKED by audit; cannot lock scope without canonical decision
+
+### 8.5 Process recommendation
+Should Spaarke institutionalize periodic AI architecture review (e.g., per-quarter) to prevent recurrence?
+
+---
+
+## 9. Scope estimates
+
+Audit project size (best estimate):
+- Inventory: ~3 days (systematic file-by-file with consumer mapping)
+- Canonical-architecture decisions: ~3 days (per-category analysis + owner review)
+- Migration plan: ~2 days (per-service work-item sizing)
+- Documentation + decision records: ~2 days
+- Total: **~2 weeks** for the audit project
+
+After audit completes:
+- r3 wave 1 proceeds independently (~5d locked)
+- r3 wave 2 scope set per audit findings (~1-3 weeks depending on decisions)
+- r4 absorbs any "deferred to next project" items
+
+---
+
+## 10. References
+
+### r3 design discussion artifacts (input to this finding)
+- `projects/ai-spaarke-insights-engine-r3/design.md` — r3 design with Tier 1.5 + Tier 2.5 locks
+- `projects/spaarke-ai-platform-unification-r5/notes/insights-r2-coordination.md` §8.12-§8.16 — R5 heads-up
+
+### Memory notes
+- `~/.claude/projects/.../memory/feedback-check-existing-infra-before-designing.md` — general lesson encoded
+
+### Key code paths to audit
+- `src/server/api/Sprk.Bff.Api/Services/Ai/` (entire AI service tree)
+- `src/server/api/Sprk.Bff.Api/Infrastructure/DI/` (DI registration patterns)
+- `src/server/api/Sprk.Bff.Api/Models/Ai/` (AI model proliferation)
+- `infrastructure/ai-search/` (AI Search index definitions)
+- `scripts/` (deploy/seed scripts)
+
+### Related shipped projects
+- `projects/ai-sprk-chat-platform-enhancement-r2/` (Complete 2026-03-17)
+- `projects/ai-spaarke-insights-engine-r1/` (Complete)
+- `projects/ai-spaarke-insights-engine-r2/` (Complete 2026-06-04)
+- `projects/spaarke-ai-platform-unification-r5/` (in flight)
+
+---
+
+*Initial findings captured 2026-06-04 by Claude (main session) at owner's direction to preserve context for the dedicated audit project. Owner: Ralph Schroeder. Next action: audit project authors design.md based on these findings.*

--- a/projects/bff-ai-architecture-audit-r1/tasks/TASK-INDEX.md
+++ b/projects/bff-ai-architecture-audit-r1/tasks/TASK-INDEX.md
@@ -1,0 +1,31 @@
+# Task Index — BFF AI Architecture Audit r1
+
+> **Status**: 🆕 PLACEHOLDER — task POMLs not yet authored
+> **Created**: 2026-06-04
+> **Source**: derives from [`design.md`](../design.md) once methodology + scope lock
+
+---
+
+## Status legend
+
+🔲 not-started · 🔄 in-progress · ✅ complete · 🚧 blocked · ⏭️ deferred
+
+---
+
+## Tasks
+
+> No tasks yet. Awaiting [`design.md`](../design.md) methodology + scope lock from owner, then derivation of phase-by-phase task POMLs.
+
+Likely task structure (per design.md §3.1):
+
+| Phase | Likely tasks |
+|---|---|
+| Inventory | Systematic file enumeration; consumer mapping; state classification |
+| Per-category analysis | One task per category (intent classifiers, lookup services, search services, cache, prompt builders, ...) |
+| Owner review | Iterative; per category as findings form |
+| Migration planning | Per-service work-item sizing |
+| Documentation | Final reports + decision records |
+
+---
+
+*Placeholder 2026-06-04. Populated when task POMLs are authored from design.md.*


### PR DESCRIPTION
New dedicated audit project. Triggered by Insights r3 design surfacing 4 parallel intent classifiers + 4 lookup-service DRY violation + 5+ project accumulation. Owner chose Option C. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)