### PR TITLE
fix(r5): initialize KnowledgeDocument.Tags to empty array — fixes Azure Search 400 on session-files index

### DIFF
--- a/src/server/api/Sprk.Bff.Api/Services/Ai/RagIndexingPipeline.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/RagIndexingPipeline.cs
@@ -455,6 +455,13 @@ public sealed partial class RagIndexingPipeline
                 ChunkIndex = chunk.Index,
                 ChunkCount = chunks.Count,
                 ContentVector = i < embeddings.Count ? embeddings[i] : ReadOnlyMemory<float>.Empty,
+                // Initialize collection fields to empty (NOT null). Azure Search rejects
+                // null values for Collection(Edm.String) fields with default Nullable=False
+                // semantics — observed as a 400 on the spaarke-session-files index upload
+                // during R5 SC-18 walkthrough 2026-06-05. Existing customer-corpus indexes
+                // (knowledge/discovery) accept empty lists fine; this keeps the same
+                // behavior across all three target indexes.
+                Tags = Array.Empty<string>(),
                 CreatedAt = now,
                 UpdatedAt = now
             });


### PR DESCRIPTION
## Summary

One-line bug fix surfaced during live SC-18 walkthrough on Spaarke Dev (2026-06-05). R5 task 032 wired the upload endpoint into `RagIndexingPipeline.IndexSessionFileAsync` — but every chat-session file upload triggered an Azure Search 400 in the indexing call. The error was caught by task 032's defensive wrapper (so HTTP 202 still returned), but `ChatSession.UploadedFiles` never got populated → orchestrator declined → agent responded *"I don't see the document uploaded yet"*.

## Bug

`BuildKnowledgeDocuments` constructed `KnowledgeDocument` instances WITHOUT initializing `IList<string>? Tags`. Serialized as `"tags": null`. Azure Search rejected:

```
A null value was found for the property named 'tags', which has the expected type
'Collection(Edm.String)[Nullable=False]'. The expected type
'Collection(Edm.String)[Nullable=False]' does not allow null values.
Status: 400 (Bad Request)
```

The `spaarke-session-files` index schema declares `tags` as `Collection(Edm.String)`; Azure Search treats Collection types as `Nullable=False` by default.

## Fix

```diff
docs.Add(new KnowledgeDocument
{
    ...
    ContentVector = i < embeddings.Count ? embeddings[i] : ReadOnlyMemory<float>.Empty,
+   Tags = Array.Empty<string>(),
    CreatedAt = now,
    UpdatedAt = now
});
```

One line in `RagIndexingPipeline.BuildKnowledgeDocuments`. Plus an inline comment so nobody removes it.

## Why this wasn't caught earlier

Unit tests mock `SearchClient` and never serialize the document over the wire. The schema check is server-side at index-upload time. Only the live SC-18 walkthrough surfaced it (which is exactly what SC-18 walkthroughs are designed to do).

## Why this only breaks session-files

The customer-corpus knowledge + discovery indexes appear to be more lenient with null collection fields (or their JSON serializer omits null entries before sending). The R5 session-files index is stricter. Producer-side fix works across all three target indexes regardless.

## Test plan

- [x] `dotnet build -c Release src/server/api/Sprk.Bff.Api/` → 0 errors
- [ ] CI gates pass
- [ ] Merge to master
- [ ] Deploy to Dev via `.\scripts\Deploy-BffApi.ps1`
- [ ] Live test: upload a file in SpaarkeAi → log should show *"Session-files indexing complete for documentId=..."* instead of the failure
- [ ] Chat agent's response to *"summarize"* should now invoke the Summarize tool (no more *"I don't see the document"*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)