### PR TITLE
fix(r5): suppress 7 customer-corpus-only fields from session-files writes + regression test

### DIFF
--- a/src/server/api/Sprk.Bff.Api/Models/Ai/KnowledgeDocument.cs
+++ b/src/server/api/Sprk.Bff.Api/Models/Ai/KnowledgeDocument.cs
@@ -49,22 +49,32 @@ public class KnowledgeDocument
     /// <summary>
     /// Deployment identifier (sprk_aiknowledgedeployment record ID).
     /// </summary>
+    /// <remarks>
+    /// Suppressed from JSON when null so writes to the <c>spaarke-session-files</c> index
+    /// (which does not declare this field) do not trigger 400 "property does not exist".
+    /// Customer-corpus writers that need this field set it explicitly.
+    /// </remarks>
     [SimpleField(IsFilterable = true, IsFacetable = true)]
     [JsonPropertyName("deploymentId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? DeploymentId { get; set; }
 
     /// <summary>
-    /// Deployment model type: Shared, Dedicated, or CustomerOwned.
+    /// Deployment model type: Shared, Dedicated, or CustomerOwned. Default "Shared" preserves
+    /// existing customer-corpus behavior; session-files writers null this out explicitly to
+    /// suppress serialization per the same pattern as <see cref="SessionId"/>.
     /// </summary>
     [SimpleField(IsFilterable = true, IsFacetable = true)]
     [JsonPropertyName("deploymentModel")]
-    public string DeploymentModel { get; set; } = "Shared";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DeploymentModel { get; set; } = "Shared";
 
     /// <summary>
     /// Source knowledge record ID (sprk_analysisknowledge).
     /// </summary>
     [SimpleField(IsFilterable = true, IsFacetable = true)]
     [JsonPropertyName("knowledgeSourceId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? KnowledgeSourceId { get; set; }
 
     /// <summary>
@@ -72,6 +82,7 @@ public class KnowledgeDocument
     /// </summary>
     [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.StandardLucene, IsSortable = true)]
     [JsonPropertyName("knowledgeSourceName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? KnowledgeSourceName { get; set; }
 
     /// <summary>
@@ -146,8 +157,15 @@ public class KnowledgeDocument
     /// Document-level vector embedding (3072 dimensions for text-embedding-3-large).
     /// Used for document similarity visualization.
     /// </summary>
+    /// <remarks>
+    /// Suppressed from JSON when default (empty <see cref="ReadOnlyMemory{T}"/>) — session-files
+    /// writers leave this default and the index would reject an empty 0-dimensional vector
+    /// against its declared 3072-dimension profile. Customer-corpus writers that populate it
+    /// are unaffected.
+    /// </remarks>
     [VectorSearchField(VectorSearchDimensions = 3072, VectorSearchProfileName = "knowledge-vector-profile-3072")]
     [JsonPropertyName("documentVector3072")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public ReadOnlyMemory<float> DocumentVector { get; set; }
 
     /// <summary>
@@ -184,10 +202,12 @@ public class KnowledgeDocument
     /// </summary>
     /// <remarks>
     /// Used for entity-scoped semantic search. Nullable to support documents
-    /// indexed before parent entity tracking was implemented.
+    /// indexed before parent entity tracking was implemented. Suppressed from JSON when null
+    /// (session-files index lacks this field).
     /// </remarks>
     [SimpleField(IsFilterable = true, IsFacetable = true)]
     [JsonPropertyName("parentEntityType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ParentEntityType { get; set; }
 
     /// <summary>
@@ -195,10 +215,12 @@ public class KnowledgeDocument
     /// </summary>
     /// <remarks>
     /// Combined with ParentEntityType for entity-scoped filtering.
-    /// Nullable to support legacy documents without entity association.
+    /// Nullable to support legacy documents without entity association. Suppressed from JSON
+    /// when null (session-files index lacks this field).
     /// </remarks>
     [SimpleField(IsFilterable = true)]
     [JsonPropertyName("parentEntityId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ParentEntityId { get; set; }
 
     /// <summary>
@@ -206,10 +228,12 @@ public class KnowledgeDocument
     /// </summary>
     /// <remarks>
     /// Searchable field to allow finding documents by entity name.
-    /// Nullable to support legacy documents without entity association.
+    /// Nullable to support legacy documents without entity association. Suppressed from JSON
+    /// when null (session-files index lacks this field).
     /// </remarks>
     [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.StandardLucene, IsSortable = true)]
     [JsonPropertyName("parentEntityname")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ParentEntityName { get; set; }
 
     /// <summary>
@@ -217,11 +241,15 @@ public class KnowledgeDocument
     /// Empty collection means the document is public (no privilege restriction).
     /// Filterable string collection — used by privilege-aware retrieval (AIPU2-027).
     /// </summary>
+    /// <remarks>
+    /// Default empty list preserves customer-corpus behavior (Collection(Edm.String) is
+    /// implicitly Nullable=False — rejects null writes with 400). Session-files writers
+    /// explicitly null this out so JsonIgnore.WhenWritingNull suppresses it — the
+    /// session-files index does not declare this field.
+    /// </remarks>
     [SimpleField(IsFilterable = true)]
     [JsonPropertyName("privilege_group_ids")]
-    // Default to empty list — Azure Search Collection(Edm.String) is implicitly Nullable=False
-    // and rejects null writes (400 Bad Request). Empty list correctly signals "public document"
-    // to the privilege filter (matches "not privilege_group_ids/any()" clause).
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IList<string>? PrivilegeGroupIds { get; set; } = new List<string>();
 }
 

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/RagIndexingPipeline.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/RagIndexingPipeline.cs
@@ -437,11 +437,12 @@ public sealed partial class RagIndexingPipeline
     {
         var now = DateTimeOffset.UtcNow;
         var docs = new List<KnowledgeDocument>(chunks.Count);
+        var isSessionFilesWrite = !string.IsNullOrEmpty(sessionId);
 
         for (int i = 0; i < chunks.Count; i++)
         {
             var chunk = chunks[i];
-            docs.Add(new KnowledgeDocument
+            var doc = new KnowledgeDocument
             {
                 // Format: {documentId}_{suffix}_{chunkIndex} — unique per index type
                 // ("k" knowledge, "d" discovery, "s" session-files per R5 task 003).
@@ -455,16 +456,26 @@ public sealed partial class RagIndexingPipeline
                 ChunkIndex = chunk.Index,
                 ChunkCount = chunks.Count,
                 ContentVector = i < embeddings.Count ? embeddings[i] : ReadOnlyMemory<float>.Empty,
-                // Initialize collection fields to empty (NOT null). Azure Search rejects
-                // null values for Collection(Edm.String) fields with default Nullable=False
-                // semantics — observed as a 400 on the spaarke-session-files index upload
-                // during R5 SC-18 walkthrough 2026-06-05. Existing customer-corpus indexes
-                // (knowledge/discovery) accept empty lists fine; this keeps the same
-                // behavior across all three target indexes.
+                // Tags: must be a non-null empty array, not null. Azure Search rejects null
+                // values for Collection(Edm.String) fields (Nullable=False semantics).
                 Tags = Array.Empty<string>(),
                 CreatedAt = now,
                 UpdatedAt = now
-            });
+            };
+
+            if (isSessionFilesWrite)
+            {
+                // Session-files index schema (infrastructure/ai-search/spaarke-session-files.json)
+                // does NOT declare deploymentModel or privilege_group_ids. Both have non-null
+                // model defaults ("Shared" / empty list) intended for customer-corpus writes,
+                // so we explicitly null them so JsonIgnore.WhenWritingNull suppresses them on
+                // the wire. Without this, Azure Search rejects with 400 "property does not
+                // exist on type 'search.documentFields'" — observed cycle 4 of R5 SC-18 walkthrough.
+                doc.DeploymentModel = null;
+                doc.PrivilegeGroupIds = null;
+            }
+
+            docs.Add(doc);
         }
 
         return docs;

--- a/tests/unit/Sprk.Bff.Api.Tests/Models/Ai/KnowledgeDocumentSerializationTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Models/Ai/KnowledgeDocumentSerializationTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using FluentAssertions;
+using Sprk.Bff.Api.Models.Ai;
+using Xunit;
+
+namespace Sprk.Bff.Api.Tests.Models.Ai;
+
+/// <summary>
+/// Wire-format regression tests for <see cref="KnowledgeDocument"/>.
+///
+/// The same model class is serialized into multiple Azure Search indexes whose schemas differ.
+/// Azure Search rejects documents with unknown properties (400 "property does not exist on
+/// type 'search.documentFields'"). When a property is null/default and the target schema
+/// does not declare it, the model must omit the property from the serialized payload — which
+/// is what <c>[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]</c> and
+/// <c>WhenWritingDefault</c> achieve.
+///
+/// These tests lock that contract so a future field added to the model without the suppression
+/// attribute trips here, not in production at the next SC-18 walkthrough.
+///
+/// History: R5 SC-18 walkthrough surfaced four cycles of these bugs (Tags=null, then
+/// deploymentId/deploymentModel/knowledgeSourceId/parentEntity*/privilege_group_ids as
+/// successive 400 "property does not exist" rejections). PR #360 (2026-06-05) applied
+/// JsonIgnore.WhenWritingNull / WhenWritingDefault uniformly + added this test.
+/// </summary>
+public class KnowledgeDocumentSerializationTests
+{
+    /// <summary>
+    /// Canonical field set for the <c>spaarke-session-files</c> index, kept in sync with
+    /// <c>infrastructure/ai-search/spaarke-session-files.json</c>. Test failure when adding a
+    /// field to the schema is intentional — update this set + the model in lockstep.
+    /// </summary>
+    private static readonly HashSet<string> SessionFilesIndexFields = new(StringComparer.Ordinal)
+    {
+        "id",
+        "tenantId",
+        "sessionId",
+        "documentId",
+        "speFileId",
+        "documentName",
+        "fileName",
+        "documentType",
+        "fileType",
+        "chunkIndex",
+        "chunkCount",
+        "content",
+        "contentVector3072",
+        "documentVector3072",
+        "metadata",
+        "tags",
+        "createdAt",
+        "updatedAt"
+    };
+
+    [Fact]
+    public void SessionFilesMode_SerializedKeys_AreSubsetOfSessionFilesSchema()
+    {
+        // Arrange — build a doc the same way RagIndexingPipeline.BuildKnowledgeDocuments does
+        // for a session-files write (sessionId != null path).
+        var doc = new KnowledgeDocument
+        {
+            Id = "doc1_s_0",
+            TenantId = "tenant-a",
+            SessionId = "session-1",
+            DocumentId = "doc1",
+            SpeFileId = "spe-1",
+            FileName = "engagement-letter.docx",
+            Content = "chunk body",
+            ChunkIndex = 0,
+            ChunkCount = 1,
+            ContentVector = new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f, 0.3f }),
+            Tags = Array.Empty<string>(),
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            DeploymentModel = null,
+            PrivilegeGroupIds = null
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(doc);
+        using var parsed = JsonDocument.Parse(json);
+        var actualKeys = parsed.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet();
+
+        // Assert — every key in the payload must exist in the session-files schema.
+        var unknownKeys = actualKeys.Except(SessionFilesIndexFields).ToList();
+        unknownKeys.Should().BeEmpty(
+            "every JSON key written to spaarke-session-files must exist in the index schema; " +
+            "found {0} unknown key(s): [{1}]. " +
+            "Either add the field to infrastructure/ai-search/spaarke-session-files.json " +
+            "(and SessionFilesIndexFields here), or add " +
+            "[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] (or WhenWritingDefault) " +
+            "to the property on KnowledgeDocument.",
+            unknownKeys.Count,
+            string.Join(", ", unknownKeys));
+    }
+
+    [Fact]
+    public void SessionFilesMode_SerializedKeys_ExcludeCustomerCorpusOnlyFields()
+    {
+        // Arrange — same configuration as RagIndexingPipeline session-files write.
+        var doc = new KnowledgeDocument
+        {
+            Id = "doc1_s_0",
+            TenantId = "tenant-a",
+            SessionId = "session-1",
+            DocumentId = "doc1",
+            SpeFileId = "spe-1",
+            FileName = "engagement-letter.docx",
+            Content = "chunk body",
+            ChunkIndex = 0,
+            ChunkCount = 1,
+            ContentVector = new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f, 0.3f }),
+            Tags = Array.Empty<string>(),
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            DeploymentModel = null,
+            PrivilegeGroupIds = null
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(doc);
+
+        // Assert — explicitly enumerate the customer-corpus-only fields that have caused
+        // 400 rejections historically. These MUST NOT appear in a session-files payload.
+        var customerCorpusOnlyFields = new[]
+        {
+            "deploymentId",
+            "deploymentModel",
+            "knowledgeSourceId",
+            "knowledgeSourceName",
+            "parentEntityType",
+            "parentEntityId",
+            "parentEntityname",
+            "privilege_group_ids",
+            "documentVector3072"
+        };
+
+        foreach (var field in customerCorpusOnlyFields)
+        {
+            json.Should().NotContain($"\"{field}\"",
+                "customer-corpus-only field '{0}' must be suppressed when writing to session-files",
+                field);
+        }
+    }
+
+    [Fact]
+    public void CustomerCorpusMode_SerializedKeys_RetainDefaults()
+    {
+        // Arrange — a customer-corpus write does NOT override DeploymentModel or
+        // PrivilegeGroupIds; they keep their model defaults ("Shared" and empty list).
+        var doc = new KnowledgeDocument
+        {
+            Id = "doc1_k_0",
+            TenantId = "tenant-a",
+            DocumentId = "doc1",
+            SpeFileId = "spe-1",
+            FileName = "policy.pdf",
+            Content = "chunk body",
+            ChunkIndex = 0,
+            ChunkCount = 1,
+            ContentVector = new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f }),
+            Tags = Array.Empty<string>(),
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+            // DeploymentModel left at "Shared", PrivilegeGroupIds left at empty list,
+            // SessionId left null (suppressed).
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(doc);
+
+        // Assert — customer-corpus defaults are still on the wire (no regression).
+        json.Should().Contain("\"deploymentModel\":\"Shared\"");
+        json.Should().Contain("\"privilege_group_ids\":[]");
+        // SessionId remains suppressed when null (existing canonical pattern).
+        json.Should().NotContain("\"sessionId\"");
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the cycle-by-cycle SC-18 walkthrough loop. Cycles 3 + 4 surfaced two of 8 fields rejected by Azure Search on session-files writes (`tags=null`, then `deploymentId` property-does-not-exist). Without this PR, cycles 5/6/7 would surface `deploymentModel`, `knowledgeSourceId`, `parentEntity*`, `privilege_group_ids` in sequence.
- Applies `JsonIgnore.WhenWritingNull` / `WhenWritingDefault` uniformly to all 8 customer-corpus-only fields on `KnowledgeDocument`, matching the canonical pattern already used for `SessionId`.
- Adds `KnowledgeDocumentSerializationTests` — a wire-format regression test that asserts session-files JSON payloads only contain keys present in `infrastructure/ai-search/spaarke-session-files.json`. Locks the contract so a future field added to either model or schema can't silently reintroduce this class of bug.

## Why this happened

`KnowledgeDocument` is ONE C# class used as the payload type for FOUR Azure Search indexes:
- `spaarke-knowledge-index-v2` (customer corpus, ~26 fields)
- `spaarke-discovery-index` (customer corpus)
- `spaarke-references-index` (customer corpus)
- `spaarke-session-files` (R5, 18 fields — strict subset)

R5 task 022 reused the existing model for the new session-files index but applied `JsonIgnore.WhenWritingNull` to only one field (`SessionId`), not the seven other customer-corpus-only fields that have the same asymmetry. Each unknown field triggers `Azure.RequestFailedException: ... property 'X' does not exist on type 'search.documentFields'`, and `RagIndexingPipeline.UploadSessionFileDocumentsAsync` swallows the exception — so uploads silently fail to populate `ChatSession.UploadedFiles` and the agent reports "I don't see the document".

## Changes

**`src/server/api/Sprk.Bff.Api/Models/Ai/KnowledgeDocument.cs`** — 8 attribute additions:
| Field | Attribute |
|---|---|
| `DeploymentId` | `[JsonIgnore(WhenWritingNull)]` |
| `DeploymentModel` (now `string?`, default `"Shared"` retained) | `[JsonIgnore(WhenWritingNull)]` |
| `KnowledgeSourceId` | `[JsonIgnore(WhenWritingNull)]` |
| `KnowledgeSourceName` | `[JsonIgnore(WhenWritingNull)]` |
| `ParentEntityType` | `[JsonIgnore(WhenWritingNull)]` |
| `ParentEntityId` | `[JsonIgnore(WhenWritingNull)]` |
| `ParentEntityName` | `[JsonIgnore(WhenWritingNull)]` |
| `PrivilegeGroupIds` (empty-list default retained) | `[JsonIgnore(WhenWritingNull)]` |
| `DocumentVector` (value type) | `[JsonIgnore(WhenWritingDefault)]` |

**`src/server/api/Sprk.Bff.Api/Services/Ai/RagIndexingPipeline.cs`** — `BuildKnowledgeDocuments`: when `sessionId != null` (session-files write), explicitly null `DeploymentModel` and `PrivilegeGroupIds` so `JsonIgnore.WhenWritingNull` suppresses them. Customer-corpus writes (`sessionId == null`) keep the existing defaults — no behavior change.

**`tests/unit/Sprk.Bff.Api.Tests/Models/Ai/KnowledgeDocumentSerializationTests.cs`** — 3 new tests:
1. JSON keys from session-files-mode doc are a strict subset of `spaarke-session-files.json`'s 18 fields
2. None of the 9 customer-corpus-only keys appear in session-files payload
3. Customer-corpus mode still emits `"deploymentModel":"Shared"` and `"privilege_group_ids":[]` (no regression)

## Test plan

- [x] `dotnet build src/server/api/Sprk.Bff.Api/ -c Release` — 0 errors, 16 pre-existing warnings
- [x] `dotnet test ... --filter KnowledgeDocumentSerialization` — 3/3 pass
- [x] `dotnet test ... --filter RagIndexingPipeline` — all 15 existing tests pass (no regression)
- [ ] Deploy to Spaarke Dev via `Deploy-BffApi.ps1`; verify hash MATCH + healthz 200
- [ ] Operator SC-18 walkthrough: upload doc + `/summarize` → expect agent sees file + BFF log shows "Session-files indexing complete for documentId=… sessionId=…"

## BFF publish-size delta

Pure model + behavior change; no new dependencies. Expected delta: 0 MB. (Previous baseline ~45.5 MB.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)