### PR TITLE
feat(r5/closeout): SC-18 cycle 6-9 architectural fixes

### DIFF
--- a/src/client/shared/Spaarke.UI.Components/src/components/SprkChat/SprkChat.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/SprkChat/SprkChat.tsx
@@ -1114,12 +1114,16 @@ export const SprkChat: React.FC<ISprkChatProps> = ({
       if (!list || list.length === 0) {
         return;
       }
+      // Snapshot to File[] BEFORE clearing — `input.files` is a live FileList
+      // and `input.value = ''` empties it. Without this, `addAttachmentFiles`
+      // receives a zero-length list.
+      const fileSnapshot: File[] = Array.from(list);
       // Reset input so re-picking the same file works.
       e.target.value = '';
       // Fire-and-forget; the hook updates `files` optimistically and patches
       // status as extraction resolves. We intentionally do not await here so
       // the UI thread stays responsive.
-      void addAttachmentFiles(list);
+      void addAttachmentFiles(fileSnapshot);
     },
     [addAttachmentFiles]
   );

--- a/src/client/shared/Spaarke.UI.Components/src/components/SprkChat/hooks/useChatFileAttachment.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/SprkChat/hooks/useChatFileAttachment.ts
@@ -334,12 +334,28 @@ export function useChatFileAttachment(options: UseChatFileAttachmentOptions = {}
       // chunk for `pdfjs-dist`, which is what task 061 / the bundle audit
       // verifies.
       pdfJsRef.current = import('pdfjs-dist').then(mod => {
-        // pdfjs-dist exports a `GlobalWorkerOptions` object in modern
-        // versions; if absent the worker is best-effort and may fall back to
-        // a same-thread mode in test environments. We leave the workerSrc
-        // unset here — consumers that need real worker isolation should set
-        // it during their bootstrap rather than coupling the hook to a
-        // particular bundler.
+        // pdfjs-dist v4+ REQUIRES `GlobalWorkerOptions.workerSrc` to be set
+        // or `getDocument` throws "No GlobalWorkerOptions.workerSrc specified".
+        // The previous "leave unset, let consumers configure" approach worked
+        // up to v3 but breaks v4/v5 (observed in R5 SC-18 walkthrough cycle 6,
+        // 2026-06-05 — pdfjs-dist 5.7.x installed via npm).
+        //
+        // Default behavior: if a consumer-supplied workerSrc isn't already
+        // populated (consumers CAN set it before this code runs by importing
+        // pdfjs-dist eagerly and writing GlobalWorkerOptions), point at a
+        // versioned jsdelivr CDN URL matching the installed major.minor.
+        // This works in browser contexts allowing external CDN (most Power
+        // Apps environments allow jsdelivr per default CSP). Consumers in
+        // CSP-restricted contexts should pre-set workerSrc to a same-origin
+        // bundled worker URL.
+        const modAny = mod as unknown as {
+          GlobalWorkerOptions?: { workerSrc?: string };
+          version?: string;
+        };
+        if (modAny.GlobalWorkerOptions && !modAny.GlobalWorkerOptions.workerSrc) {
+          const version = modAny.version ?? '5.7.76';
+          modAny.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${version}/build/pdf.worker.min.mjs`;
+        }
         return mod as unknown as PdfJsModule;
       });
     }

--- a/src/solutions/SpaarkeAi/jest.config.ts
+++ b/src/solutions/SpaarkeAi/jest.config.ts
@@ -21,6 +21,20 @@ const config: Config = {
     '^@spaarke/auth$': '<rootDir>/../../client/shared/Spaarke.AI.Widgets/src/__mocks__/@spaarke/auth.ts',
     '^@spaarke/ai-context$': '<rootDir>/../../client/shared/Spaarke.AI.Context/src/index.ts',
     '^@spaarke/ai-outputs$': '<rootDir>/../../client/shared/Spaarke.AI.Outputs/src/index.ts',
+    // d3-force ships pure ESM — ts-jest's CommonJS transform can't consume it.
+    // Map to a tiny CJS stub so transitive imports of useForceSimulation don't
+    // crash jsdom tests. (R5 task 038.) The stub returns the chainable
+    // simulation surface the hook expects.
+    '^d3-force$': '<rootDir>/src/__mocks__/d3-force.ts',
+    // Dedupe React — the workspace-linked shared libraries each have their own
+    // node_modules/react copy. Without forcing a single instance, hooks fail
+    // with "Cannot read properties of null (reading 'useRef')" because the
+    // dispatcher pointer lives in the test-runner's React, but a sub-component
+    // imports a SECOND React instance from a nested node_modules. (R5 task 038.)
+    '^react$': '<rootDir>/node_modules/react',
+    '^react/(.*)$': '<rootDir>/node_modules/react/$1',
+    '^react-dom$': '<rootDir>/node_modules/react-dom',
+    '^react-dom/(.*)$': '<rootDir>/node_modules/react-dom/$1',
     // CSS modules
     '\\.css$': 'identity-obj-proxy',
   },

--- a/src/solutions/SpaarkeAi/src/__mocks__/d3-force.ts
+++ b/src/solutions/SpaarkeAi/src/__mocks__/d3-force.ts
@@ -1,0 +1,63 @@
+/**
+ * d3-force test stub — installed via jest.config.ts moduleNameMapper.
+ *
+ * d3-force ships pure ESM and ts-jest's CommonJS transform can't consume it,
+ * so any transitive import (notably @spaarke/ui-components/hooks/useForceSimulation)
+ * crashes jsdom test runs with `Unexpected token 'export'`. This module replaces
+ * the real d3-force at the resolver level so the SpaarkeAi test suite can run
+ * any component that transitively imports the @spaarke/ui-components barrel.
+ *
+ * The stub returns chainable-API shims for the d3-force functions used by
+ * useForceSimulation; tests that DEPEND on real force-graph behaviour (none in
+ * R5) should mock these per-test instead.
+ *
+ * Added in R5 task 038 (closeout-07).
+ */
+
+type Chainable = (...args: unknown[]) => Chainable;
+const chainable: Chainable = function chainable(): Chainable {
+  return chainable;
+};
+
+const simulationStub = {
+  nodes: chainable,
+  force: chainable,
+  on: chainable,
+  stop: chainable,
+  alpha: chainable,
+  alphaTarget: chainable,
+  alphaDecay: chainable,
+  velocityDecay: chainable,
+  tick: () => {},
+  restart: () => simulationStub,
+};
+
+export const forceSimulation = (): typeof simulationStub => simulationStub;
+export const forceLink = (): { id: Chainable; distance: Chainable; strength: Chainable } => ({
+  id: chainable,
+  distance: chainable,
+  strength: chainable,
+});
+export const forceManyBody = (): { strength: Chainable } => ({ strength: chainable });
+export const forceCenter = (): unknown => chainable;
+export const forceCollide = (): { radius: Chainable; strength: Chainable } => ({
+  radius: chainable,
+  strength: chainable,
+});
+export const forceX = (): { strength: Chainable; x: Chainable } => ({ strength: chainable, x: chainable });
+export const forceY = (): { strength: Chainable; y: Chainable } => ({ strength: chainable, y: chainable });
+export const forceRadial = (): { strength: Chainable; radius: Chainable } => ({
+  strength: chainable,
+  radius: chainable,
+});
+
+export default {
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+  forceCollide,
+  forceX,
+  forceY,
+  forceRadial,
+};

--- a/src/solutions/SpaarkeAi/src/components/conversation/ConversationPane.tsx
+++ b/src/solutions/SpaarkeAi/src/components/conversation/ConversationPane.tsx
@@ -85,14 +85,9 @@ import { PaneHeader, SprkChat } from "@spaarke/ui-components";
 import type { AttachmentChip, ChatAttachment, IChatMessage } from "@spaarke/ui-components";
 import { useAiSession, usePaneEvent, useDispatchPaneEvent } from "@spaarke/ai-widgets";
 import type { WorkspacePaneEvent, ContextPaneEvent } from "@spaarke/ai-widgets";
-// R4 task 042 (W-4): symbolic widget type ID + payload shape for the
-// Assistant-pane PDF-upload → DocumentViewer demo. We import the constant
-// (NOT the literal "document-viewer") so a rename in the registration file
-// surfaces at compile time.
-import {
-  DOCUMENT_VIEWER_WIDGET_TYPE,
-  type DocumentViewerWidgetData,
-} from "@spaarke/ai-widgets";
+// R4 task 042 (W-4): the DocumentViewerWidget dispatch from this file was
+// disabled in R5 SC-18 cycle 6 (see handleAttachmentReady). Import will be
+// reinstated when R5 task 022 upgrades the widget.
 import type { IChatSession } from "@spaarke/ai-context";
 import { WelcomePanel } from "../WelcomePanel";
 import {
@@ -1129,6 +1124,14 @@ export function ConversationPane(): React.JSX.Element {
                 authenticatedFetch,
                 getAccessToken,
                 publishPaneEvent: dispatch,
+                // R5 task 038: pass the chat sessionId as the streamId so
+                // every `workspace.streaming_*` event carries `streamId ===
+                // chatSessionId`. The Summary tab in WorkspacePane registers
+                // `correlationId = chatSessionId` on the
+                // StructuredOutputStreamWidget and gates auto-focus on the
+                // same id, so this propagation is required for session
+                // isolation (FR-06 acceptance).
+                streamId: chatSessionId,
               });
               // Flip Held → Indexed badges on the promoted chip ids.
               setPromotedChipIds(prev => {
@@ -1342,20 +1345,32 @@ export function ConversationPane(): React.JSX.Element {
    */
   const handleAttachmentReady = React.useCallback(
     (attachment: ChatAttachment) => {
-      const widgetData: DocumentViewerWidgetData = {
-        filename: attachment.filename,
-        contentType: attachment.contentType,
-        textContent: attachment.textContent,
-      };
-      dispatch("workspace", {
-        type: "widget_load",
-        widgetType: DOCUMENT_VIEWER_WIDGET_TYPE,
-        widgetData,
-        // Use the filename as the tab label — operator-visible behaviour per
-        // OC-R4-07. WorkspacePane.tsx prefers event.displayName over the
-        // registry metadata's generic "Document Viewer" label.
-        displayName: attachment.filename,
-      });
+      // R5 SC-18 cycle-6 (2026-06-05): the DocumentViewerWidget shows
+      // "Preview not available" for chat-uploaded files because no SharePoint
+      // Embedded preview URL exists (the file is held client-side until the
+      // user triggers an intent like /summarize that promotes it). The empty
+      // preview tab is misleading — operator feedback: "preview but seems too
+      // fast for an actual preview to be generated, says 'Preview not
+      // available'". Suppressing the dispatch until R5 task 022 upgrades the
+      // widget to render text content as a fallback OR a real previewUrl
+      // pipeline is wired for client-staged files. Until then, the chip strip
+      // above the input bar is the visible confirmation that the file was
+      // received; the structured Summarize output will appear in the
+      // Workspace-pane Summary tab (task 038) when /summarize fires.
+      //
+      // Original dispatch (kept commented for reversibility — uncomment when
+      // task 022 ships):
+      //   const widgetData: DocumentViewerWidgetData = {
+      //     filename: attachment.filename,
+      //     contentType: attachment.contentType,
+      //     textContent: attachment.textContent,
+      //   };
+      //   dispatch("workspace", {
+      //     type: "widget_load",
+      //     widgetType: DOCUMENT_VIEWER_WIDGET_TYPE,
+      //     widgetData,
+      //     displayName: attachment.filename,
+      //   });
 
       // R5 task 036: capture the File so the promote-and-execute
       // orchestrator (`executeSummarizeIntent`) can POST multipart binary

--- a/src/solutions/SpaarkeAi/src/components/conversation/sseToPaneEventBridge.ts
+++ b/src/solutions/SpaarkeAi/src/components/conversation/sseToPaneEventBridge.ts
@@ -184,10 +184,20 @@ export function createSseToPaneEventBridge(streamId: string): SseToPaneEventBrid
           return [];
         }
 
+        // BFF's IncrementalJsonParser emits JSONPath-style keys ($.tldr,
+        // $.summary, $.keywords, $.entities) but the StructuredOutputStreamWidget's
+        // SUMMARIZE_SCHEMA declares bare top-level keys (tldr, summary, keywords,
+        // entities) — see Spaarke.AI.Widgets workspace/StructuredOutputStreamWidget.tsx
+        // SUMMARIZE_SCHEMA export. Without this normalization the widget can't
+        // map deltas to schema fields and sections render empty even though
+        // events ARE arriving. Observed in R5 SC-18 cycle 9 / 2026-06-05.
+        const normalizedPath = delta.path.startsWith('$.')
+          ? delta.path.slice(2)
+          : delta.path;
         mapped = {
           type: 'field_delta',
           streamId,
-          fieldPath: delta.path,
+          fieldPath: normalizedPath,
           fieldContent: delta.content,
           sequence: delta.sequence,
         };

--- a/src/solutions/SpaarkeAi/src/components/workspace/WorkspacePane.tsx
+++ b/src/solutions/SpaarkeAi/src/components/workspace/WorkspacePane.tsx
@@ -39,6 +39,14 @@ import {
   useAiSession,
 } from "@spaarke/ai-widgets";
 import type { WorkspacePaneEvent, ConversationPaneEvent } from "@spaarke/ai-widgets";
+// R5 task 038 — Summary tab schema + widget-type symbol. The schema must
+// match the SessionSummarizeOrchestrator's output (TL;DR / Summary / Keywords
+// / Entities) so streamed `field_delta` events render in the right fields.
+import {
+  STRUCTURED_OUTPUT_STREAM_WIDGET_TYPE,
+  SUMMARIZE_SCHEMA,
+} from "@spaarke/ai-widgets";
+import type { StructuredOutputStreamWidgetData } from "@spaarke/ai-widgets";
 import { buildBffApiUrl } from "@spaarke/auth";
 import { usePaneCollapseContext } from "../shell/ThreePaneShell";
 import { WorkspaceTabManager } from "./WorkspaceTabManager";
@@ -536,6 +544,175 @@ export function WorkspacePane(): React.JSX.Element {
   }, [isAuthenticated]);
 
   // ---------------------------------------------------------------------------
+  // Auto-install Summary tab — R5 task 038 (2026-06-05)
+  //
+  // Operator feedback from SC-18 cycle 4: the structured Summarize output
+  // (TL;DR / Summary / Keywords / Entities) streamed into the chat pane
+  // instead of into the Workspace pane. Root cause: the existing
+  // `StructuredOutputStreamWidget` (R5 task 017) subscribes to
+  // `workspace.streaming_*` events but was never registered as a workspace-
+  // pane tab in SpaarkeAi.
+  //
+  // This effect installs a "Summary" tab as the FIRST (leftmost) workspace
+  // tab using the new `prependTab` method on `WorkspaceTabManager`. The tab
+  // hosts the existing widget with `mode: 'streaming'` + `SUMMARIZE_SCHEMA`
+  // + `correlationId` set to the active chat sessionId so it consumes only
+  // events for the current session (FR-06 isolation per the widget's existing
+  // correlation gate). The tab is the default-active tab on mount.
+  //
+  // Bypasses the `dispatch('workspace', widget_load, ...)` round-trip so the
+  // tab lands at the FIRST position rather than appended. The dispatch path
+  // would append (per `addTab` semantics) — we want leftmost.
+  //
+  // Run-once guard via ref so re-renders / auth refresh don't re-stack the
+  // tab. The chat sessionId is read at effect time; if the session ID is not
+  // available yet the widget mounts with `correlationId: undefined` and
+  // refines its filter on the first `streaming_started` event (the
+  // ConversationPane passes `streamId = chatSessionId` so this matches once
+  // a session exists).
+  //
+  // Auto-focus + manual-override tracking (rules below) is implemented in a
+  // separate `usePaneEvent('workspace', ...)` subscription further down so
+  // the install effect doesn't have to know about the streaming lifecycle.
+  // ---------------------------------------------------------------------------
+
+  const summaryTabIdRef = React.useRef<string | null>(null);
+  const installedSummaryTabRef = React.useRef<boolean>(false);
+
+  React.useEffect(() => {
+    if (installedSummaryTabRef.current) return; // run once per mount
+    installedSummaryTabRef.current = true;
+
+    const manager = managerRef.current;
+    const widgetData: StructuredOutputStreamWidgetData = {
+      mode: "streaming",
+      schema: SUMMARIZE_SCHEMA,
+      // correlationId is the active chat sessionId; the ConversationPane
+      // executes Summarize with `streamId = chatSessionId` so events tagged
+      // with this id flow to this widget instance. May be null/undefined at
+      // first mount — `executeSummarizeIntent` only fires after a session
+      // exists, so by then the chat-pane caller will pass the right streamId.
+      ...(chatSessionId ? { correlationId: chatSessionId } : {}),
+      title: "Summary",
+    };
+
+    const tabId = manager.prependTab(
+      STRUCTURED_OUTPUT_STREAM_WIDGET_TYPE,
+      widgetData,
+      "Summary",
+    );
+    summaryTabIdRef.current = tabId;
+
+    // Activate Summary IMMEDIATELY (sync, before any render flushes) so the
+    // first render of `WorkspaceTabManagerComponent` has `activeTabId === tabId`
+    // and the Fluent v9 `TabList`'s internal `useControllableState` enters
+    // controlled mode on its very first render. If we deferred activation to
+    // the resolveWorkspaceWidget .then() callback, the first render would have
+    // `selectedValue === undefined`, locking TabList into uncontrolled mode
+    // for the rest of its lifetime (Fluent's `useIsControlled` is a snapshot,
+    // not a watcher).
+    manager.setActiveTab(tabId);
+
+    // Resolve the widget component lazily — same pattern as the
+    // dispatch('widget_load') path below.
+    void resolveWorkspaceWidget(STRUCTURED_OUTPUT_STREAM_WIDGET_TYPE).then(
+      (Component) => {
+        manager.resolveTabComponent(tabId, Component, "Summary");
+        syncState();
+
+        // Notify ShellStageManager about the new tab count.
+        dispatch("workspace", {
+          type: "tab_count_change",
+          tabCount: manager.getSnapshot().tabs.length,
+        });
+      },
+    );
+    syncState();
+    // Run ONCE per mount — the chatSessionId dep is intentionally not in
+    // the deps array; widgetData.correlationId is read at install time and
+    // the install is idempotent via the ref guard above. If a future task
+    // requires re-targeting the correlationId on session change, lift to
+    // an explicit update via `updateTab`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep the Summary tab's correlationId in sync if the session changes
+  // after the tab is installed. This handles the case where the user signs
+  // in (or switches sessions) AFTER the Summary tab mounted with no session.
+  React.useEffect(() => {
+    const tabId = summaryTabIdRef.current;
+    if (!tabId) return;
+    if (!chatSessionId) return;
+
+    const widgetData: StructuredOutputStreamWidgetData = {
+      mode: "streaming",
+      schema: SUMMARIZE_SCHEMA,
+      correlationId: chatSessionId,
+      title: "Summary",
+    };
+    managerRef.current.updateTab(tabId, widgetData);
+    syncState();
+  }, [chatSessionId, syncState]);
+
+  // ---------------------------------------------------------------------------
+  // Summary-tab auto-focus on `workspace.streaming_started` — R5 task 038
+  //
+  // Rules (per task spec):
+  //   - Auto-focus the Summary tab when a `streaming_started` event fires for
+  //     the active chat session (event.streamId === chatSessionId).
+  //   - Do NOT auto-focus on `field_delta` or `streaming_complete` — those
+  //     flow into the already-active tab (or get dropped if Summary isn't
+  //     active because the user clicked away).
+  //   - Respect manual override: if the user clicks a different tab during an
+  //     active stream, set `streamFocusOverrideRef = true` so subsequent
+  //     events (within the same stream cycle) do NOT pull focus back.
+  //   - Reset the override on `streaming_complete` so the next stream can
+  //     again auto-focus.
+  //   - Correlation isolation: streaming_started events with mismatched
+  //     streamId (i.e. NOT for the active session) do NOT trigger auto-focus.
+  // ---------------------------------------------------------------------------
+
+  const streamFocusOverrideRef = React.useRef<boolean>(false);
+
+  usePaneEvent("workspace", (event: WorkspacePaneEvent): void => {
+    if (event.type === "streaming_started") {
+      // Correlation isolation — only auto-focus when the stream belongs to
+      // the active chat session. When `chatSessionId` is null/undefined we
+      // tolerate (cold-load convenience) but still require a streamId to be
+      // present on the event so unknown / probe events don't pull focus.
+      if (chatSessionId && event.streamId && event.streamId !== chatSessionId) {
+        return;
+      }
+
+      // Respect user override from a PRIOR session/stream cycle that has not
+      // yet completed. If the override is set, do not pull focus. The
+      // override clears on `streaming_complete` (below) so the NEXT
+      // `streaming_started` can again auto-focus.
+      if (streamFocusOverrideRef.current) {
+        return;
+      }
+
+      const summaryTabId = summaryTabIdRef.current;
+      if (!summaryTabId) return;
+
+      // Switch to Summary unless we're already there.
+      const manager = managerRef.current;
+      if (manager.getSnapshot().activeTabId !== summaryTabId) {
+        manager.setActiveTab(summaryTabId);
+        syncState();
+        // Note: setActiveTab fires onActiveTabChange which dispatches the
+        // `active_widget_changed` signal (Round 4 Fix 4 infrastructure).
+      }
+    } else if (event.type === "streaming_complete") {
+      // Reset override so the NEXT streaming_started can again auto-focus.
+      streamFocusOverrideRef.current = false;
+    }
+    // `field_delta` is intentionally not handled here — those events flow
+    // into the widget through its own subscription; auto-focus must NOT
+    // fire on field_delta (per task spec).
+  });
+
+  // ---------------------------------------------------------------------------
   // PaneEventBus subscription — 'workspace' channel
   // ---------------------------------------------------------------------------
 
@@ -671,6 +848,24 @@ export function WorkspacePane(): React.JSX.Element {
       const manager = managerRef.current;
       manager.setActiveTab(tabId);
       syncState();
+
+      // R5 task 038 — Manual override for the Summary tab auto-focus.
+      //
+      // When the user manually clicks a tab OTHER THAN Summary, set the
+      // override flag so subsequent `field_delta` / `streaming_complete`
+      // events in the current stream cycle do NOT pull focus back to
+      // Summary. The override is reset on the NEXT `streaming_started`
+      // event (so the next stream can again auto-focus) AND on
+      // `streaming_complete` (defensive double-reset — see the auto-focus
+      // subscription above).
+      const summaryTabId = summaryTabIdRef.current;
+      if (summaryTabId && tabId !== summaryTabId) {
+        streamFocusOverrideRef.current = true;
+      } else if (tabId === summaryTabId) {
+        // User clicked back to Summary themselves — clear the override
+        // (no longer in "I want to be elsewhere" mode).
+        streamFocusOverrideRef.current = false;
+      }
 
       // Find the newly active tab to include widget info in the event.
       const activeTab = manager.getActiveTab();

--- a/src/solutions/SpaarkeAi/src/components/workspace/WorkspaceTabManager.ts
+++ b/src/solutions/SpaarkeAi/src/components/workspace/WorkspaceTabManager.ts
@@ -385,6 +385,71 @@ export class WorkspaceTabManager {
   }
 
   // -------------------------------------------------------------------------
+  // prependTab — add a widget tab at the FIRST position (R5 task 038)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Add a new widget tab AT THE FIRST POSITION (after the Home tab if one
+   * exists). Used by R5 task 038 to install the always-leftmost "Summary"
+   * tab that hosts `StructuredOutputStreamWidget` for chat-driven streaming
+   * AI output.
+   *
+   * Like `addTab`, this enforces `MAX_WORKSPACE_TABS` by FIFO-evicting the
+   * OLDEST non-Home tab — the newly prepended tab itself is exempt from the
+   * eviction-candidate set. Unlike `addTab`, the new tab does NOT auto-
+   * activate. Callers that want it active call `setActiveTab(newId)` after.
+   *
+   * @param widgetType   - Widget type string (e.g. `"structured-output-stream"`).
+   * @param widgetData   - Arbitrary payload to pass to the widget component.
+   * @param displayName  - Optional display label; defaults to widgetType.
+   * @returns The new tab's stable id.
+   */
+  prependTab(widgetType: string, widgetData: unknown, displayName?: string): string {
+    // Enforce MAX_WORKSPACE_TABS — evict the oldest non-Home tab when at cap.
+    // Note: identical policy to addTab(); the new prepended tab is exempt from
+    // the eviction candidate set because it is not yet in `_tabs`.
+    const nonHomeIndices = this._tabs
+      .map((t, i) => (t.kind === "widget" ? i : -1))
+      .filter((i) => i >= 0);
+
+    if (nonHomeIndices.length >= MAX_WORKSPACE_TABS) {
+      const oldestNonHomeIdx = nonHomeIndices[0];
+      this._tabs = [
+        ...this._tabs.slice(0, oldestNonHomeIdx),
+        ...this._tabs.slice(oldestNonHomeIdx + 1),
+      ];
+    }
+
+    const id = `wstab-${++this._nextSeq}-${widgetType}`;
+
+    const newTab: WorkspaceTab = {
+      id,
+      kind: "widget",
+      widgetType,
+      widgetData,
+      Component: null,
+      isLoading: true,
+      displayName: displayName ?? widgetType,
+    };
+
+    // Insert AFTER any Home tab (which by convention sits at index 0) so the
+    // new tab is the FIRST widget tab. With no Home, it goes to index 0.
+    const homeIdx = this._tabs.findIndex((t) => t.kind === "home");
+    const insertAt = homeIdx >= 0 ? homeIdx + 1 : 0;
+    this._tabs = [
+      ...this._tabs.slice(0, insertAt),
+      newTab,
+      ...this._tabs.slice(insertAt),
+    ];
+
+    // Persist the new state. Unlike addTab, do NOT auto-activate — callers
+    // (e.g. WorkspacePane's Summary-tab auto-install effect) decide whether
+    // the prepended tab should also become active.
+    this._notifyPersistChange();
+    return id;
+  }
+
+  // -------------------------------------------------------------------------
   // resolveTabComponent
   // -------------------------------------------------------------------------
 

--- a/src/solutions/SpaarkeAi/src/components/workspace/__tests__/WorkspacePane.summary-tab.test.tsx
+++ b/src/solutions/SpaarkeAi/src/components/workspace/__tests__/WorkspacePane.summary-tab.test.tsx
@@ -1,0 +1,469 @@
+/**
+ * WorkspacePane — R5 task 038 Summary-tab registration + auto-focus tests
+ *
+ * Covers the acceptance criteria from
+ * `tasks/038-workspace-pane-summary-tab-registration.poml`:
+ *
+ *   (1) Workspace pane installs a "Summary" tab on mount that hosts the
+ *       existing `StructuredOutputStreamWidget` (`structured-output-stream`
+ *       widget type) with `correlationId = chatSessionId` + `SUMMARIZE_SCHEMA`.
+ *
+ *   (2) Summary tab is the FIRST tab (leftmost) and is default-active on
+ *       mount. When a workspace layout is auto-installed later in the same
+ *       render cycle, Summary remains LEFT of the layout.
+ *
+ *   (3) `workspace.streaming_started` event with `streamId === chatSessionId`
+ *       auto-focuses the Summary tab (even when another tab is active).
+ *
+ *   (4) Mismatched-correlationId `streaming_started` events do NOT trigger
+ *       auto-focus (session isolation per FR-06).
+ *
+ *   (5) Manual click on a different tab during a stream is RESPECTED —
+ *       subsequent `streaming_started` events within the same cycle do NOT
+ *       refocus (override semantic). `streaming_complete` resets the
+ *       override so the next stream can again auto-focus.
+ *
+ *   (6) `field_delta` events do NOT change focus (those flow into whatever
+ *       tab is currently active; this is intentional).
+ *
+ * Test strategy:
+ *
+ *   - WorkspacePane depends on many hooks (`useAiSession`,
+ *     `useWorkspaceLayouts`, `usePaneCollapseContext`). We mock
+ *     `@spaarke/ai-widgets`'s `useAiSession` to a minimal authenticated stub
+ *     so the network paths (tab restore, layout fetch) are not exercised.
+ *   - We mock `useWorkspaceLayouts` to return no active layout so the
+ *     default-workspace effect doesn't auto-install a layout tab (keeps the
+ *     test simple — we focus on Summary + a manually-injected widget tab).
+ *   - We use the REAL `PaneEventBus` + `PaneEventBusProvider` so events
+ *     flow through the same machinery the production code uses. Tests
+ *     dispatch events synchronously via the bus.
+ *   - We mock `resolveWorkspaceWidget` to return a tiny synchronous stub
+ *     component so we can assert on the rendered tab without spinning up
+ *     the real `StructuredOutputStreamWidget`.
+ *
+ * All test invariants are stable across Jest + jsdom; no real timers, no
+ * real fetch.
+ */
+
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+
+import {
+  PaneEventBus,
+  PaneEventBusProvider,
+  STRUCTURED_OUTPUT_STREAM_WIDGET_TYPE,
+} from '@spaarke/ai-widgets';
+
+// ---------------------------------------------------------------------------
+// Mock `@spaarke/ai-widgets` — keep the real bus + provider + types, but
+// override `useAiSession` (minimal auth stub) and `resolveWorkspaceWidget`
+// (stub component for the Summary widget — the real widget's internal
+// PaneEventBus subscriptions would otherwise interfere with focus tests).
+// ---------------------------------------------------------------------------
+
+const stubWidgetRenderCounts: Record<string, number> = {};
+
+jest.mock('@spaarke/ai-widgets', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const actual = jest.requireActual('@spaarke/ai-widgets') as any;
+
+  // Stub widget — renders `data-testid="widget-stub-{widgetType}"` so tests
+  // can assert which widget is mounted. Bumps a render counter so tests can
+  // distinguish "tab mounted" from "tab unmounted".
+  const makeStub = (widgetType: string): React.FC<{ data?: unknown }> => {
+    return function StubWidget(): React.JSX.Element {
+      stubWidgetRenderCounts[widgetType] = (stubWidgetRenderCounts[widgetType] ?? 0) + 1;
+      return <div data-testid={`widget-stub-${widgetType}`}>{widgetType}</div>;
+    };
+  };
+
+  return {
+    ...actual,
+    useAiSession: () => ({
+      isAuthenticated: true,
+      // Always return 404 so the tab-restore effect's `if (response.status
+      // === 404) return;` path triggers (treats as "no tabs to restore" —
+      // benign). Without this default response shape, the restore effect
+      // throws and logs telemetry, which is fine but noisy in test output.
+      authenticatedFetch: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      } as Partial<Response> as Response),
+      getAccessToken: jest.fn().mockResolvedValue('test-token'),
+      bffBaseUrl: 'https://test-bff.example.com',
+      tenantId: 'test-tenant',
+      chatSessionId: 'session-aaa',
+      setChatSessionId: jest.fn(),
+      playbookId: undefined,
+      setPlaybookId: jest.fn(),
+      entityContext: null,
+      contextMapping: null,
+      isLoadingContextMapping: false,
+      streaming: { onPaneEvent: null },
+      streamingState: { isStreaming: false, tokenCount: 0 },
+      turnCount: 0,
+      isLoading: false,
+    }),
+    // Resolve to a stub component synchronously. The production registry
+    // resolves via dynamic `import()` — our stub bypasses that so jsdom
+    // doesn't have to evaluate the real widget's `usePaneEvent` subscription.
+    resolveWorkspaceWidget: jest.fn(async (widgetType: string) => {
+      return makeStub(widgetType);
+    }),
+    getWorkspaceWidgetMetadata: jest.fn(() => ({
+      displayName: 'Stubbed Widget',
+      category: 'analysis',
+      defaultOrder: 100,
+      allowMultiple: true,
+    })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock `useWorkspaceLayouts` — return no active layout so the default-
+// workspace auto-install effect inside WorkspacePane doesn't add a second
+// tab. This keeps tests focused on Summary-tab behaviour.
+// ---------------------------------------------------------------------------
+
+jest.mock('../../../hooks/useWorkspaceLayouts', () => ({
+  useWorkspaceLayouts: () => ({
+    layouts: [],
+    activeLayout: null,
+    isLoading: false,
+    refetch: jest.fn(),
+    setActiveLayoutById: jest.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock pinnedWorkspaces — no pinned layouts so the pin-auto-open effect
+// doesn't dispatch anything.
+// ---------------------------------------------------------------------------
+
+jest.mock('../../../services/pinnedWorkspaces', () => ({
+  getPinnedWorkspaces: jest.fn(() => []),
+  pinWorkspace: jest.fn(),
+  unpinWorkspace: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock pane-header from @spaarke/ui-components — minimal pass-through that
+// renders the title + rightSlot so the test renders without depending on the
+// real PaneHeader's styling internals.
+// ---------------------------------------------------------------------------
+
+// We intentionally do NOT call jest.requireActual — the @spaarke/ui-components
+// barrel pulls in ESM-only deps (marked, d3-force, dompurify) that crash
+// ts-jest. WorkspacePane only consumes `PaneHeader` from this package; nothing
+// else is referenced via the test render path.
+jest.mock('@spaarke/ui-components', () => ({
+  PaneHeader: ({ title, rightSlot }: { title: string; rightSlot?: React.ReactNode }) => (
+    <div data-testid="pane-header">
+      <span>{title}</span>
+      {rightSlot}
+    </div>
+  ),
+}));
+
+// Import AFTER mocks so module resolution picks them up.
+import { WorkspacePane } from '../WorkspacePane';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderPane(): { bus: PaneEventBus } {
+  const bus = new PaneEventBus();
+  render(
+    <FluentProvider theme={webLightTheme}>
+      <PaneEventBusProvider bus={bus}>
+        <WorkspacePane />
+      </PaneEventBusProvider>
+    </FluentProvider>,
+  );
+  return { bus };
+}
+
+/**
+ * Wait for the Summary tab to mount (its stub widget appears) — we await
+ * the dynamic-import promise resolution by flushing microtasks AND macrotasks.
+ *
+ * `usePaneEvent` registers via useEffect (a passive effect), and the
+ * default-layout auto-install effect defers its dispatch via `setTimeout(0)`.
+ * We need to flush both so all pending async work resolves before assertions.
+ */
+async function waitForSummaryTab(): Promise<void> {
+  await act(async () => {
+    // Flush microtasks (resolveWorkspaceWidget promise chain).
+    for (let i = 0; i < 4; i++) {
+      await Promise.resolve();
+    }
+    // Flush a macrotask so deferred setTimeout(..., 0) dispatches (auto-
+    // install default layout) have a chance to run.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    // Drain any micro/macro tasks queued by the above.
+    for (let i = 0; i < 4; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(stubWidgetRenderCounts)) {
+    delete stubWidgetRenderCounts[key];
+  }
+  // jsdom does not implement Element.scrollIntoView; WorkspaceTabManagerComponent
+  // calls it inside a requestAnimationFrame callback after each active-tab
+  // change. Stub so the rAF callback doesn't throw.
+  if (!Element.prototype.scrollIntoView) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    Element.prototype.scrollIntoView = function (): void {};
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (1) Summary tab installs on mount + is FIRST + is default-active
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePane — Summary tab registration (R5 task 038)', () => {
+  it('mounts a Summary tab using StructuredOutputStreamWidget', async () => {
+    renderPane();
+    await waitForSummaryTab();
+
+    // Tab strip should show a "Summary" tab.
+    expect(screen.getByRole('tab', { name: /summary/i })).toBeInTheDocument();
+
+    // The Summary widget stub should render (default-active).
+    expect(
+      screen.getByTestId(`widget-stub-${STRUCTURED_OUTPUT_STREAM_WIDGET_TYPE}`),
+    ).toBeInTheDocument();
+  });
+
+  it('places the Summary tab FIRST (leftmost) — before any auto-installed layout', async () => {
+    const { bus } = renderPane();
+    await waitForSummaryTab();
+
+    // Inject a SECOND tab via the standard `widget_load` dispatch (simulates
+    // the default-layout auto-install OR a pinned workspace open). The
+    // standard `addTab` path appends; Summary should stay leftmost.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'widget_load',
+        widgetType: 'workspace',
+        widgetData: { layoutId: 'corp', layoutName: 'Corporate' },
+        displayName: 'Corporate',
+      });
+    });
+    await waitForSummaryTab();
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.length).toBeGreaterThanOrEqual(2);
+    expect(tabs[0]).toHaveTextContent(/summary/i);
+    expect(tabs[1]).toHaveTextContent(/corporate/i);
+  });
+
+  it('makes Summary the default-active tab on mount', async () => {
+    renderPane();
+    await waitForSummaryTab();
+
+    // Verify the Summary tab is mounted as the ACTIVE tab by checking that
+    // its widget stub is rendered in the content area (only the active tab's
+    // component is mounted per WorkspaceTabManagerComponent's ActiveWidgetContent
+    // semantics).
+    expect(
+      screen.getByTestId(`widget-stub-${STRUCTURED_OUTPUT_STREAM_WIDGET_TYPE}`),
+    ).toBeInTheDocument();
+
+    // Wait for the Fluent v9 TabList's internal context to reflect the
+    // controlled selectedValue — context updates settle after the initial
+    // render commit, hence the waitFor.
+    await waitFor(() => {
+      const summaryTab = screen.getByRole('tab', { name: /summary/i });
+      expect(summaryTab.getAttribute('aria-selected')).toBe('true');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) Auto-focus on workspace.streaming_started for matching correlationId
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePane — Summary tab auto-focus on streaming_started', () => {
+  it('auto-focuses Summary when streaming_started fires with the active sessionId', async () => {
+    const { bus } = renderPane();
+    await waitForSummaryTab();
+
+    // Add a second tab and switch to it so Summary is NOT active.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'widget_load',
+        widgetType: 'workspace',
+        widgetData: { layoutId: 'corp' },
+        displayName: 'Corporate',
+      });
+    });
+    await waitForSummaryTab();
+
+    // Verify Corporate (the newly added tab) is now active (addTab auto-activates).
+    const corpTab = screen.getByRole('tab', { name: /corporate/i });
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+
+    // Fire streaming_started for the active session — Summary should refocus.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'streaming_started',
+        streamId: 'session-aaa', // matches the mocked chatSessionId
+      });
+    });
+
+    const summaryTab = screen.getByRole('tab', { name: /summary/i });
+    expect(summaryTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('does NOT auto-focus when streaming_started carries a mismatched streamId', async () => {
+    const { bus } = renderPane();
+    await waitForSummaryTab();
+
+    // Add + activate a second tab (Corporate).
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'widget_load',
+        widgetType: 'workspace',
+        widgetData: { layoutId: 'corp' },
+        displayName: 'Corporate',
+      });
+    });
+    await waitForSummaryTab();
+
+    const corpTab = screen.getByRole('tab', { name: /corporate/i });
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+
+    // streaming_started for a DIFFERENT session — must NOT refocus Summary.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'streaming_started',
+        streamId: 'session-other-bbb', // does NOT match 'session-aaa'
+      });
+    });
+
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+    const summaryTab = screen.getByRole('tab', { name: /summary/i });
+    expect(summaryTab.getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3) Manual override + reset on streaming_complete
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePane — manual override during stream', () => {
+  it('respects user override during a stream cycle (no refocus until streaming_complete)', async () => {
+    const user = userEvent.setup();
+    const { bus } = renderPane();
+    await waitForSummaryTab();
+
+    // Add a Corporate tab.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'widget_load',
+        widgetType: 'workspace',
+        widgetData: { layoutId: 'corp' },
+        displayName: 'Corporate',
+      });
+    });
+    await waitForSummaryTab();
+
+    // streaming_started focuses Summary.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'streaming_started',
+        streamId: 'session-aaa',
+      });
+    });
+    const summaryTab = screen.getByRole('tab', { name: /summary/i });
+    expect(summaryTab.getAttribute('aria-selected')).toBe('true');
+
+    // User manually clicks Corporate during the stream — override engaged.
+    const corpTab = screen.getByRole('tab', { name: /corporate/i });
+    await user.click(corpTab);
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+
+    // A SECOND streaming_started (e.g. concurrent summarize) MUST respect the
+    // override and NOT pull focus back.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'streaming_started',
+        streamId: 'session-aaa',
+      });
+    });
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+    expect(summaryTab.getAttribute('aria-selected')).toBe('false');
+
+    // streaming_complete clears the override.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'streaming_complete',
+        streamId: 'session-aaa',
+        completionStatus: 'complete',
+      });
+    });
+    // Corporate is still active (we don't yank focus on complete).
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+
+    // The NEXT streaming_started (after complete) should again auto-focus.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'streaming_started',
+        streamId: 'session-aaa',
+      });
+    });
+    expect(summaryTab.getAttribute('aria-selected')).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (4) field_delta events MUST NOT change focus
+// ---------------------------------------------------------------------------
+
+describe('WorkspacePane — field_delta never changes focus', () => {
+  it('field_delta events do not pull focus to Summary', async () => {
+    const { bus } = renderPane();
+    await waitForSummaryTab();
+
+    // Add a Corporate tab and let addTab auto-activate it.
+    act(() => {
+      bus.dispatch('workspace', {
+        type: 'widget_load',
+        widgetType: 'workspace',
+        widgetData: { layoutId: 'corp' },
+        displayName: 'Corporate',
+      });
+    });
+    await waitForSummaryTab();
+
+    const corpTab = screen.getByRole('tab', { name: /corporate/i });
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+
+    // Fire several field_delta events — focus must stay on Corporate.
+    for (let i = 0; i < 5; i++) {
+      act(() => {
+        bus.dispatch('workspace', {
+          type: 'field_delta',
+          streamId: 'session-aaa',
+          fieldPath: 'tldr',
+          fieldContent: `chunk-${i}`,
+          sequence: i,
+        });
+      });
+    }
+
+    expect(corpTab.getAttribute('aria-selected')).toBe('true');
+    const summaryTab = screen.getByRole('tab', { name: /summary/i });
+    expect(summaryTab.getAttribute('aria-selected')).toBe('false');
+  });
+});

--- a/src/solutions/SpaarkeAi/src/components/workspace/__tests__/WorkspaceTabManager.test.ts
+++ b/src/solutions/SpaarkeAi/src/components/workspace/__tests__/WorkspaceTabManager.test.ts
@@ -875,3 +875,100 @@ describe("WorkspaceTabManager — onPersistChange callback (NFR-09)", () => {
     }).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// R5 task 038 — prependTab (Summary tab installs at first position)
+// ---------------------------------------------------------------------------
+
+describe("WorkspaceTabManager — prependTab (R5 task 038)", () => {
+  it("inserts the tab at index 0 when there are no other tabs", () => {
+    const mgr = makeManager();
+    const id = mgr.prependTab("structured-output-stream", { foo: 1 }, "Summary");
+
+    const { tabs } = mgr.getSnapshot();
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].id).toBe(id);
+    expect(tabs[0].widgetType).toBe("structured-output-stream");
+    expect(tabs[0].displayName).toBe("Summary");
+    expect(tabs[0].kind).toBe("widget");
+    expect(tabs[0].isLoading).toBe(true);
+  });
+
+  it("inserts the tab BEFORE other widget tabs (leftmost position)", () => {
+    const mgr = makeManager();
+    const layoutId = mgr.addTab("workspace", { layoutId: "abc" }, "Layout A");
+    const summaryId = mgr.prependTab(
+      "structured-output-stream",
+      { mode: "streaming" },
+      "Summary",
+    );
+
+    const { tabs } = mgr.getSnapshot();
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0].id).toBe(summaryId);     // FIRST = Summary
+    expect(tabs[0].displayName).toBe("Summary");
+    expect(tabs[1].id).toBe(layoutId);      // SECOND = pre-existing layout
+    expect(tabs[1].displayName).toBe("Layout A");
+  });
+
+  it("inserts AFTER the Home tab when one is present (Home stays at index 0)", () => {
+    const mgr = makeManager();
+    const homeId = mgr.ensureHomeTab("Home");
+    const summaryId = mgr.prependTab(
+      "structured-output-stream",
+      null,
+      "Summary",
+    );
+
+    const { tabs } = mgr.getSnapshot();
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0].id).toBe(homeId);       // Home stays at idx 0
+    expect(tabs[0].kind).toBe("home");
+    expect(tabs[1].id).toBe(summaryId);    // Summary at idx 1 (first WIDGET)
+  });
+
+  it("does NOT auto-activate the prepended tab (unlike addTab)", () => {
+    const mgr = makeManager();
+    const layoutId = mgr.addTab("workspace", null, "Layout");
+    // addTab made layoutId active.
+    expect(mgr.getSnapshot().activeTabId).toBe(layoutId);
+
+    const summaryId = mgr.prependTab("structured-output-stream", null, "Summary");
+    expect(summaryId).toBeDefined();
+    // Active tab must NOT change just because we prepended.
+    expect(mgr.getSnapshot().activeTabId).toBe(layoutId);
+  });
+
+  it("respects MAX_WORKSPACE_TABS by evicting the oldest non-Home tab when at cap", () => {
+    const mgr = makeManager();
+    const widgetIds: string[] = [];
+    for (let i = 1; i <= MAX_WORKSPACE_TABS; i++) {
+      widgetIds.push(mgr.addTab(`widget-${i}`, null));
+    }
+    // The cap is hit; prepending should evict widget-1 (the oldest non-Home).
+    const summaryId = mgr.prependTab("structured-output-stream", null, "Summary");
+
+    const { tabs } = mgr.getSnapshot();
+    expect(tabs).toHaveLength(MAX_WORKSPACE_TABS);
+    expect(tabs[0].id).toBe(summaryId); // Summary is first
+    expect(tabs.some((t) => t.id === widgetIds[0])).toBe(false); // oldest evicted
+  });
+
+  it("falls back to widgetType when displayName is omitted", () => {
+    const mgr = makeManager();
+    mgr.prependTab("structured-output-stream", null);
+    const { tabs } = mgr.getSnapshot();
+    expect(tabs[0].displayName).toBe("structured-output-stream");
+  });
+
+  it("fires onPersistChange after prepend", () => {
+    const onPersistChange = jest.fn();
+    const mgr = new WorkspaceTabManager({ onPersistChange });
+    mgr.prependTab("structured-output-stream", null, "Summary");
+    expect(onPersistChange).toHaveBeenCalledTimes(1);
+    const snap = onPersistChange.mock.calls[0][0];
+    expect(snap.tabs).toHaveLength(1);
+    expect(snap.tabs[0].widgetType).toBe("structured-output-stream");
+  });
+});
+


### PR DESCRIPTION
## Summary

Closes out R5 by landing the cycle-6 through cycle-9 fixes already deployed to Spaarke Dev. These resolve the remaining vertical-slice defects surfaced during the SC-18 SME walkthrough. Cycles 1–5 already on master (PRs #354, #359, #361, #362).

## Cycles in this PR

**Cycle 6 — paperclip silent failure**
- `SprkChat.handleAttachInputChange`: snapshot `FileList` to `File[]` BEFORE clearing `input.value`. Setting `input.value = ''` clears the live FileList by reference, so `addAttachmentFiles` was receiving an empty list.
- `ChatAttachment` / `AttachmentChip`: optional `file?: File` field forwards the original `File` ref across the `@spaarke/ui-components` package boundary so binary-upload paths (PDF/DOCX) don't have to reconstruct a synthetic File from extracted text.

**Cycle 7 — pdfjs worker missing**
- `useChatFileAttachment`: default `GlobalWorkerOptions.workerSrc` to a versioned jsdelivr CDN URL when consumers haven't pre-set one. `pdfjs-dist` v4+ requires this; previously `getDocument` threw "No GlobalWorkerOptions.workerSrc specified" on any PDF.

**Cycle 8 — Workspace Summary tab + misleading preview (task 038)**
- `WorkspaceTabManager`: new `prependTab(widgetType, widgetData, displayName)` method.
- `WorkspacePane`: install Summary tab on `streaming_started` + auto-focus until user clicks another tab; manual override tracked.
- `ConversationPane.handleAttachmentReady`: stop dispatching `DocumentViewerWidget` for chat uploads (no SPE preview URL exists for client-staged files; widget rendered "Preview not available" misleadingly). Reinstate when task 022 upgrades the widget.
- Tests: `WorkspacePane.summary-tab.test.tsx` (7 cases), extended `WorkspaceTabManager` tests, jest d3-force ESM mapper + stub.

**Cycle 9 — JSONPath vs widget schema mismatch**
- `sseToPaneEventBridge`: strip leading `$.` from `delta.path` so `StructuredOutputStreamWidget` can match field keys against its `SUMMARIZE_SCHEMA` (`tldr`/`summary`/...). The BFF `IncrementalJsonParser` emits JSONPath-style keys; the widget schema uses bare keys.

## Known limitations deferred to R6

See `projects/spaarke-ai-platform-unification-r6/design.md` (separate PR):

- Renderer is not schema-aware for array/object fields (TL;DR renders raw JSON fragments, Entities renders JSON object literal). → R6 Pillar 5 (Playbook Output-Type / schema-aware rendering).
- Duplicate-fire (chat agent + workspace path both invoke summarize for `/summarize`). → R6 Pillars 5 + 8.

## Test plan
- [ ] Vite build succeeds for `src/solutions/SpaarkeAi` (verified locally)
- [ ] `@spaarke/ai-widgets` typecheck passes (verified locally)
- [ ] `@spaarke/ui-components` typecheck passes (verified locally)
- [ ] Spaarke Dev SC-18 walkthrough: paperclip → PDF → `/summarize` → Workspace Summary tab populates with structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)