### PR TITLE
ai-workspace-ui-r1: follow-ups — CalendarSidePane fix + CreateTodo card + CSS reset CI gate

### DIFF
--- a/.github/workflows/css-reset-gate.yml
+++ b/.github/workflows/css-reset-gate.yml
@@ -1,0 +1,52 @@
+name: CSS Reset Gate
+
+# Repository-wide enforcement of the universal box-sizing reset in every
+# Code Page host index.html (Vite + Webpack). Prevents regressions of the
+# class of bug that the ai-spaarke-ai-workspace-UI-r1 iter-2 round 11 fix
+# resolved: missing reset → DataGrid cells render +24px wider than declared
+# → horizontal overflow.
+#
+# Reference: docs/guides/DATAGRID-CODE-PAGE-HOST-CONTRACT.md §2
+# Origin: projects/ai-spaarke-ai-workspace-UI-r1/notes/followup-backlog.md §8
+#
+# Lightweight check (sub-second runtime), runs on every PR + master push
+# that touches any Code Page index.html or the check script itself.
+
+on:
+  pull_request:
+    paths:
+      - 'src/solutions/**/index.html'
+      - 'src/client/code-pages/**/index.html'
+      - 'scripts/check-html-css-reset.mjs'
+      - '.github/workflows/css-reset-gate.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/solutions/**/index.html'
+      - 'src/client/code-pages/**/index.html'
+      - 'scripts/check-html-css-reset.mjs'
+      - '.github/workflows/css-reset-gate.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: css-reset-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-reset:
+    name: Verify box-sizing reset on all Code Page hosts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run repo-wide reset gate
+        run: node scripts/check-html-css-reset.mjs --all

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,9 @@ coverage/
 # Generated files
 *.min.js
 *_generated.*
+# PCF manifest types and other tool-emitted `generated/` directories.
+# Hand-formatting these is wasted work — the PCF tooling overwrites them.
+**/generated/
 
 # C# files (handled by dotnet format + .editorconfig)
 *.cs

--- a/projects/ai-spaarke-ai-workspace-UI-r1/notes/followup-backlog.md
+++ b/projects/ai-spaarke-ai-workspace-UI-r1/notes/followup-backlog.md
@@ -170,7 +170,7 @@ event at worst.
 
 ---
 
-## 4. CreateTodoWizard — placement / discoverability — MEDIUM
+## 4. CreateTodoWizard — placement / discoverability — DONE (Quick Start card)
 
 **Operator question**: *"this doesn't launch from command bar — where do I
 launch this? Also the wizard should be added to the Quick Start spaarke.ai
@@ -204,9 +204,12 @@ Estimated 30-45 min including a SpaarkeAi rebuild + deploy.
 
 ### Recommended owner
 
-- Quick Start card addition: this project (small fast-follow PR) or
-  smart-todo-r4 if it makes sense to bundle with other SmartTodo work.
-- Ribbon publish verification: operator.
+- Quick Start card addition: **DONE** in `feature/ai-workspace-ui-r1-followups`
+  (commit `dbcd94c8e`, 2026-06-10). Added action card at position 4 in
+  `getStartedConfig.ts` calling `ctx.onOpenWizard("sprk_createtodowizard")`;
+  bumped `maxVisible` 4→5 in `getStarted.registration.ts` so the new card
+  stays in the default visible set. Deployed to SpaarkeAi (3704 KB).
+- Ribbon publish verification: operator (still pending).
 
 ---
 
@@ -268,7 +271,7 @@ deploy scripts when convenient.
 
 ---
 
-## 7. CalendarSidePane — orphaned build (pre-existing) — LOW
+## 7. CalendarSidePane — orphaned build (pre-existing) — DONE
 
 **Surfaced**: 2026-06-10 during Wave 3 deploy attempts.
 
@@ -293,13 +296,19 @@ CalendarSection's exported API matches the destructure, rebuild, redeploy.
 Estimated 15 minutes if the exports line up; longer if the API changed in
 the hoist.
 
+**Status**: ✅ **DONE** in `feature/ai-workspace-ui-r1-followups`
+(commit `3baf44e48`, 2026-06-10). Hoisted exports from
+`@spaarke/events-components` matched the prior local API exactly — one-line
+import swap. Build clean (1213 KB), deployed to spaarkedev1
+`sprk_calendarsidepane.html` (1185 KB).
+
 **Recommended owner**: whichever project owns CalendarSidePane long-term.
 If it's truly orphaned (no consumer), candidate for retirement in a future
 solutions audit.
 
 ---
 
-## Cross-cutting follow-up — CI gate adoption
+## Cross-cutting follow-up — CI gate adoption — DONE (Option A)
 
 The new `scripts/check-html-css-reset.mjs` is currently invoked from 3
 surface `package.json` build scripts. For maximum prevention:
@@ -311,4 +320,19 @@ surface `package.json` build scripts. For maximum prevention:
 - **Option B** — extend each surface's `package.json` `build` script as we
   touch them. Slow burn, but doesn't add CI complexity.
 
-Either is fine. Operator preference TBD.
+**Shipped**: ✅ Option A. New workflow
+[`.github/workflows/css-reset-gate.yml`](../../../.github/workflows/css-reset-gate.yml)
+runs `node scripts/check-html-css-reset.mjs --all` on every PR + master
+push that touches a Code Page `index.html` or the check script itself.
+The script grew an `--all` mode that auto-discovers all Code Page hosts
+(`src/solutions/*/index.html` + `src/client/code-pages/*/index.html`) so the
+gate adapts when new surfaces are added without any workflow edit.
+
+The discovery scan also surfaced 5 hosts that already had the reset but
+with sibling resets (`margin: 0; padding: 0;`) inside the same rule block,
+which the original strict regex rejected. The regex was loosened to accept
+sibling properties (`[^{}]*` around `box-sizing: border-box`) while still
+requiring the universal `*` selector. Verified clean against all 26
+discovered hosts.
+
+Committed in `feature/ai-workspace-ui-r1-followups` (2026-06-10).

--- a/scripts/check-html-css-reset.mjs
+++ b/scripts/check-html-css-reset.mjs
@@ -15,42 +15,60 @@
 // was documented but not enforced at build time. Established 2026-06-09
 // after iter-2 round 11 fix on ai-spaarke-ai-workspace-UI-r1.
 //
-// Usage (in a surface's package.json build script):
+// Usage 1 — Single-file check (in a surface's package.json build script):
 //
 //   "build": "node ../../../scripts/check-html-css-reset.mjs && vite build && ..."
 //
-// Or as a standalone check from the repo root:
+// Or with explicit path from the repo root:
 //
 //   node scripts/check-html-css-reset.mjs src/solutions/MySurface/index.html
+//
+// Usage 2 — Repo-wide check (used by CI; auto-discovers all Code Page hosts):
+//
+//   node scripts/check-html-css-reset.mjs --all
+//
+// Scans:
+//   - src/solutions/*/index.html        (Vite Code Pages)
+//   - src/client/code-pages/*/index.html (Webpack Code Pages)
+//
+// Returns exit code 0 if every discovered index.html has the reset.
+// Returns exit code 1 with a list of failures otherwise.
 
-import { readFileSync, existsSync } from 'fs';
-import { resolve } from 'path';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { resolve, join } from 'path';
 
-const indexHtmlArg = process.argv[2] ?? 'index.html';
-const indexHtmlPath = resolve(process.cwd(), indexHtmlArg);
-
-if (!existsSync(indexHtmlPath)) {
-  console.error(`✗ check-html-css-reset: file not found — ${indexHtmlPath}`);
-  process.exit(1);
-}
-
-const html = readFileSync(indexHtmlPath, 'utf8');
-
-// Look for the canonical universal selector + box-sizing border-box rule.
-// Accept some whitespace + ordering variation. Reject configurations that
-// only set box-sizing on specific elements (insufficient — the rule must be
-// universal to catch every Fluent cell + descendants).
+// Same regex used by both modes — single source of truth for the contract.
 //
 // Matched patterns (any of):
 //   *, *::before, *::after { box-sizing: border-box; }
-//   * { box-sizing: border-box; }  (broader; also acceptable)
+//   * { box-sizing: border-box; }                       (broader; also acceptable)
+//   * { box-sizing: border-box; margin: 0; padding: 0; } (with sibling resets — common pattern)
 //
 // Rejected (insufficient — e.g. only html/body):
 //   html, body { box-sizing: border-box; }
-const universalReset = /\*\s*(,\s*\*::before\s*,\s*\*::after\s*)?\{\s*box-sizing\s*:\s*border-box\s*;?\s*\}/;
+//
+// The character-class `[^{}]*` lets sibling properties appear in the same rule
+// block without rejecting the match, while still requiring the universal `*`
+// selector at the start of the rule.
+const universalReset = /\*\s*(,\s*\*::before\s*,\s*\*::after\s*)?\{[^{}]*box-sizing\s*:\s*border-box[^{}]*\}/;
 
-if (!universalReset.test(html)) {
-  console.error(`✗ check-html-css-reset: ${indexHtmlPath} is missing the universal box-sizing reset.`);
+function checkOne(htmlPath) {
+  if (!existsSync(htmlPath)) {
+    return { path: htmlPath, ok: false, reason: 'file-not-found' };
+  }
+  const html = readFileSync(htmlPath, 'utf8');
+  if (!universalReset.test(html)) {
+    return { path: htmlPath, ok: false, reason: 'missing-reset' };
+  }
+  return { path: htmlPath, ok: true };
+}
+
+function printSingleFailure(htmlPath, reason) {
+  if (reason === 'file-not-found') {
+    console.error(`✗ check-html-css-reset: file not found — ${htmlPath}`);
+    return;
+  }
+  console.error(`✗ check-html-css-reset: ${htmlPath} is missing the universal box-sizing reset.`);
   console.error('');
   console.error('Add this <style> block to <head>:');
   console.error('');
@@ -60,6 +78,79 @@ if (!universalReset.test(html)) {
   console.error('Without it, every DataGrid cell renders +24px wider than its');
   console.error('declared width (12+12 padding adds to content-box) and the grid');
   console.error('overflows the page.');
+}
+
+function discoverAllSurfaceHtmls(repoRoot) {
+  const roots = [
+    join(repoRoot, 'src', 'solutions'),
+    join(repoRoot, 'src', 'client', 'code-pages'),
+  ];
+  const out = [];
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    for (const name of readdirSync(root)) {
+      const dir = join(root, name);
+      let s;
+      try {
+        s = statSync(dir);
+      } catch {
+        continue;
+      }
+      if (!s.isDirectory()) continue;
+      const indexHtml = join(dir, 'index.html');
+      if (existsSync(indexHtml)) out.push(indexHtml);
+    }
+  }
+  return out;
+}
+
+const args = process.argv.slice(2);
+
+if (args.includes('--all')) {
+  // Repo-wide mode: scan all known Code Page roots; aggregate failures.
+  // CWD here is the repo root when called from CI (`node scripts/check-html-css-reset.mjs --all`).
+  const repoRoot = process.cwd();
+  const surfaces = discoverAllSurfaceHtmls(repoRoot);
+
+  if (surfaces.length === 0) {
+    console.error('✗ check-html-css-reset --all: no Code Page index.htmls discovered.');
+    console.error(`  Searched: src/solutions/*/index.html, src/client/code-pages/*/index.html`);
+    console.error(`  CWD: ${repoRoot}`);
+    process.exit(1);
+  }
+
+  const results = surfaces.map(checkOne);
+  const failures = results.filter((r) => !r.ok);
+  const passed = results.length - failures.length;
+
+  if (failures.length > 0) {
+    console.error(`✗ check-html-css-reset --all: ${failures.length} of ${results.length} Code Page hosts FAILED.`);
+    console.error('');
+    for (const f of failures) {
+      const rel = f.path.startsWith(repoRoot) ? f.path.slice(repoRoot.length + 1) : f.path;
+      console.error(`  - ${rel} (${f.reason})`);
+    }
+    console.error('');
+    console.error('Add the canonical reset to each failing host:');
+    console.error('');
+    console.error('  *, *::before, *::after { box-sizing: border-box; }');
+    console.error('');
+    console.error('Reference: docs/guides/DATAGRID-CODE-PAGE-HOST-CONTRACT.md §2.');
+    console.error('History: surfaced 2026-06-09 by ai-spaarke-ai-workspace-UI-r1 iter-2 round 11.');
+    process.exit(1);
+  }
+
+  console.log(`✓ check-html-css-reset --all: ${passed} Code Page host(s) verified clean.`);
+  process.exit(0);
+}
+
+// Single-file mode (backward-compatible — used by per-surface build scripts).
+const indexHtmlArg = args[0] ?? 'index.html';
+const indexHtmlPath = resolve(process.cwd(), indexHtmlArg);
+const result = checkOne(indexHtmlPath);
+
+if (!result.ok) {
+  printSingleFailure(indexHtmlPath, result.reason);
   process.exit(1);
 }
 

--- a/src/client/shared/Spaarke.AI.Widgets/src/registry/register-context-widgets.ts
+++ b/src/client/shared/Spaarke.AI.Widgets/src/registry/register-context-widgets.ts
@@ -36,9 +36,7 @@ import type { ContextWidgetComponent } from '../types/widget-types';
 // expression evaluation failure, malformed registration object) does not skip
 // the registrations that follow. See safeRegister docblock + the same pattern
 // in `register-workspace-widgets.ts`.
-function safeRegisterContext(
-  ...args: Parameters<typeof registerContextWidget>
-): void {
+function safeRegisterContext(...args: Parameters<typeof registerContextWidget>): void {
   safeRegister('ContextWidget', args[0], () => registerContextWidget(...args));
 }
 

--- a/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/DocumentUploadWizardWidget.tsx
+++ b/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/DocumentUploadWizardWidget.tsx
@@ -58,10 +58,7 @@ import {
 
 import { FileUploadZone } from '@spaarke/ui-components/components/FileUpload/FileUploadZone';
 import { UploadedFileList } from '@spaarke/ui-components/components/FileUpload/UploadedFileList';
-import type {
-  IUploadedFile,
-  IFileValidationError,
-} from '@spaarke/ui-components/components/FileUpload/fileUploadTypes';
+import type { IUploadedFile, IFileValidationError } from '@spaarke/ui-components/components/FileUpload/fileUploadTypes';
 
 import type { WorkspaceWidgetProps } from '../../types/widget-types';
 import type { WidgetState } from '../../types/shared';

--- a/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/register-workspace-widgets.ts
+++ b/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/register-workspace-widgets.ts
@@ -43,9 +43,7 @@ import type { WorkspaceWidgetComponent } from '../../types/widget-types';
 // failure, missing import) would skip all subsequent registrations, leaving
 // the registry partially populated and the workspace pane rendering empty
 // widget tabs. See safeRegister docblock + brittleness-remediation-plan.md.
-function safeRegisterWidget(
-  ...args: Parameters<typeof registerWorkspaceWidget>
-): void {
+function safeRegisterWidget(...args: Parameters<typeof registerWorkspaceWidget>): void {
   safeRegister('WorkspaceWidget', args[0], () => registerWorkspaceWidget(...args));
 }
 

--- a/src/client/shared/Spaarke.Events.Components/src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx
+++ b/src/client/shared/Spaarke.Events.Components/src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx
@@ -770,34 +770,31 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
     return null;
   }, [pending.fromDate, pending.toDate]);
 
-  const applyPreset = React.useCallback(
-    (preset: 'last30' | 'last90' | 'thisYear' | 'lastYear') => {
-      const today = new Date();
-      const toIso = (d: Date) =>
-        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-      let from: Date;
-      let to: Date = today;
-      switch (preset) {
-        case 'last30':
-          from = new Date(today);
-          from.setDate(from.getDate() - 30);
-          break;
-        case 'last90':
-          from = new Date(today);
-          from.setDate(from.getDate() - 90);
-          break;
-        case 'thisYear':
-          from = new Date(today.getFullYear(), 0, 1);
-          break;
-        case 'lastYear':
-          from = new Date(today.getFullYear() - 1, 0, 1);
-          to = new Date(today.getFullYear() - 1, 11, 31);
-          break;
-      }
-      setPending(prev => ({ ...prev, fromDate: toIso(from), toDate: toIso(to) }));
-    },
-    [],
-  );
+  const applyPreset = React.useCallback((preset: 'last30' | 'last90' | 'thisYear' | 'lastYear') => {
+    const today = new Date();
+    const toIso = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    let from: Date;
+    let to: Date = today;
+    switch (preset) {
+      case 'last30':
+        from = new Date(today);
+        from.setDate(from.getDate() - 30);
+        break;
+      case 'last90':
+        from = new Date(today);
+        from.setDate(from.getDate() - 90);
+        break;
+      case 'thisYear':
+        from = new Date(today.getFullYear(), 0, 1);
+        break;
+      case 'lastYear':
+        from = new Date(today.getFullYear() - 1, 0, 1);
+        to = new Date(today.getFullYear() - 1, 11, 31);
+        break;
+    }
+    setPending(prev => ({ ...prev, fromDate: toIso(from), toDate: toIso(to) }));
+  }, []);
 
   return (
     <div className={styles.root}>
@@ -810,7 +807,7 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
             <Button
               className={mergeClasses(
                 styles.filterChipButton,
-                pending.eventTypeId ? styles.filterChipButtonActive : undefined,
+                pending.eventTypeId ? styles.filterChipButtonActive : undefined
               )}
               appearance="subtle"
               size="small"
@@ -846,7 +843,7 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
             <Button
               className={mergeClasses(
                 styles.filterChipButton,
-                pending.eventStatusValue !== null ? styles.filterChipButtonActive : undefined,
+                pending.eventStatusValue !== null ? styles.filterChipButtonActive : undefined
               )}
               appearance="subtle"
               size="small"
@@ -882,7 +879,7 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
             <Button
               className={mergeClasses(
                 styles.filterChipButton,
-                dateRangeDisplay ? styles.filterChipButtonActive : undefined,
+                dateRangeDisplay ? styles.filterChipButtonActive : undefined
               )}
               appearance="subtle"
               size="small"
@@ -898,17 +895,13 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
             <Input
               type="date"
               value={pending.fromDate}
-              onChange={(_e, data) =>
-                setPending(prev => ({ ...prev, fromDate: data.value }))
-              }
+              onChange={(_e, data) => setPending(prev => ({ ...prev, fromDate: data.value }))}
             />
             <Text className={styles.filterPopoverLabel}>To</Text>
             <Input
               type="date"
               value={pending.toDate}
-              onChange={(_e, data) =>
-                setPending(prev => ({ ...prev, toDate: data.value }))
-              }
+              onChange={(_e, data) => setPending(prev => ({ ...prev, toDate: data.value }))}
             />
             <Text className={styles.filterPopoverLabel}>Quick select</Text>
             <div className={styles.quickSelectGrid}>
@@ -930,9 +923,7 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
                 <Button
                   size="small"
                   appearance="subtle"
-                  onClick={() =>
-                    setPending(prev => ({ ...prev, fromDate: '', toDate: '' }))
-                  }
+                  onClick={() => setPending(prev => ({ ...prev, fromDate: '', toDate: '' }))}
                 >
                   Clear range
                 </Button>
@@ -947,9 +938,7 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
             <Button
               className={mergeClasses(
                 styles.filterChipButton,
-                pending.dateField && pending.dateField !== DATE_FIELD_NONE
-                  ? styles.filterChipButtonActive
-                  : undefined,
+                pending.dateField && pending.dateField !== DATE_FIELD_NONE ? styles.filterChipButtonActive : undefined
               )}
               appearance="subtle"
               size="small"
@@ -964,9 +953,7 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
             <Text className={styles.filterPopoverLabel}>Filter by Date Field</Text>
             <RadioGroup
               value={pending.dateField}
-              onChange={(_e, data) =>
-                setPending(prev => ({ ...prev, dateField: data.value }))
-              }
+              onChange={(_e, data) => setPending(prev => ({ ...prev, dateField: data.value }))}
             >
               {DATE_FIELDS.map(f => (
                 <Radio key={f.value || 'none'} value={f.value} label={f.label} />
@@ -988,13 +975,7 @@ const CalendarWorkspaceLayout: React.FC<ICalendarWorkspaceLayoutProps> = ({ init
           <Tooltip content={calendarCollapsed ? 'Show calendar' : 'Hide calendar'} relationship="label">
             <Button
               appearance={calendarCollapsed ? 'subtle' : 'primary'}
-              icon={
-                calendarCollapsed ? (
-                  <CalendarLtr24Regular />
-                ) : (
-                  <CalendarLtr24Filled />
-                )
-              }
+              icon={calendarCollapsed ? <CalendarLtr24Regular /> : <CalendarLtr24Filled />}
               onClick={toggleCollapsed}
               aria-expanded={!calendarCollapsed}
               aria-label={calendarCollapsed ? 'Show calendar' : 'Hide calendar'}

--- a/src/client/shared/Spaarke.UI.Components/src/components/AppErrorBoundary/AppErrorBoundary.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/AppErrorBoundary/AppErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 import {
   Body1,
   Button,
@@ -9,9 +9,9 @@ import {
   shorthands,
   tokens,
   webLightTheme,
-} from "@fluentui/react-components";
-import { ArrowClockwise20Regular, ErrorCircle24Regular } from "@fluentui/react-icons";
-import { reportClientError } from "../../services/reportClientError";
+} from '@fluentui/react-components';
+import { ArrowClockwise20Regular, ErrorCircle24Regular } from '@fluentui/react-icons';
+import { reportClientError } from '../../services/reportClientError';
 
 export interface AppErrorBoundaryProps {
   /** Logical name shown to the user when a crash is caught — e.g. "SpaarkeAi", "Daily Briefing". */
@@ -29,28 +29,28 @@ interface AppErrorBoundaryState {
 
 const useStyles = makeStyles({
   root: {
-    minHeight: "100vh",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
+    minHeight: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     ...shorthands.padding(tokens.spacingVerticalXXL, tokens.spacingHorizontalXXL),
     backgroundColor: tokens.colorNeutralBackground1,
   },
   panel: {
-    maxWidth: "640px",
-    width: "100%",
-    display: "flex",
-    flexDirection: "column",
+    maxWidth: '640px',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
     rowGap: tokens.spacingVerticalM,
     ...shorthands.padding(tokens.spacingVerticalXL, tokens.spacingHorizontalXL),
-    ...shorthands.border("1px", "solid", tokens.colorNeutralStroke1),
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     backgroundColor: tokens.colorNeutralBackground2,
     boxShadow: tokens.shadow8,
   },
   header: {
-    display: "flex",
-    alignItems: "center",
+    display: 'flex',
+    alignItems: 'center',
     columnGap: tokens.spacingHorizontalS,
     color: tokens.colorPaletteRedForeground1,
   },
@@ -64,12 +64,12 @@ const useStyles = makeStyles({
     fontFamily: tokens.fontFamilyMonospace,
     fontSize: tokens.fontSizeBase200,
     color: tokens.colorNeutralForeground3,
-    overflow: "auto",
-    maxHeight: "240px",
-    whiteSpace: "pre-wrap",
+    overflow: 'auto',
+    maxHeight: '240px',
+    whiteSpace: 'pre-wrap',
   },
   actions: {
-    display: "flex",
+    display: 'flex',
     columnGap: tokens.spacingHorizontalS,
     marginTop: tokens.spacingVerticalS,
   },
@@ -95,11 +95,11 @@ const ErrorFallback: React.FC<{
           <Subtitle1>{surfaceName} encountered an error</Subtitle1>
         </div>
         <Body1 className={styles.message}>
-          The page could not be displayed. Reload to try again. If the problem persists, contact
-          support with the message below.
+          The page could not be displayed. Reload to try again. If the problem persists, contact support with the
+          message below.
         </Body1>
         <Text className={styles.message} weight="semibold">
-          {error.message || "Unknown error"}
+          {error.message || 'Unknown error'}
         </Text>
         <div className={styles.actions}>
           <Button appearance="primary" icon={<ArrowClockwise20Regular />} onClick={handleReload}>
@@ -108,8 +108,8 @@ const ErrorFallback: React.FC<{
           <Button appearance="secondary" onClick={resetError}>
             Try again
           </Button>
-          <Button appearance="subtle" onClick={() => setShowDetails((v) => !v)}>
-            {showDetails ? "Hide details" : "Show details"}
+          <Button appearance="subtle" onClick={() => setShowDetails(v => !v)}>
+            {showDetails ? 'Hide details' : 'Show details'}
           </Button>
         </div>
         {showDetails && error.stack && <pre className={styles.details}>{error.stack}</pre>}
@@ -137,10 +137,7 @@ const ErrorFallback: React.FC<{
  *     </AppErrorBoundary>
  *   );
  */
-export class AppErrorBoundary extends React.Component<
-  AppErrorBoundaryProps,
-  AppErrorBoundaryState
-> {
+export class AppErrorBoundary extends React.Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
   state: AppErrorBoundaryState = { error: null };
 
   static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
@@ -149,17 +146,14 @@ export class AppErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     reportClientError(error, {
-      scope: "AppErrorBoundary",
+      scope: 'AppErrorBoundary',
       surface: this.props.surfaceName,
       componentStack: errorInfo.componentStack ?? undefined,
     });
     try {
       this.props.onError?.(error, errorInfo);
     } catch (telemetryErr) {
-      console.warn(
-        `[AppErrorBoundary:${this.props.surfaceName}] onError callback threw:`,
-        telemetryErr,
-      );
+      console.warn(`[AppErrorBoundary:${this.props.surfaceName}] onError callback threw:`, telemetryErr);
     }
   }
 
@@ -177,11 +171,7 @@ export class AppErrorBoundary extends React.Component<
       // because the boundary may fire before theme resolution completes.
       return (
         <FluentProvider theme={webLightTheme}>
-          <ErrorFallback
-            surfaceName={this.props.surfaceName}
-            error={this.state.error}
-            resetError={this.resetError}
-          />
+          <ErrorFallback surfaceName={this.props.surfaceName} error={this.state.error} resetError={this.resetError} />
         </FluentProvider>
       );
     }

--- a/src/client/shared/Spaarke.UI.Components/src/components/AppErrorBoundary/index.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/AppErrorBoundary/index.ts
@@ -1,2 +1,2 @@
-export { AppErrorBoundary } from "./AppErrorBoundary";
-export type { AppErrorBoundaryProps } from "./AppErrorBoundary";
+export { AppErrorBoundary } from './AppErrorBoundary';
+export type { AppErrorBoundaryProps } from './AppErrorBoundary';

--- a/src/client/shared/Spaarke.UI.Components/src/components/DataGrid/DataGrid.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/DataGrid/DataGrid.tsx
@@ -1044,8 +1044,7 @@ export const DataGrid: React.FC<DataGridProps> = props => {
     // Reserve space for selection cell (~44px when multiselect), gridScroll
     // horizontal padding (24px = 12+12), and a small scrollbar safety
     // buffer (10px). Anything left over is shared across the columns.
-    const selectionWidth =
-      resolved && resolved.behavior.selectionMode === 'multi' ? 44 : 0;
+    const selectionWidth = resolved && resolved.behavior.selectionMode === 'multi' ? 44 : 0;
     // ai-spaarke-ai-workspace-UI-r1 iter 2 round 11 (2026-06-09):
     // Subtract per-cell horizontal padding (~24px = 12+12 spacingHorizontalM)
     // from each column's available width. Without this, hosts that haven't
@@ -1059,10 +1058,7 @@ export const DataGrid: React.FC<DataGridProps> = props => {
     // subtraction is the defensive layer for any future surface that misses
     // it.
     const perColPaddingReserve = visibleColumns.length * 24;
-    const available = Math.max(
-      0,
-      containerWidth - selectionWidth - 24 - 10 - perColPaddingReserve,
-    );
+    const available = Math.max(0, containerWidth - selectionWidth - 24 - 10 - perColPaddingReserve);
     // Bidirectional scale: when `available` < `baseSum`, scale < 1 shrinks
     // the columns to fit (down to each column's minimum); when `available`
     // > `baseSum`, scale > 1 expands them to fill. Skip the no-op when the

--- a/src/client/shared/Spaarke.UI.Components/src/components/WidgetErrorBoundary/WidgetErrorBoundary.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/WidgetErrorBoundary/WidgetErrorBoundary.tsx
@@ -1,14 +1,7 @@
-import * as React from "react";
-import {
-  Button,
-  Caption1,
-  Text,
-  makeStyles,
-  shorthands,
-  tokens,
-} from "@fluentui/react-components";
-import { ArrowClockwise16Regular, ErrorCircle20Regular } from "@fluentui/react-icons";
-import { reportClientError } from "../../services/reportClientError";
+import * as React from 'react';
+import { Button, Caption1, Text, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { ArrowClockwise16Regular, ErrorCircle20Regular } from '@fluentui/react-icons';
+import { reportClientError } from '../../services/reportClientError';
 
 export interface WidgetErrorBoundaryProps {
   /** Widget type string — e.g. "matters-list", "calendar", "BudgetDashboard". Surfaced in fallback + telemetry. */
@@ -30,25 +23,25 @@ interface WidgetErrorBoundaryState {
 
 const useStyles = makeStyles({
   root: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-start",
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
     rowGap: tokens.spacingVerticalS,
     ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalM),
-    ...shorthands.border("1px", "solid", tokens.colorPaletteRedBorder1),
+    ...shorthands.border('1px', 'solid', tokens.colorPaletteRedBorder1),
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
     backgroundColor: tokens.colorPaletteRedBackground1,
     color: tokens.colorPaletteRedForeground2,
     margin: tokens.spacingVerticalM,
-    maxWidth: "560px",
+    maxWidth: '560px',
   },
   header: {
-    display: "flex",
-    alignItems: "center",
+    display: 'flex',
+    alignItems: 'center',
     columnGap: tokens.spacingHorizontalS,
   },
   actions: {
-    display: "flex",
+    display: 'flex',
     columnGap: tokens.spacingHorizontalS,
   },
   message: {
@@ -68,14 +61,9 @@ const InlineFallback: React.FC<{
         <ErrorCircle20Regular />
         <Text weight="semibold">{displayName} failed to load</Text>
       </div>
-      <Caption1 className={styles.message}>{error.message || "Unknown error"}</Caption1>
+      <Caption1 className={styles.message}>{error.message || 'Unknown error'}</Caption1>
       <div className={styles.actions}>
-        <Button
-          appearance="primary"
-          size="small"
-          icon={<ArrowClockwise16Regular />}
-          onClick={resetError}
-        >
+        <Button appearance="primary" size="small" icon={<ArrowClockwise16Regular />} onClick={resetError}>
           Retry
         </Button>
       </div>
@@ -105,10 +93,7 @@ const InlineFallback: React.FC<{
  *     <Widget data={tab.widgetData} widgetType={tab.widgetType} />
  *   </WidgetErrorBoundary>
  */
-export class WidgetErrorBoundary extends React.Component<
-  WidgetErrorBoundaryProps,
-  WidgetErrorBoundaryState
-> {
+export class WidgetErrorBoundary extends React.Component<WidgetErrorBoundaryProps, WidgetErrorBoundaryState> {
   state: WidgetErrorBoundaryState = { error: null };
 
   static getDerivedStateFromError(error: Error): WidgetErrorBoundaryState {
@@ -117,7 +102,7 @@ export class WidgetErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     reportClientError(error, {
-      scope: "WidgetErrorBoundary",
+      scope: 'WidgetErrorBoundary',
       surface: this.props.surface,
       widgetType: this.props.widgetType,
       componentStack: errorInfo.componentStack ?? undefined,
@@ -125,10 +110,7 @@ export class WidgetErrorBoundary extends React.Component<
     try {
       this.props.onError?.(error, errorInfo);
     } catch (telemetryErr) {
-      console.warn(
-        `[WidgetErrorBoundary:${this.props.widgetType}] onError callback threw:`,
-        telemetryErr,
-      );
+      console.warn(`[WidgetErrorBoundary:${this.props.widgetType}] onError callback threw:`, telemetryErr);
     }
   }
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/WidgetErrorBoundary/index.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/WidgetErrorBoundary/index.ts
@@ -1,2 +1,2 @@
-export { WidgetErrorBoundary } from "./WidgetErrorBoundary";
-export type { WidgetErrorBoundaryProps } from "./WidgetErrorBoundary";
+export { WidgetErrorBoundary } from './WidgetErrorBoundary';
+export type { WidgetErrorBoundaryProps } from './WidgetErrorBoundary';

--- a/src/client/shared/Spaarke.UI.Components/src/services/AppInsightsService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/services/AppInsightsService.ts
@@ -115,19 +115,14 @@ class AppInsightsServiceImpl {
   public trackException(
     error: Error,
     properties?: Record<string, unknown>,
-    severity: SeverityLevel = SeverityLevel.Error,
+    severity: SeverityLevel = SeverityLevel.Error
   ): void {
     if (!this._initialized || !this._appInsights) {
-      console.warn(
-        `[AppInsightsService] trackException('${error.message}') called before initialize() — dropped.`,
-      );
+      console.warn(`[AppInsightsService] trackException('${error.message}') called before initialize() — dropped.`);
       return;
     }
     try {
-      this._appInsights.trackException(
-        { exception: error, severityLevel: severity },
-        properties,
-      );
+      this._appInsights.trackException({ exception: error, severityLevel: severity }, properties);
     } catch (err) {
       console.warn('[AppInsightsService] trackException failed:', err);
     }

--- a/src/client/shared/Spaarke.UI.Components/src/services/reportClientError.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/services/reportClientError.ts
@@ -62,15 +62,8 @@ export function setClientErrorTelemetryHook(hook: TelemetryHook | null): void {
  *     componentStack: errorInfo.componentStack ?? undefined,
  *   });
  */
-export function reportClientError(
-  error: Error,
-  context: ClientErrorContext,
-): void {
-  console.error(
-    `[${context.scope}${context.surface ? `:${context.surface}` : ''}]`,
-    error,
-    context,
-  );
+export function reportClientError(error: Error, context: ClientErrorContext): void {
+  console.error(`[${context.scope}${context.surface ? `:${context.surface}` : ''}]`, error, context);
 
   if (_telemetryHook) {
     try {

--- a/src/client/shared/Spaarke.UI.Components/src/utils/safeRegister.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/utils/safeRegister.ts
@@ -1,4 +1,4 @@
-import { reportClientError } from "../services/reportClientError";
+import { reportClientError } from '../services/reportClientError';
 
 /**
  * safeRegister — defensive wrapper for side-effect registration calls.
@@ -34,16 +34,12 @@ import { reportClientError } from "../services/reportClientError";
  * @param action             - The registration call (typically a thunk).
  * @returns                    The action's return value, or undefined if it threw.
  */
-export function safeRegister<T>(
-  registryName: string,
-  registrationLabel: string,
-  action: () => T,
-): T | undefined {
+export function safeRegister<T>(registryName: string, registrationLabel: string, action: () => T): T | undefined {
   try {
     return action();
   } catch (err) {
     reportClientError(err instanceof Error ? err : new Error(String(err)), {
-      scope: "safeRegister",
+      scope: 'safeRegister',
       registryName,
       registrationLabel,
     });

--- a/src/solutions/CalendarSidePane/src/App.tsx
+++ b/src/solutions/CalendarSidePane/src/App.tsx
@@ -30,7 +30,7 @@ import {
 import {
   CalendarSection,
   type CalendarFilterOutput,
-} from "./components";
+} from "@spaarke/events-components";
 
 // Pane id MUST match the host EventsPage's sidePaneFilter.paneId
 // (see src/solutions/EventsPage/src/config/eventConfig.ts → CALENDAR_PANE_ID).

--- a/src/solutions/LegalWorkspace/src/components/GetStarted/getStartedConfig.ts
+++ b/src/solutions/LegalWorkspace/src/components/GetStarted/getStartedConfig.ts
@@ -6,6 +6,7 @@ import {
   SearchRegular,
   MailRegular,
   CalendarAddRegular,
+  ClipboardTaskAddRegular,
 } from "@fluentui/react-icons";
 import type { FluentIcon } from "@fluentui/react-icons";
 
@@ -54,6 +55,12 @@ export const ACTION_CARD_CONFIGS: IActionCardConfig[] = [
     label: "Assign Work",
     icon: PersonAddRegular,
     ariaLabel: "Create a new work assignment",
+  },
+  {
+    id: "create-new-todo",
+    label: "Create New To Do",
+    icon: ClipboardTaskAddRegular,
+    ariaLabel: "Create a new To Do",
   },
   {
     id: "summarize-new-files",

--- a/src/solutions/LegalWorkspace/src/sections/getStarted.registration.ts
+++ b/src/solutions/LegalWorkspace/src/sections/getStarted.registration.ts
@@ -21,10 +21,11 @@ import { ACTION_CARD_CONFIGS } from "../components/GetStarted/getStartedConfig";
 /**
  * Section registration for Get Started (action-cards).
  *
- * The factory wires all 7 card click handlers using `ctx.onOpenWizard`:
+ * The factory wires all 8 card click handlers using `ctx.onOpenWizard`:
  *   - create-new-matter       → sprk_creatematterwizard
  *   - create-new-project      → sprk_createprojectwizard
  *   - assign-to-counsel       → sprk_createworkassignmentwizard
+ *   - create-new-todo         → sprk_createtodowizard
  *   - summarize-new-files     → sprk_summarizefileswizard
  *   - find-similar            → sprk_findsimilar
  *   - send-email-message      → sprk_playbooklibrary (intent=email-compose)
@@ -57,6 +58,8 @@ export const getStartedRegistration: SectionRegistration = {
         ctx.onOpenWizard("sprk_createprojectwizard"),
       "assign-to-counsel": () =>
         ctx.onOpenWizard("sprk_createworkassignmentwizard"),
+      "create-new-todo": () =>
+        ctx.onOpenWizard("sprk_createtodowizard"),
       "summarize-new-files": () =>
         ctx.onOpenWizard("sprk_summarizefileswizard"),
       "find-similar": () =>
@@ -86,7 +89,7 @@ export const getStartedRegistration: SectionRegistration = {
       cards,
       onCardClick,
       toolbar,
-      maxVisible: 4,
+      maxVisible: 5,
       style: {},
     };
   },


### PR DESCRIPTION
## Summary

Three fast-follow items from `ai-spaarke-ai-workspace-UI-r1`'s
[`followup-backlog.md`](projects/ai-spaarke-ai-workspace-UI-r1/notes/followup-backlog.md),
bundled because each is small + mechanical + the three slices are independent.

- **§7 CalendarSidePane orphan** (`3baf44e48`) — App.tsx imported `CalendarSection` from `./components` which was deleted by the R4 hoist (`dfabe436a`). One-line swap to `@spaarke/events-components` (same exports). Builds clean, deployed to spaarkedev1.
- **§4 CreateTodoWizard discoverability** (`dbcd94c8e`) — Added "Create New To Do" action card at position 4 in `getStartedConfig.ts` calling `ctx.onOpenWizard("sprk_createtodowizard")`. Bumped `maxVisible` 4→5 so the new card stays in the default visible set without demoting "Summarize New File(s)" to the expand drawer. Deployed SpaarkeAi.
- **§8 CSS reset CI gate (Option A)** (`49225c32f`) — Extended `scripts/check-html-css-reset.mjs` with a `--all` mode that auto-discovers all Code Page hosts (`src/solutions/*/index.html` + `src/client/code-pages/*/index.html`) and aggregates failures. New top-level workflow `.github/workflows/css-reset-gate.yml` runs the check on every PR + master push that touches a Code Page index.html or the script itself. Also loosened the script's regex (`[^{}]*` around `box-sizing: border-box`) to accept sibling resets like `margin: 0; padding: 0;` in the same rule block — surfaced because 5 hosts (DocumentUploadWizard + 4 webpack code pages) had the reset already but with siblings the original strict regex rejected. Verified clean against all 26 discovered hosts.

## Deployment status

| Item | Web resource | Deployed | Size |
|---|---|---|---|
| §7 | `sprk_calendarsidepane.html` | ✅ spaarkedev1 | 1185 KB |
| §4 | `sprk_spaarkeai` | ✅ spaarkedev1 | 3704 KB |
| §8 | (CI only) | n/a | n/a |

Both deploys went from this branch's commit state (not master). After merge, no
additional deploy needed unless another parallel branch overwrites `sprk_spaarkeai`
in between (see r6 coordination notes).

## Test plan

- [ ] CI: \`CSS Reset Gate\` workflow passes on this PR
- [ ] Manual: open SpaarkeAi in spaarkedev1, confirm \"Create New To Do\" action card appears in Get Started (position 4 of 5 visible)
- [ ] Manual: click \"Create New To Do\" card → CreateTodoWizard opens
- [ ] Manual: CalendarSidePane no longer build-broken (`cd src/solutions/CalendarSidePane && npm run build` succeeds)
- [ ] (Optional) Confirm gate fires on PR touching any `index.html` — e.g. break the SpaarkeAi reset in a draft PR to verify the workflow fails as expected

## What's deferred

The HIGH-severity items from the same backlog are NOT in this PR:
- §1 modal-preview standard for all dataset grids (needs new project)
- §3 Find Similar 403 (needs Dataverse permission grant from operator)
- §5 Summarize Files Wizard bugs (need operator to capture 400 response body + create-Project repro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)