### PR TITLE
feat(multi-container-multi-index-r1): wizard lookup cascade for sprk_ai_search_index

### DIFF
--- a/projects/spaarke-multi-container-multi-index-r1/notes/handoffs/RESUME-2026-06-10-phase-g-post-merge.md
+++ b/projects/spaarke-multi-container-multi-index-r1/notes/handoffs/RESUME-2026-06-10-phase-g-post-merge.md
@@ -1,0 +1,208 @@
+# 🚦 RESUME POINT — Phase G post-merge (2026-06-10)
+
+> **Created**: 2026-06-10 (post-PR-#369-merge, pre-compaction)
+> **Worktree**: `C:/code_files/spaarke-wt-spaarke-multi-container-multi-index-r1`
+> **Branch on disk**: `master` @ `254302259` (sync with origin: 0/0)
+> **PR**: [#369](https://github.com/spaarke-dev/spaarke/pull/369) — **MERGED** via squash to master as `254302259`
+> **Live deploys**: BFF + PCF v1.1.76 + `sprk_semanticsearch` code page all live in `spaarkedev1`
+
+---
+
+## TL;DR
+
+Phase G code work is **done and merged**. The worktree is on master. What remains:
+
+1. **Manual UAT** (4 H-phase tasks + 2 G-phase verifications)
+2. **2 bugs found during UAT** that need follow-up (not on the original task list)
+3. **24–48hr soak** then task 110 cleanup
+4. **Task 111 wrap-up** (lessons + runbook + pattern doc)
+5. **TASK-INDEX status flips** for 100/103/105/109 (work done; just not marked ✅)
+
+---
+
+## Current worktree state
+
+| Item | Value |
+|---|---|
+| Worktree path | `C:/code_files/spaarke-wt-spaarke-multi-container-multi-index-r1` |
+| Current branch | `master` |
+| HEAD | `254302259` (PR #369 squash-merge) |
+| origin/master | `254302259` (in sync 0/0) |
+| Work branch `work/spaarke-multi-container-multi-index-r1` | Still exists locally at `c8a8cc0a1` (+1 CI-fix commit ahead of master; pushed to origin) |
+| Uncommitted | `.husky/_/*` only — husky-managed git hooks, **ignore** (not feature work) |
+
+**The `c8a8cc0a1` commit on the work branch** is a CI-only fix added post-merge ("build Spaarke.SdapClient in CI before UI.Components tsc"). Not in master. Likely the merge coordinator will handle separately.
+
+---
+
+## ✅ What's been done
+
+### Deploys live in dev (`spaarkedev1.crm.dynamics.com` + `spaarke-bff-dev.azurewebsites.net`)
+
+| Component | Version | Includes |
+|---|---|---|
+| BFF API | latest (post-merge) | FetchXml link-entity resolver + `DataverseAllowedIndexesProvider` (cached) + ChunkIndex-nullable hotfix |
+| PCF `sprk_Sprk.SemanticSearchControl` | **v1.1.76** | Lookup resolution via `context.webAPI` with correct `sprk_AI_Search_Index` PascalCase nav property |
+| Code page `sprk_semanticsearch` | latest | Side-pane redesign: Search Index dropdown + relocated Threshold/Mode + InfoPopover + Document-target host-context-preserve hotfix |
+| Data | — | 8 `sprk_aisearchindex` catalog rows + 196 records migrated text → lookup |
+
+### Schema/data state (Dataverse `spaarkedev1`)
+
+- `sprk_aisearchindex` table has 7+3 columns including new `sprk_targetentitytype` Choice
+- 8 active rows: Development Files 1/2 (Document target), Matters/Projects/Invoices/Events/Work Assignments/All Records (record target)
+- `sprk_ai_search_index` lookup column exists on 7 entities: businessunit, sprk_matter, sprk_project, sprk_invoice, sprk_event, sprk_workassignment, sprk_document
+- 196 records have lookup populated (BU: 2, Matter: 15, Project: 3, WorkAssignment: 2, Document: 174). Invoice + Event had 0 text-set records → 0 migrations needed.
+
+### App Service config (`spaarke-bff-dev`)
+
+`AiSearch__AllowedIndexes__0=spaarke-file-index` + `AiSearch__AllowedIndexes__1=spaarke-knowledge-index-v2` — still in place as text-fallback for the BFF allow-list (will remove in task 110 post-soak).
+
+---
+
+## 🔲 Outstanding work (in priority order)
+
+### A. TASK-INDEX status flips (5 min, low-risk)
+
+Update [`projects/spaarke-multi-container-multi-index-r1/tasks/TASK-INDEX.md`](../../../tasks/TASK-INDEX.md):
+
+| Task | Current status | Should be | Note |
+|---|---|---|---|
+| 100 | 🔄 | ✅ | All 7 lookup columns added |
+| 103 | 🔄 | ✅ | BFF deployed; tests green; App Insights smoke can verify post-UAT |
+| 105 | 🔲 | ✅ | User confirmed field mapping created earlier (BU→Matter etc.) |
+| 109 | 🔄 | ✅ | Code page deployed; e2e UAT can verify alongside H-phase smoke |
+
+### B. UAT smoke tests (H phase — manual)
+
+| Task | Verification | Required |
+|---|---|---|
+| 071 | Wizards smoke — MCP-verify both fields populated on Matter/Project/Invoice/Event/WorkAssignment create | Quick MCP query post-create |
+| 072 | PCF smoke on Protected Matter (BFF log verification) | Open a Matter, run search, check App Insights logs |
+| 073 | Filter-parity walkthrough (PCF vs code page side-by-side) | Compare PCF panel ↔ code page modal results |
+| 074 | BU-change coexistence proof (INV-3) | Confirm BU change doesn't break existing record lookups |
+
+### C. 2 bugs found during UAT (need follow-up work)
+
+#### Bug C1: "Unknown Matter" on returned docs
+**Symptom**: Search Index="Development Files 1" Matter (with sprk_ai_search_index → spaarke-knowledge-index-v2) returns 9 docs all displaying "Unknown Matter" in the Parent Entity column.
+
+**Root cause investigation needed**: BFF's `SearchAssociatedOnlyAsync.MapDocumentEntityToSearchResult` reads `doc.MatterName` for `parentName`. If this field is null/empty on the underlying `sprk_document` records, the code page falls back to "Unknown Matter" display. Two possibilities:
+1. Source `sprk_document` records don't have `_sprk_matter_value` populated as expected
+2. The BFF mapping reads the wrong field name (case sensitivity? typo?)
+
+**File to investigate**: `src/server/api/Sprk.Bff.Api/Services/Ai/SemanticSearch/SemanticSearchService.cs` (`MapDocumentEntityToSearchResult` method)
+
+#### Bug C2: Matter/Project/Invoice/Event/WorkAssignment dropdown rows don't work
+**Symptom**: Selecting a non-Document target (e.g., "Matters" or "Projects") in the dropdown sends `scope='entity'` to the BFF without an `entityId`. BFF rejects with 400 `EntityIdRequired`.
+
+**Root cause**: The hotfix in App.tsx (Document-target preserve-host-context) only covers `fragment.entityType === 'document'`. Records-target rows still fall through to the original (broken) fragment path.
+
+**Fix needed**: Map records-target dropdown selections to:
+- `scope='all'` (tenant-wide)
+- `filters.entityTypes=[<normalized-label>]` (e.g., `['matter']`)
+- `searchIndexName=<row's index name>`
+
+**Files to change**:
+- `src/client/code-pages/SemanticSearch/src/services/targetEntityNormalize.ts` — change `buildSearchRequestFragment` shape for records targets
+- `src/client/code-pages/SemanticSearch/src/hooks/useSemanticSearch.ts` — update request body construction
+- Possibly `useRecordSearch.ts` too
+
+### D. Soak (24–48hr) + post-soak cleanup
+
+**Task 110** (FULL rigor — destructive operations):
+1. Monitor App Insights for `PhaseG.TextFallback` warnings → expected zero post-migration
+2. After clean soak:
+   - Drop text-to-text field mappings (inventory in `notes/phase-g/field-mappings-added.md` — not yet created)
+   - Drop `sprk_searchindexname` text column from 7 entities
+   - Remove BFF text-fallback code (`SearchIndexNameResolver` fallback branches)
+   - Remove `AiSearch__AllowedIndexes__*` App Service config
+3. Redeploy BFF without fallback path
+
+### E. Phase G wrap-up (task 111)
+
+- Write `projects/spaarke-multi-container-multi-index-r1/notes/phase-g/lessons-learned.md`
+- Update `docs/guides/MULTI-CONTAINER-MULTI-INDEX-OPERATOR-RUNBOOK.md` (already exists from task 060) with sprk_aisearchindex management section
+- Create `.claude/patterns/ai/semantic-vs-relational-views.md` (the "files = AI Search; documents = Dataverse views; no mixing" pattern)
+- Find Similar UAT (verify intra-index works, cross-index returns empty gracefully)
+
+---
+
+## 🚫 Intentionally deferred
+
+| Task | Reason |
+|---|---|
+| 023 — CreateInvoiceWizard | Intentionally deferred per project decision |
+
+---
+
+## 📍 How to resume
+
+### Option 1: Start a new branch off master in this worktree
+```bash
+cd c:/code_files/spaarke-wt-spaarke-multi-container-multi-index-r1
+git checkout master   # Already on master
+git pull origin master
+git checkout -b work/spaarke-multi-container-multi-index-r1-phase-g-followups
+```
+Then tackle items in priority order (A → B → C1/C2 → D → E).
+
+### Option 2: Resume on the old work branch
+The work branch `work/spaarke-multi-container-multi-index-r1` is still there at `c8a8cc0a1`. If the merge coordinator merges that CI-fix commit separately, you can:
+```bash
+git checkout work/spaarke-multi-container-multi-index-r1
+git pull origin work/spaarke-multi-container-multi-index-r1
+```
+
+### Option 3: Just close the project
+If you decide UAT + soak + cleanup are out of scope for this session, the worktree is at a clean master state. Phase G is functionally shipped via PR #369.
+
+---
+
+## Key files for resume
+
+| Purpose | Path |
+|---|---|
+| This resume point | `projects/spaarke-multi-container-multi-index-r1/notes/handoffs/RESUME-2026-06-10-phase-g-post-merge.md` |
+| Phase G spec | `projects/spaarke-multi-container-multi-index-r1/notes/phase-g/spec.md` |
+| TASK-INDEX | `projects/spaarke-multi-container-multi-index-r1/tasks/TASK-INDEX.md` |
+| Latest hotfix #1 commit | `2b74eaf04` (squashed into 254302259) |
+| BFF resolver | `src/server/api/Sprk.Bff.Api/Services/Ai/SearchIndexNameResolver.cs` |
+| BFF allow-list provider | `src/server/api/Sprk.Bff.Api/Services/Ai/DataverseAllowedIndexesProvider.cs` |
+| Code page dropdown | `src/client/code-pages/SemanticSearch/src/services/aiSearchIndexService.ts` |
+| Code page normalize util | `src/client/code-pages/SemanticSearch/src/services/targetEntityNormalize.ts` |
+| PCF v1.1.76 resolver | `src/client/pcf/SemanticSearchControl/SemanticSearchControl/services/SearchIndexResolver.ts` |
+| Catalog rows (8 active) | Dataverse `sprk_aisearchindex` table |
+| Migration script | `scripts/phase-g-lookup-migration/Migrate-SearchIndexLookup.ps1` |
+
+---
+
+## Test results (post-merge baseline)
+
+- BFF: **6255 pass / 0 fail / 109 skipped** (`dotnet test tests/unit/Sprk.Bff.Api.Tests/`)
+- Prettier: clean across `src/client/**/*.{ts,tsx}`
+- CI on PR #369 (commit `9cde6a145` pre-squash): all green except Code Quality which was still running at merge time
+
+---
+
+## Quick diagnostic commands
+
+```bash
+# Verify BFF healthy
+curl https://spaarke-bff-dev.azurewebsites.net/healthz
+
+# Check App Insights for PhaseG.TextFallback warnings
+az monitor app-insights query --app 6a76b012-46d9-412f-b4ab-4905658a9559 \
+  --analytics-query "traces | where timestamp > ago(24h) | where message has 'PhaseG.TextFallback' | count"
+
+# Verify lookup migration counts (MCP via Claude)
+SELECT (SELECT COUNT(*) FROM sprk_matter WHERE sprk_searchindexname IS NOT NULL) AS text_set,
+       (SELECT COUNT(*) FROM sprk_matter WHERE sprk_ai_search_index IS NOT NULL) AS lookup_set;
+# Both should be 15 (or equal); both should be 0 means nothing was migrated
+
+# Re-run migration if needed (idempotent)
+pwsh -File scripts/phase-g-lookup-migration/Migrate-SearchIndexLookup.ps1 -DataverseUrl https://spaarkedev1.crm.dynamics.com -Apply
+```
+
+---
+
+*If returning here cold: read this file first, then `tasks/TASK-INDEX.md`, then the appropriate section above. Spec lives in `notes/phase-g/spec.md` for design context.*

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateEventWizard/eventService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateEventWizard/eventService.ts
@@ -273,6 +273,24 @@ export class EventService {
             '[EventService] User BU has neither sprk_containerid nor sprk_searchindexname — leaving payload fields unset; BFF tenant-default chain will apply.'
           );
         }
+        // Phase G: cascade BU's `sprk_ai_search_index` lookup onto the new Event.
+        if (buDefaults.searchIndexId) {
+          const aiNavProp = _findNavProp(navProps, 'sprk_aisearchindex');
+          if (aiNavProp) {
+            entity[`${aiNavProp}@odata.bind`] = `/sprk_aisearchindexes(${buDefaults.searchIndexId})`;
+            console.info(
+              '[EventService] Cascaded sprk_ai_search_index from user BU:',
+              buDefaults.searchIndexId,
+              '(BU:',
+              buDefaults.businessUnitId,
+              ')'
+            );
+          } else {
+            console.warn(
+              '[EventService] sprk_ai_search_index nav-prop not discovered on sprk_event — lookup cascade skipped.'
+            );
+          }
+        }
       } else {
         console.warn(
           '[EventService] Xrm.Utility.getUserId() unavailable — skipping BU cascade for sprk_containerid / sprk_searchindexname. BFF tenant-default will apply server-side.'

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateMatterWizard/matterService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateMatterWizard/matterService.ts
@@ -301,6 +301,17 @@ export class MatterService {
         guid: form.assignedOutsideCounselId,
       });
 
+    // Phase G (spaarke-multi-container-multi-index-r1): cascade BU's `sprk_ai_search_index`
+    // lookup onto the new Matter. Nav-prop discovered as `sprk_AI_Search_Index` (PascalCase).
+    // INV-5 moot — Matter create form has no field for the user to override this.
+    if (cascadeDefaults?.searchIndexId) {
+      lookups.push({
+        col: 'sprk_ai_search_index',
+        entitySet: 'sprk_aisearchindexes',
+        guid: cascadeDefaults.searchIndexId,
+      });
+    }
+
     for (const lk of lookups) {
       const navProp = navPropMap[lk.col] ?? lk.col;
       entity[`${navProp}@odata.bind`] = `/${lk.entitySet}(${lk.guid})`;

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateProjectWizard/projectService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateProjectWizard/projectService.ts
@@ -375,6 +375,16 @@ export class ProjectService {
       });
     }
 
+    // Phase G: cascade BU's `sprk_ai_search_index` lookup onto the new Project.
+    if (cascadeDefaults?.searchIndexId) {
+      lookups.push({
+        referencedEntity: 'sprk_aisearchindex',
+        entitySet: 'sprk_aisearchindexes',
+        guid: cascadeDefaults.searchIndexId,
+        label: 'AI Search Index',
+      });
+    }
+
     for (const lk of lookups) {
       const navProp = _findNavProp(navProps, lk.referencedEntity, lk.columnHint);
       if (navProp) {

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateWorkAssignmentWizard/workAssignmentService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateWorkAssignmentWizard/workAssignmentService.ts
@@ -459,25 +459,6 @@ export class WorkAssignmentService {
       entity['sprk_containerid'] = this._containerId;
     }
 
-    // FR-WIZ-04: Cascade `sprk_containerid` + `sprk_searchindexname` from the current user's
-    // owning Business Unit. INV-5 guards each field independently — values set by the caller
-    // above (or pre-seeded on `form`) are preserved. If the user's BU has either field unset,
-    // the corresponding payload field is left untouched and the BFF tenant-default chain takes
-    // over server-side (e.g. Spaarke Dev 1 / Test 1 per Phase A.5 ordering).
-    try {
-      const currentUserId = _getCurrentUserId();
-      if (currentUserId) {
-        // IDataService is a structural superset of IWebApiLike (retrieveRecord, retrieveMultipleRecords).
-        const defaults = await EntityCreationService.resolveUserBuDefaults(this._dataService, currentUserId);
-        EntityCreationService.applyUserBuDefaults(entity, defaults);
-      } else {
-        console.warn('[WorkAssignmentService] BU cascade skipped: current user ID could not be resolved.');
-      }
-    } catch (err) {
-      // Non-fatal: log and continue. BFF tenant-default chain handles routing if both fields are unset.
-      console.warn('[WorkAssignmentService] BU cascade failed (non-fatal):', err);
-    }
-
     // Helper: bind a lookup if the nav-prop exists on the entity
     const bindLookup = (referencedEntity: string, entitySet: string, guid: string, columnHint?: string) => {
       const navProp = findNavProp(navProps, referencedEntity, columnHint);
@@ -489,6 +470,27 @@ export class WorkAssignmentService {
         );
       }
     };
+
+    // FR-WIZ-04: Cascade `sprk_containerid` + `sprk_searchindexname` + Phase G `sprk_ai_search_index`
+    // lookup from the current user's owning Business Unit. INV-5 guards each scalar field
+    // independently. If the user's BU has any field unset, the corresponding payload field is
+    // left untouched and the BFF tenant-default chain takes over server-side.
+    try {
+      const currentUserId = _getCurrentUserId();
+      if (currentUserId) {
+        // IDataService is a structural superset of IWebApiLike (retrieveRecord, retrieveMultipleRecords).
+        const defaults = await EntityCreationService.resolveUserBuDefaults(this._dataService, currentUserId);
+        EntityCreationService.applyUserBuDefaults(entity, defaults);
+        if (defaults.searchIndexId) {
+          bindLookup('sprk_aisearchindex', 'sprk_aisearchindexes', defaults.searchIndexId);
+        }
+      } else {
+        console.warn('[WorkAssignmentService] BU cascade skipped: current user ID could not be resolved.');
+      }
+    } catch (err) {
+      // Non-fatal: log and continue. BFF tenant-default chain handles routing if all fields are unset.
+      console.warn('[WorkAssignmentService] BU cascade failed (non-fatal):', err);
+    }
 
     // Related record (matter, project, invoice, event)
     // Uses the shared Polymorphic Resolver pattern (ADR-024):

--- a/src/client/shared/Spaarke.UI.Components/src/services/EntityCreationService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/services/EntityCreationService.ts
@@ -43,12 +43,13 @@ import { SdapApiClient, type IndexFileRequest, type IndexFileResult } from '@spa
  *
  * Per spaarke-multi-container-multi-index-r1 spec (FR-WIZ-01..05) the 5 parent-record
  * wizards (Matter, Project, Invoice, WorkAssignment, Event) and DocumentUploadWizard
- * cascade two fields from `businessunit` onto the create payload:
+ * cascade three fields from `businessunit` onto the create payload:
  *
  *   - `sprk_containerid` — SPE container/drive ID
- *   - `sprk_searchindexname` — Azure AI Search index name
+ *   - `sprk_searchindexname` — Azure AI Search index name (text, soak-only — Phase G/110 drop)
+ *   - `sprk_ai_search_index` — `sprk_aisearchindex` lookup (canonical Phase G post-2026-06-10)
  *
- * Both fields are OPTIONAL on `businessunit`. When unset on the BU, the helpers
+ * All three fields are OPTIONAL on `businessunit`. When unset on the BU, the helpers
  * leave the corresponding payload field untouched and the BFF tenant-default
  * chain (or downstream backfill) takes over server-side.
  */
@@ -57,6 +58,12 @@ export interface IUserBuCascadeDefaults {
   containerId?: string;
   /** `businessunit.sprk_searchindexname` for the current user's owning BU, or undefined if unset. */
   searchIndexName?: string;
+  /**
+   * GUID of `businessunit.sprk_ai_search_index` lookup target for the current user's owning BU,
+   * or undefined if unset. Phase G canonical field — wizards bind this as `sprk_aisearchindexes(<guid>)`
+   * via `@odata.bind` on the child entity's `sprk_AI_Search_Index` nav property.
+   */
+  searchIndexId?: string;
   /** GUID of the user's owning Business Unit (always set when the lookup succeeded). */
   businessUnitId?: string;
 }
@@ -392,7 +399,7 @@ export class EntityCreationService {
     const buRecord = await webApi.retrieveRecord(
       'businessunit',
       buId,
-      '?$select=sprk_containerid,sprk_searchindexname'
+      '?$select=sprk_containerid,sprk_searchindexname,_sprk_ai_search_index_value'
     );
 
     const normalize = (v: unknown): string | undefined => {
@@ -405,6 +412,7 @@ export class EntityCreationService {
       businessUnitId: buId,
       containerId: normalize(buRecord['sprk_containerid']),
       searchIndexName: normalize(buRecord['sprk_searchindexname']),
+      searchIndexId: normalize(buRecord['_sprk_ai_search_index_value']),
     };
   }
 

--- a/src/client/shared/Spaarke.UI.Components/src/services/document-upload/DocumentRecordService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/services/document-upload/DocumentRecordService.ts
@@ -85,13 +85,20 @@ export class DocumentRecordService {
    *                         this batch. When empty / undefined the field is OMITTED so the
    *                         BFF tenant-default chain (FR-BFF-04) takes over server-side.
    *                         Per spec FR-WIZ-07 (2026-06-07).
+   * @param searchIndexId - Optional GUID of `sprk_aisearchindex` lookup target. Cascaded from
+   *                        parent's `sprk_ai_search_index` lookup (Phase G canonical field).
+   *                        When non-empty, bound as `sprk_AI_Search_Index@odata.bind` on the
+   *                        new Document. When empty/undefined, the field is OMITTED so the
+   *                        Matter→Document Dataverse field mapping (or BFF resolver fallback)
+   *                        handles cascade server-side.
    * @returns Array of creation results (success/error per file)
    */
   async createDocuments(
     files: SpeFileMetadata[],
     parentContext: ParentContext,
     formData: DocumentFormData,
-    searchIndexName?: string
+    searchIndexName?: string,
+    searchIndexId?: string
   ): Promise<CreateResult[]> {
     this.logger.info('DocumentRecordService', `Creating ${files.length} Document records`);
 
@@ -99,7 +106,7 @@ export class DocumentRecordService {
 
     // Sequential creation
     for (const file of files) {
-      const result = await this.createSingleDocument(file, parentContext, formData, searchIndexName);
+      const result = await this.createSingleDocument(file, parentContext, formData, searchIndexName, searchIndexId);
       results.push(result);
     }
 
@@ -154,7 +161,8 @@ export class DocumentRecordService {
     file: SpeFileMetadata,
     parentContext: ParentContext,
     formData: DocumentFormData,
-    searchIndexName?: string
+    searchIndexName?: string,
+    searchIndexId?: string
   ): Promise<CreateResult> {
     try {
       // Unassociated mode: create document without parent lookup binding
@@ -181,6 +189,11 @@ export class DocumentRecordService {
         // No INV-5 guard needed here — payload is freshly assembled and has no pre-existing value.
         if (this._isNonEmptyIndexName(searchIndexName)) {
           payload.sprk_searchindexname = searchIndexName;
+        }
+        // Phase G: bind sprk_ai_search_index lookup when the caller resolved a GUID
+        // (parent's lookup → parent's BU's lookup). Nav-prop is sprk_AI_Search_Index (PascalCase).
+        if (searchIndexId && searchIndexId.trim() !== '') {
+          payload['sprk_AI_Search_Index@odata.bind'] = `/sprk_aisearchindexes(${searchIndexId.trim()})`;
         }
         this.logger.info('DocumentRecordService', `Creating unassociated Document: ${file.name}`);
         const result = await this.dataverseClient.createRecord('sprk_document', payload);
@@ -237,7 +250,8 @@ export class DocumentRecordService {
         formData,
         navigationPropertyName,
         targetEntitySetName,
-        searchIndexName
+        searchIndexName,
+        searchIndexId
       );
 
       this.logger.info('DocumentRecordService', `Creating Document: ${file.name}`);
@@ -278,6 +292,9 @@ export class DocumentRecordService {
    *                          included in the payload; when empty / undefined, the field is
    *                          OMITTED so the BFF tenant-default chain (FR-BFF-04) takes over
    *                          server-side. Per spec FR-WIZ-07 (2026-06-07).
+   * @param searchIndexId - Optional GUID of `sprk_aisearchindex` lookup target. When non-empty,
+   *                        bound as `sprk_AI_Search_Index@odata.bind`. When empty/undefined, the
+   *                        Matter→Document Dataverse field mapping cascades the parent's value.
    *
    *                          CRITICAL design invariant (design.md INV): the canonical Document
    *                          container field is `sprk_graphdriveid`. `sprk_containerid` stays
@@ -290,7 +307,8 @@ export class DocumentRecordService {
     formData: DocumentFormData,
     navigationPropertyName: string,
     entitySetName: string,
-    searchIndexName?: string
+    searchIndexName?: string,
+    searchIndexId?: string
   ): Record<string, unknown> {
     // Sanitize GUID (remove curly braces, convert to lowercase)
     const sanitizedGuid = parentContext.parentRecordId.replace(/[{}]/g, '').toLowerCase();
@@ -330,6 +348,12 @@ export class DocumentRecordService {
     // guard needed here — payload is freshly assembled and has no pre-existing value.
     if (this._isNonEmptyIndexName(searchIndexName)) {
       payload.sprk_searchindexname = searchIndexName;
+    }
+
+    // Phase G: bind sprk_ai_search_index lookup when caller resolved a GUID
+    // (parent's lookup → parent's BU's lookup). Nav-prop is sprk_AI_Search_Index (PascalCase).
+    if (searchIndexId && searchIndexId.trim() !== '') {
+      payload['sprk_AI_Search_Index@odata.bind'] = `/sprk_aisearchindexes(${searchIndexId.trim()})`;
     }
 
     this.logger.info(


### PR DESCRIPTION
## Summary

Closes the Phase G gap: PR #369 migrated existing records (text → lookup, 196 rows via task 104) but **never updated the wizard create paths**. Phase G assumed Dataverse OOB field mappings would handle cascade for new records, but field mappings don`t fire on wizard Web API creates without the parent lookup in the payload — and wizards don`t set `_owningbusinessunit_value` explicitly (Dataverse auto-assigns BU after mapping processing).

**Discovered during UAT 2026-06-10**: Matter `PAT-897705` (id `7cf177b7-4165-f111-ab0c-7ced8ddc4cc6`) + its 3 documents all had `sprk_ai_search_index = null` despite BU "Spaarke" having `sprk_ai_search_index = dd04e55f` (Development Files 2 → `spaarke-file-index`). Result: code page semantic search returned 0 results.

## Changes

- `EntityCreationService.IUserBuCascadeDefaults` — added `searchIndexId?: string`
- `EntityCreationService.resolveUserBuDefaults` — `$select` now includes `_sprk_ai_search_index_value`
- `matterService.ts` / `projectService.ts` — push lookup binding to existing `lookups` array (Pattern A col-based / Pattern B referencedEntity-based)
- `eventService.ts` / `workAssignmentService.ts` — bind via `findNavProp` after `applyUserBuDefaults`
- `DocumentRecordService.createDocuments` / `buildRecordPayload` — optional `searchIndexId` param (forward-compat — caller can pass if Matter→Document field mapping doesn`t fire)
- Resume doc `notes/handoffs/RESUME-2026-06-10-phase-g-post-merge.md` (state capture)

All cascade is no-op when BU has no lookup set → backward compatible.

## Test plan

- [ ] Build shared lib `dist/` (`@spaarke/ui-components`)
- [ ] Build + deploy 5 wizard code pages (Matter, Project, Event, WorkAssignment, DocumentUploadWizard)
- [ ] Backfill `PAT-897705` + its 3 documents: set `sprk_ai_search_index = dd04e55f` via MCP
- [ ] Create a fresh Matter via wizard → MCP-verify new Matter has `sprk_ai_search_index` populated from BU
- [ ] Upload a file via the same wizard → MCP-verify new Document inherits the lookup (via field mapping OR explicit cascade)
- [ ] Open Semantic Search code page from a wizard-created Matter → verify dropdown defaults to BU`s index + returns docs
- [ ] Repeat with Project / Event / WorkAssignment wizards

## Related

- Closes Phase G gap not covered by tasks 100-111 (no wizard task existed for lookup cascade)
- Builds on PR #369 (squash-merged 2026-06-10 as `254302259`)
- Branch successor: this branch off `master`, NOT off `work/spaarke-multi-container-multi-index-r1`

## NOT in this PR

- Wizard deploy (waiting for master full deploy to complete)
- Backfill of `PAT-897705` (will run after deploy verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)