### PR TITLE
fix(deploy): 3 deploy-script PowerShell-stderr fixes

### DIFF
--- a/.claude/skills/master-deploy/SKILL.md
+++ b/.claude/skills/master-deploy/SKILL.md
@@ -167,21 +167,25 @@ The user should hard-refresh **`spaarkedev1`** in Incognito to verify SpaarkeAi 
 
 ### F-2: `Build-AllClientComponents.ps1` reports all Vite solutions FAILED
 
-**Cause**: The PS1 batch builder hits some install/cache state issue where every solution fails (observed 2026-06-10) even though each builds individually. Root cause not fully diagnosed; likely a stale node_modules + npm install race when run in batch.
+**Cause**: PowerShell captured npm/Rollup stderr warnings (`/* #__PURE__ */`) via `2>&1` into a variable. Under script-level `$ErrorActionPreference = "Stop"`, those stderr lines became terminating error records — the catch marked every build FAILED even though `$LASTEXITCODE` was 0.
 
-**Fix**: Use `node scripts/master-deploy/build-all-vite-solutions.mjs` instead. It calls `npm run build` in each solution serially using the existing `node_modules` (no install). Verified working 2026-06-10.
+**Root-cause fix landed 2026-06-11**: localized `$ErrorActionPreference = 'Continue'` inside script blocks that invoke npm install + npm run build. Failure detection now relies on `$LASTEXITCODE` only. The script's outer Stop discipline is preserved for all other operations.
+
+**Fallback** (Node script remains a safety net): `node scripts/master-deploy/build-all-vite-solutions.mjs` — calls `npm run build` per solution serially. Use if the PS1 ever exhibits new failure modes.
 
 ### F-3: `dotnet publish --no-restore` fails inside `Deploy-BffApi.ps1`
 
-**Cause**: The script's Step 1 runs `dotnet publish ... --no-restore` but no `dotnet restore` step precedes it. If the bin/obj are stale, publish fails with exit 1.
+**Cause**: Script Step 1 ran `dotnet publish ... --no-restore` with no preceding `dotnet restore`. Fresh checkouts failed with exit 1.
 
-**Fix**: Pre-publish manually before calling the skill (see Step 6).
+**Root-cause fix landed 2026-06-11**: explicit `dotnet restore --verbosity minimal` step added immediately before publish. No more manual pre-publish needed before invoking `/bff-deploy`.
 
 ### F-4: Reporting deploy fails with `NativeCommandError` on Rollup warning
 
-**Cause**: `Deploy-ReportingCodePage.ps1` invokes `npm run build` which emits `/* #__PURE__ */` warnings to stderr. PowerShell's `$ErrorActionPreference = "Stop"` treats stderr from native commands as fatal errors.
+**Cause**: `Deploy-ReportingCodePage.ps1`'s npm install + npm run build calls inherited script-level `$ErrorActionPreference = "Stop"`. Rollup `/* #__PURE__ */` warnings on stderr became terminating error records.
 
-**Fix**: Use the Node fetch-based deploy in Step 5.
+**Root-cause fix landed 2026-06-11**: same localized `$ErrorActionPreference = 'Continue'` pattern as F-2. The PS1 script now deploys cleanly without falling back to the Node helper.
+
+**Fallback** (Node script remains a safety net): `node scripts/master-deploy/deploy-webresource-inline.mjs sprk_reporting src/solutions/Reporting/dist/index.html` — fetch-based upload bypassing the PS1 entirely. Use if the PS1 ever exhibits new failure modes.
 
 ### F-5: `execSync` ENOBUFS on Dataverse Web API responses
 

--- a/scripts/Build-AllClientComponents.ps1
+++ b/scripts/Build-AllClientComponents.ps1
@@ -148,14 +148,27 @@ function Invoke-ComponentBuild {
             $nodeModulesPath = Join-Path $BuildPath "node_modules"
             if (-not (Test-Path $nodeModulesPath)) {
                 Write-Host "        installing (no node_modules)..." -ForegroundColor DarkGray
-                $installOutput = & npm install --legacy-peer-deps --no-audit --no-fund 2>&1
+                # Localize $ErrorActionPreference inside the script block so
+                # benign stderr emissions from npm don't become terminating
+                # exceptions under the script's outer 'Stop' preference. See
+                # 2026-06-11 incident: every Vite solution was marked FAILED in
+                # batch because rollup's "/* #__PURE__ */" warnings were
+                # captured via 2>&1 and promoted to terminating errors, even
+                # though $LASTEXITCODE was 0 and the build succeeded.
+                $installOutput = & {
+                    $ErrorActionPreference = 'Continue'
+                    npm install --legacy-peer-deps --no-audit --no-fund 2>&1
+                }
                 if ($LASTEXITCODE -ne 0) {
                     throw "npm install failed (exit code $LASTEXITCODE)`n$($installOutput | Out-String)"
                 }
             }
 
-            # npm run build
-            $buildOutput = & npm run build 2>&1
+            # npm run build (same localized $ErrorActionPreference rationale)
+            $buildOutput = & {
+                $ErrorActionPreference = 'Continue'
+                npm run build 2>&1
+            }
             if ($LASTEXITCODE -ne 0) {
                 throw "npm run build failed (exit code $LASTEXITCODE)`n$($buildOutput | Out-String)"
             }

--- a/scripts/Deploy-BffApi.ps1
+++ b/scripts/Deploy-BffApi.ps1
@@ -210,6 +210,14 @@ if (-not $SkipBuild) {
 
     Push-Location $ApiProject
     try {
+        # Restore first — required by --no-restore on publish below. Without
+        # this, fresh checkouts or clean states fail with exit 1 (2026-06-11
+        # incident: master-deploy session hit "Build failed with exit code 1"
+        # because the publish skipped restore but nothing else restored).
+        dotnet restore --verbosity minimal 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Restore failed with exit code $LASTEXITCODE"
+        }
         dotnet publish -c Release -o $PublishPath --no-restore 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) {
             throw "Build failed with exit code $LASTEXITCODE"

--- a/scripts/Deploy-ReportingCodePage.ps1
+++ b/scripts/Deploy-ReportingCodePage.ps1
@@ -35,7 +35,16 @@ if ($WhatIf) {
 Write-Host '[1/6] Installing npm dependencies...' -ForegroundColor Yellow
 Push-Location $reportingDir
 try {
-    npm install --prefer-offline 2>&1 | Write-Host
+    # Localize $ErrorActionPreference for the npm call so benign stderr
+    # output (e.g. Rollup's "/* #__PURE__ */" warnings on the build step)
+    # doesn't trip the script's outer 'Stop' preference. See 2026-06-11
+    # incident: master-deploy run blocked on a Rollup annotation warning
+    # even though $LASTEXITCODE was 0. The fix relies on $LASTEXITCODE
+    # for actual failure detection; the rest of the script keeps Stop.
+    & {
+        $ErrorActionPreference = 'Continue'
+        npm install --prefer-offline 2>&1 | Write-Host
+    }
     if ($LASTEXITCODE -ne 0) {
         Write-Host 'Error: npm install failed.' -ForegroundColor Red
         exit 1
@@ -45,11 +54,14 @@ try {
     Pop-Location
 }
 
-# Step 2: npm run build
+# Step 2: npm run build (same localized $ErrorActionPreference rationale)
 Write-Host '[2/6] Building Reporting Code Page (vite build)...' -ForegroundColor Yellow
 Push-Location $reportingDir
 try {
-    npm run build 2>&1 | Write-Host
+    & {
+        $ErrorActionPreference = 'Continue'
+        npm run build 2>&1 | Write-Host
+    }
     if ($LASTEXITCODE -ne 0) {
         Write-Host 'Error: npm run build failed.' -ForegroundColor Red
         exit 1


### PR DESCRIPTION
Root-cause fixes for 3 deploy-script bugs uncovered during todays unified-master deploy. See commit message for details. The master-deploy skill (PR #382) documented these as F-2, F-3, F-4 with workarounds; this PR retires the workarounds.