### PR TITLE
feat(environment-provisioning): close out r1 — E2E verification, FR-11 license fix, factory-r1 design

### DIFF
--- a/projects/spaarke-environment-factory-r1/design.md
+++ b/projects/spaarke-environment-factory-r1/design.md
@@ -1,0 +1,137 @@
+# Spaarke Environment Factory — Design Specification
+
+> **Status**: Draft — pending owner review, then `/design-to-spec`
+> **Created**: 2026-06-12
+> **Author**: Ralph Schroeder / Claude Code
+> **Project**: spaarke-environment-factory-r1
+> **Predecessor**: spaarke-environment-provisioning-app (r1, complete — see its notes/lessons-learned.md)
+
+---
+
+## Executive Summary
+
+Build the **single, systematic process for standing up a new Spaarke environment and deploying the platform into it** — one procedure, one orchestrator, one interactive skill, all driven by the `sprk_dataverseenvironment` registry entity created in r1.
+
+Spaarke already has most of the automation. What it lacks is unification: the assets span three generations that don't reference each other, five buildout phases are still guided-manual, and nothing connects an environment's registry record to its actual provisioning state.
+
+---
+
+## Problem Statement
+
+**Current state** — three fragmented generations of provisioning assets:
+
+| Generation | Assets | Character |
+|---|---|---|
+| Gen 1 — demo deployment (2026-03) | `docs/guides/ENVIRONMENT-DEPLOYMENT-GUIDE.md` (14 sections) | Validated but heavily manual CLI; 13 documented workarounds |
+| Gen 2 — customer onboarding | `scripts/Provision-Customer.ps1` (13 steps, idempotent, resumable), `infrastructure/bicep/{customer,platform}.bicep` + 24 modules, `CUSTOMER-ONBOARDING-RUNBOOK.md`, `Decommission-Customer.ps1`, `Validate-DeployedEnvironment.ps1` | Strong automation, but unaware of Gen 1 guide and Gen 3 registry |
+| Gen 3 — environment registry (r1) | `sprk_dataverseenvironment` entity, registration/user-provisioning flow, `auth-deployment-setup.md` (auth v2, 21 MUSTs) | Registry exists but only the registration flow consumes it |
+
+An operator standing up a new environment today must mentally merge three documents, decide which script generation applies, and execute 5 phases by hand. Nothing records which phase an environment has reached.
+
+**Desired state**: one canonical procedure + one orchestrator + one skill; the registry record is created at provisioning start, tracks per-phase progress, and reaches `Setup Status = Ready` only when validation passes. Estimated effort for a repeat operator drops from ~2–3 hours of guide-juggling to a supervised scripted run.
+
+---
+
+## Lifecycle Coverage Matrix (current state, inventoried 2026-06-12)
+
+| # | Phase | Existing asset | Automation level |
+|---|-------|----------------|------------------|
+| 1 | Power Platform env creation | Provision-Customer.ps1 step 5 | Scripted |
+| 2 | Azure subscription setup | ENVIRONMENT-DEPLOYMENT-GUIDE §2 | Guided-manual |
+| 3 | Azure infrastructure | customer.bicep / platform.bicep + 24 modules | Scripted |
+| 4 | Entra ID app registrations | ENVIRONMENT-DEPLOYMENT-GUIDE §4 (11 permission GUIDs) | **Guided-manual — automate** |
+| 5 | Key Vault secrets | Provision-Customer.ps1 step 4 | Scripted |
+| 6 | Solution export & fix pipeline | ENVIRONMENT-DEPLOYMENT-GUIDE §6 (8 manual fix steps) | **Guided-manual — automate** |
+| 7 | Solution import | Deploy-DataverseSolutions.ps1 | Scripted |
+| 8 | Dataverse environment variables | Provision-Customer.ps1 step 8 | Scripted |
+| 9 | SPE container type + root container | §9 manual SPO PowerShell; partial Create-NewContainerType.ps1 | **Guided-manual — automate (idempotent)** |
+| 10 | BFF deploy + app settings | Deploy-BffApi.ps1 + auth-deployment-setup.md §3/§3.5 | Scripted + checklist |
+| 11 | Dataverse application user | PPAC UI only | Manual **by platform design** — document |
+| 12 | Validation | Validate-DeployedEnvironment.ps1, Test-Deployment.ps1 | Scripted (exit-code gate) |
+| 13 | User provisioning | r1 registration app + registry lookup | Scripted (done in r1) |
+| 14 | Data seeding | per-module seed scripts; spaarke-data-cli (design only, separate repo) | Partial — out of scope here |
+| 15 | Ongoing releases | Deploy-Release.ps1 + /deploy-new-release skill | Scripted/interactive (done) |
+
+---
+
+## Scope
+
+### In Scope
+
+1. **Canonical procedure**: `docs/procedures/new-environment-provisioning.md` — the phase table above with one automation entry point per phase; supersedes Gen 1 guide for buildout (banner added); links Gen 2 runbook and auth-deployment-setup as phase detail.
+2. **Registry integration**: extend `sprk_dataverseenvironment` with provisioning fields (Azure subscription ID, resource group, App Service name, Key Vault name, container-type ID, per-phase checklist JSON or status fields). Orchestrator creates/updates the record; `sprk_setupstatus → Ready` only on validation pass.
+3. **Gap automation** (the three automatable manual phases):
+   - `scripts/Register-SpaarkeEnvironmentApps.ps1` — Entra app registrations + the 11 permission grants, idempotent, outputs IDs for Key Vault/env vars (build on existing `Register-EntraAppRegistrations.ps1`)
+   - `scripts/Initialize-SpeContainerType.ps1` — container type create + billing + Graph registration + root container, with existence checks and the westus-billing + token-propagation-wait workarounds encoded (extend `Create-NewContainerType.ps1`)
+   - `scripts/Export-FixedSolutions.ps1` — scripted solution export/fix pipeline (the 8 sed-style fixes from §6) with post-fix verification
+4. **Unified orchestrator**: `scripts/Provision-Environment.ps1` — evolution of `Provision-Customer.ps1` that (a) calls the new gap scripts, (b) reads/writes the registry record, (c) keeps idempotency/resume/WhatIf semantics, (d) ends with the validation gate.
+5. **Interactive skill**: `.claude/skills/provision-environment/` modeled on `deploy-new-release` — pre-flight, parameter collection (into the registry record), confirmation gates, phase execution, handoff report.
+6. **r1 carry-over closure**:
+   - Migrate `DemoExpirationService` off `[Obsolete]` `DemoProvisioningOptions.Environments`/`DefaultEnvironment` — resolve environment per-request via the registration record's `sprk_dataverseenvironmentid` lookup; then delete `DemoProvisioning__Environments__*` + `__DefaultEnvironment` from Azure (closes r1 criterion 10).
+   - Doc drift: `auth-azure-resources.md` App Service names (`spe-api-dev-67e2xz` → `spaarke-bff-dev`/`rg-spaarke-dev`; prod `spaarke-bff-prod`/`rg-spaarke-platform-prod`).
+   - r1 spec/design column names → deployed reality (`sprk_envaccountdomain`, `sprk_mdaappid`).
+   - Live provisioning sign-off round (r1 criteria 5, 8, 9, 11) — folded into the E2E dry run.
+7. **E2E dry run (program acceptance)**: stand up one brand-new environment using only the new procedure + orchestrator + skill.
+
+### Out of Scope
+
+- Demo/customer data seeding tooling (`spaarke-data-cli` — separate repo/project)
+- Multi-tenant architecture changes (see spe-multi-tenant-architecture-r1)
+- Disaster recovery / backup automation
+- Environment health monitoring beyond the validation gate
+- Changes to the release process (`/deploy-new-release` is consumed as-is)
+
+---
+
+## Data Model — `sprk_dataverseenvironment` extension (indicative; finalize in spec)
+
+| Schema Name | Type | Purpose |
+|---|---|---|
+| `sprk_azuresubscriptionid` | Text(100) | Azure subscription hosting this environment's resources |
+| `sprk_resourcegroupname` | Text(200) | Resource group |
+| `sprk_appservicename` | Text(200) | BFF App Service |
+| `sprk_keyvaultname` | Text(200) | Key Vault |
+| `sprk_containertypeid` | Text(100) | SPE container type |
+| `sprk_provisioningstatejson` | Multiline(4000) | Per-phase checklist written by the orchestrator (phase, status, timestamp, notes) |
+| `sprk_provisionedon` | DateTime | When validation first passed |
+
+Constraint carried from r1: no plugins (ADR-002); orchestrator and BFF write via Web API.
+
+---
+
+## Placement Justification (CLAUDE.md §10)
+
+- New scripts + skill + procedure doc: live in `scripts/`, `.claude/skills/`, `docs/procedures/` — no BFF impact.
+- The only BFF change is the `DemoExpirationService` migration (modifying an existing registered service to use the existing `DataverseEnvironmentService`; no new endpoints, packages, or DI registrations). Publish-size verification per task as usual; expected delta ≈ 0.
+- Registry schema extension is Dataverse-only.
+
+---
+
+## Phasing (input to /project-pipeline)
+
+| Phase | Content | Depends on |
+|---|---|---|
+| A | Canonical procedure doc + Gen-1 guide supersession + doc-drift fixes | — |
+| B | Gap automation scripts (Entra apps, SPE container type, solution export/fix) — independently testable | — (parallel with A) |
+| C | Registry schema extension + Provision-Environment.ps1 orchestrator integrating B | A, B |
+| D | /provision-environment skill | C |
+| E | DemoExpirationService migration + Azure legacy-config deletion + verification | — (parallel; BFF task, FULL rigor) |
+| F | E2E dry run: new environment end-to-end + r1 live sign-off items + wrap-up | C, D, E |
+
+---
+
+## Success Criteria
+
+1. [ ] One procedure doc covers all 15 phases with a single automation entry point or explicit manual-by-design marking per phase
+2. [ ] `Provision-Environment.ps1` runs phases 1–12 with registry state tracking, resumable, `-WhatIf` supported
+3. [ ] Entra app registration, SPE container type, and solution export/fix run unattended and idempotently
+4. [ ] A brand-new environment reaches `Setup Status = Ready` via the new process; `Validate-DeployedEnvironment.ps1` exits 0
+5. [ ] `DemoProvisioning__Environments__*` and `__DefaultEnvironment` deleted from Azure; expiration flow verified working
+6. [ ] r1 manual sign-off items (live provisioning into Dev + Demo 1, bulk grid approve) pass during the dry run
+7. [ ] `/provision-environment` skill executes the full flow with confirmation gates and produces a handoff report
+
+## Open Questions (for owner before /design-to-spec)
+
+1. **Decommission**: should `Decommission-Customer.ps1` be upgraded to registry-aware in this project, or deferred?
+2. **Environment kinds**: does the orchestrator need different profiles (demo vs customer vs trial — e.g., skip per-customer Bicep for shared-platform demo envs)? Suggested: a `-Profile` parameter mapping to bicep stack selection.
+3. **Where does the dry-run environment live** (new Azure sub vs existing dev sub; gets decommissioned after acceptance or kept as a template env)?

--- a/projects/spaarke-environment-provisioning-app/README.md
+++ b/projects/spaarke-environment-provisioning-app/README.md
@@ -1,6 +1,6 @@
 # Spaarke Environment Provisioning App
 
-> **Status**: In Progress
+> **Status**: Complete (2026-06-12) — one criterion carried to r2, live-provisioning sign-off pending
 > **Branch**: `work/spaarke-environment-provisioning-app`
 > **Started**: 2026-04-06
 
@@ -10,16 +10,18 @@ Create a reusable `sprk_dataverseenvironment` entity in Dataverse as the platfor
 
 ## Graduation Criteria
 
-- [ ] Environment entity exists in Dev and Demo Dataverse with correct schema
-- [ ] Admin can CRUD environment records via MDA form
-- [ ] Registration request has Target Environment lookup (blank by default)
-- [ ] Form approve validates environment is selected
-- [ ] Grid approve fails individual records missing environment
-- [ ] BFF reads config from Dataverse at approval time
-- [ ] Malformed license JSON returns clear error
-- [ ] Dev + Demo 1 seed data works with existing provisioning flow
-- [ ] `DemoProvisioning__Environments__*` removed from Azure config
-- [ ] Bulk approve uses per-record environment; missing ones fail individually
+- [x] Environment entity exists in Dev Dataverse with correct schema (16 cols; Demo Dataverse deferred — registry lives in admin env only)
+- [x] Admin can CRUD environment records via MDA form
+- [x] Registration request has Target Environment lookup (blank by default)
+- [x] Form approve validates environment is selected (FR-06, static-verified)
+- [x] Grid approve fails individual records missing environment (FR-07, static-verified)
+- [x] BFF reads config from Dataverse at approval time (no caching, NFR-01)
+- [x] Malformed license JSON returns clear error (unit-tested 2026-06-12)
+- [x] Dev + Demo 1 seed data populated incl. real license SKU IDs (D-040-02 fix)
+- [ ] `DemoProvisioning__Environments__*` removed from Azure config — **BLOCKED, carried to r2**: still required by `DemoExpirationService` (see notes/e2e-test-results.md)
+- [x] Bulk approve uses per-record environment; missing ones fail individually (static-verified; live bulk run = manual sign-off item)
+
+See [notes/e2e-test-results.md](notes/e2e-test-results.md) for full E2E disposition (7/11 verified, 4 manual sign-off items, 1 carried).
 
 ## Architecture
 

--- a/projects/spaarke-environment-provisioning-app/current-task.md
+++ b/projects/spaarke-environment-provisioning-app/current-task.md
@@ -1,41 +1,34 @@
 # Current Task State
 
 > **Project**: spaarke-environment-provisioning-app
-> **Status**: in-progress
-> **Current Task**: 001 - Create DataverseEnvironment Schema Script
-> **Phase**: 1
-> **Last Updated**: 2026-04-06
+> **Status**: complete
+> **Current Task**: none
+> **Phase**: —
+> **Last Updated**: 2026-06-12
 
 ## Quick Recovery
 
 | Field | Value |
 |-------|-------|
-| **Task** | 015 - Refactor DemoProvisioningService |
-| **Step** | Next pending task |
-| **Status** | not-started |
-| **Next Action** | Work on task 015 |
+| **Task** | none |
+| **Step** | — |
+| **Status** | Project complete (all 22 tasks ✅) |
+| **Next Action** | Successor program: environment-factory-r1 (see projects/spaarke-environment-factory-r1/design.md) |
 
-## Knowledge Files Loaded
-- scripts/Create-RegistrationRequestSchema.ps1 (pattern template)
-- docs/guides/DATAVERSE-HOW-TO-CREATE-UPDATE-SCHEMA.md (API constraints)
+## Project Outcome
 
-## Completed Tasks This Session
-- ✅ 001: Schema script created
-- ✅ 010-012: DTO, Service, DI registration
-- ✅ 013-014: ApproveRequest refactored + license JSON validation
-- ✅ 020-022: Ribbon JS environment picker removed, lookup validation added
+All 22 tasks complete. E2E results: notes/e2e-test-results.md (7/11 criteria verified, 4 manual
+sign-off items, criterion 10 carried to r2). Lessons: notes/lessons-learned.md.
 
-## Remaining Tasks
-- 🔲 002-007: Dataverse schema deployment + customizations (blocked on running script)
-- 🔲 015-016: Provisioning service refactor + admin email source
-- 🔲 030-032: Config cleanup + URL refactor + docs
-- 🔲 040, 090: E2E testing + wrap-up
+Defects fixed during E2E (2026-06-12): FR-11 per-environment license wiring (4 BFF files +
+LicenseResolutionTests, 6/6 pass) and seed-record license SKU population (Dataverse data fix).
 
-## Files Modified This Session
-- scripts/Create-DataverseEnvironmentSchema.ps1 (new)
-- src/server/api/Sprk.Bff.Api/Services/Registration/DataverseEnvironmentRecord.cs (new)
-- src/server/api/Sprk.Bff.Api/Services/Registration/DataverseEnvironmentService.cs (new)
-- src/server/api/Sprk.Bff.Api/Services/Registration/RegistrationDataverseService.cs (modified — added env lookup)
-- src/server/api/Sprk.Bff.Api/Infrastructure/DI/RegistrationModule.cs (modified — added DI)
-- src/server/api/Sprk.Bff.Api/Endpoints/RegistrationEndpoints.cs (modified — refactored approve)
-- src/client/webresources/js/sprk_registrationribbon.js (modified — v2.0 refactored)
+## Carry-overs → environment-factory-r1
+
+- DemoExpirationService migration off obsolete Environments config (unblocks deleting
+  DemoProvisioning__Environments__* from Azure)
+- Live provisioning sign-off round (criteria 5, 8, 9, 11)
+- auth-azure-resources.md App Service name drift (spe-api-dev-67e2xz → spaarke-bff-dev/rg-spaarke-dev)
+- spec.md/design.md column names → deployed reality (sprk_envaccountdomain, sprk_mdaappid)
+- Lookup filtering by environment type
+- Azure resource provisioning automation (Entra groups / Conditional Access / SPE containers)

--- a/projects/spaarke-environment-provisioning-app/notes/e2e-test-results.md
+++ b/projects/spaarke-environment-provisioning-app/notes/e2e-test-results.md
@@ -1,0 +1,75 @@
+# E2E Test Results — spaarke-environment-provisioning-app (Task 040)
+
+> **Date**: 2026-06-12
+> **Environment**: spaarkedev1.crm.dynamics.com (Dev) + spaarke-bff-dev App Service
+> **Method**: Dataverse MCP (live queries), static code verification, Azure CLI config inspection, unit tests
+> **Spec**: projects/spaarke-environment-provisioning-app/spec.md — 11 success criteria
+
+## Summary
+
+| # | Criterion | Result | Method |
+|---|-----------|--------|--------|
+| 1 | Environment record creatable — form layout + all fields | ✅ PASS | Entity deployed with all 16 custom columns (Dataverse MCP `describe`); 2 records exist, created via MDA form (commit d1450fc2 deployed form/views/sitemap) |
+| 2 | Registration request lookup blank by default | ✅ PASS | `sprk_dataverseenvironmentid` lookup exists on `sprk_registrationrequest`; no default mechanism (no plugin/business rule); recent Submitted records have blank lookup |
+| 3 | Form approve without environment → alert blocks | ✅ PASS (static) | `sprk_registrationribbon.js` FR-06 validation: `getAttribute("sprk_dataverseenvironmentid")` → `openAlertDialog("Please select a Target Environment before approving.")` and returns. Live UI click-through: see Manual items |
+| 4 | Grid approve without environment → per-record error | ✅ PASS (static) | Ribbon JS grid path retrieves each record with `$expand=sprk_dataverseenvironmentid`; pushes `"{Name}: No target environment selected"` to skipped errors |
+| 5 | Approve with environment → BFF provisions from Dataverse config | 🔶 MANUAL | Code path verified (approve endpoint reads `DataverseEnvironmentService.GetByIdAsync` fresh per NFR-01, maps to `DemoEnvironmentConfig`). Live run creates a real Entra user + licenses — needs operator sign-off. Two Submitted test requests exist in Dev |
+| 6 | Deactivated environment excluded from lookup | ✅ PASS (server) / 🔶 MANUAL (UI) | Server: approve endpoint returns 400 "environment is inactive". UI lookup filtering by Active view: verify manually in MDA |
+| 7 | Malformed license JSON → clear error | ✅ PASS | Endpoint catches `JsonException` → 400 ProblemDetails "Invalid license configuration for environment '{name}'". Unit-tested: `ParseLicenseConfig_MalformedJson_ThrowsJsonException` ✅ |
+| 8 | Provision into Dev works after migration | 🔶 MANUAL | Same as #5 — requires live provisioning run |
+| 9 | Provision into Demo 1 uses correct config | 🔶 MANUAL | Multi-URL cross-environment path implemented (per-URL token cache, commit a95865c2); live verification pending |
+| 10 | Remove `DemoProvisioning__Environments__*` from Azure | ❌ BLOCKED | Settings still present on `spaarke-bff-dev` AND still **required**: `DemoExpirationService.ResolveDefaultEnvironment()` reads `_options.Environments`/`DefaultEnvironment` (marked `[Obsolete]`, migration deferred). Removing now would break expiration. → carry to r2 |
+| 11 | Bulk grid approve — per-record lookup, individual failures | ✅ PASS (static) / 🔶 MANUAL (live) | Grid JS validates each record independently (criterion 4); live bulk run pending |
+
+**BFF health**: `https://spaarke-bff-dev.azurewebsites.net/healthz` → 200 Healthy ✅
+
+## Defects found & fixed during E2E
+
+### D-040-01 — FR-11 per-environment licenses never used (FIXED)
+
+The approve endpoint parsed `sprk_licenseconfigjson` (FR-12 validation) but discarded the
+result; `GraphUserService.AssignLicensesAsync` always used global `DemoProvisioning:Licenses`
+from appsettings. Per-environment license sets (FR-11 acceptance: "Different environments can
+have different license SKU sets") were silently ignored.
+
+**Fix** (this session):
+- `DemoEnvironmentConfig.Licenses` (new optional property) — `Configuration/DemoProvisioningOptions.cs`
+- Approve endpoint maps parsed `LicenseConfig` → `LicenseSkuConfig` — `Endpoints/RegistrationEndpoints.cs`
+- `DemoProvisioningService` step 5 passes `environment.Licenses` — `Services/Registration/DemoProvisioningService.cs`
+- `GraphUserService.AssignLicensesAsync(userId, environmentLicenses, ct)` + internal static
+  `ResolveLicenses(global, perEnvironment)`: per-env wins when it has ≥1 non-empty SKU, else
+  falls back to global (protects legacy/empty environment records) — `Services/Registration/GraphUserService.cs`
+- Tests: `tests/unit/Sprk.Bff.Api.Tests/Services/Registration/LicenseResolutionTests.cs` — 6/6 pass
+
+### D-040-02 — Seed records had empty license SKU IDs (FIXED)
+
+Both `sprk_dataverseenvironment` records (Dev, Demo 1) had `sprk_licenseconfigjson` with empty
+SKU values (FR-14 migration copied repo appsettings placeholders, not real Azure values).
+Populated both records with actual SKU IDs from `spaarke-bff-dev` app settings
+(PowerApps Plan 2 Trial `dcb1a3ae…`, Fabric Free `a403ebcc…`, Power Automate Free `f30db892…`).
+Verified via read-back query.
+
+## Carry-overs (input for r2 systematization)
+
+1. **Criterion 10 blocked**: migrate `DemoExpirationService` off `[Obsolete]`
+   `DemoProvisioningOptions.Environments`/`DefaultEnvironment` — it should resolve the
+   environment per-request via the request's `sprk_dataverseenvironmentid` lookup, then the
+   Azure `DemoProvisioning__Environments__*` + `__DefaultEnvironment` settings can be deleted.
+2. **Doc drift**: `docs/architecture/auth-azure-resources.md` names App Service
+   `spe-api-dev-67e2xz` / RG `spe-infrastructure-westus2`; actual dev BFF is
+   `spaarke-bff-dev` / `rg-spaarke-dev` (prod: `spaarke-bff-prod` / `rg-spaarke-platform-prod`).
+3. **Manual verification round** (criteria 5, 8, 9, 11 + UI part of 3, 4, 6): one live
+   approve per environment using the existing Submitted test requests, plus a bulk grid
+   approve. Requires operator (creates real Entra users/licenses; cleanup via expiration flow).
+
+## Quality gates (Step 9.5)
+
+- Build: `dotnet build Sprk.Bff.Api` — 0 errors ✅
+- Unit tests: LicenseResolutionTests 6/6 ✅
+- Publish size (NFR-01 / CLAUDE.md §10.4): **46.02 MB compressed** (139.23 MB uncompressed) vs
+  ~45.65 MB baseline (2026-05-26) → +0.37 MB cumulative drift since baseline, no escalation
+  threshold crossed (ceiling 60 MB; single-task +5 MB)
+- ADR check: ADR-001 (no new endpoints), ADR-002 (no plugins), ADR-010 (no DI changes;
+  concrete types unchanged), ADR-019 (existing ProblemDetails paths unchanged) ✅
+- BFF placement (§10): modification of existing Registration services only — no new endpoints,
+  packages, DI registrations, or background work; placement unchanged ✅

--- a/projects/spaarke-environment-provisioning-app/notes/lessons-learned.md
+++ b/projects/spaarke-environment-provisioning-app/notes/lessons-learned.md
@@ -1,0 +1,52 @@
+# Lessons Learned — spaarke-environment-provisioning-app
+
+> **Date**: 2026-06-12
+> **Project**: Dataverse Environment Registry + Registration Provisioning Refactor
+
+## What went well
+
+1. **Platform-entity framing paid off.** Designing `sprk_dataverseenvironment` as a reusable
+   platform registry (not a registration-specific table) means customer management, deployment
+   tooling, and the r2 systematization effort can consume it without schema changes.
+2. **Per-URL token cache pattern** (`ConcurrentDictionary<string, AccessToken>` with
+   semaphore-protected refresh in `RegistrationDataverseService`) cleanly enabled
+   cross-environment provisioning without a second service class. Reusable pattern for any
+   future multi-environment Dataverse operation.
+3. **Validation in both layers** (ribbon JS alert + API 400 ProblemDetails) per the no-plugins
+   constraint (ADR-002) worked without server-side gaps — the API check is authoritative,
+   the JS check is UX.
+
+## What bit us
+
+1. **"Validated but not wired" defect (D-040-01).** The approve endpoint parsed the
+   per-environment license JSON for FR-12 validation but never passed it into provisioning —
+   `AssignLicensesAsync` silently kept using global appsettings. Acceptance criteria that say
+   "different environments can have different X" need an E2E assertion that the per-environment
+   value actually *reaches* the consumer, not just that it parses. Caught only in task 040.
+2. **Seed-data fidelity (D-040-02).** FR-14 seeding copied repo appsettings placeholders
+   (empty SKU IDs) instead of the real values living in Azure App Service settings. When config
+   migrates from Azure → Dataverse, seed from the *deployed* config (`az webapp config
+   appsettings list`), not the repo template.
+3. **Column-name drift between spec and deployment.** `sprk_accountdomain` → deployed as
+   `sprk_envaccountdomain`, `sprk_appid` → `sprk_mdaappid` (commit d1450fc2 fixed collisions).
+   The DTO was updated, but spec.md/design.md still show the old names. When a schema script
+   hits reserved/colliding names, back-propagate the final names into the spec data model.
+4. **Worktree drift.** The provisioning worktree sat at a pre-merge commit while later work
+   (schema deployment d1450fc2) landed on master via a different checkout; `current-task.md`
+   and `TASK-INDEX.md` disagreed by months. Always `git merge origin/master` a resumed worktree
+   FIRST and trust the merged TASK-INDEX over `current-task.md`.
+5. **Obsolete-config removal blocked by a second consumer.** Criterion 10 (delete
+   `DemoProvisioning__Environments__*` from Azure) assumed the registration flow was the only
+   consumer, but `DemoExpirationService.ResolveDefaultEnvironment()` still reads it. Before
+   promising "remove legacy config" in a spec, enumerate all readers of the config section.
+
+## Carry-overs → r2 systematization
+
+| Item | Detail |
+|---|---|
+| DemoExpirationService migration | Resolve environment per-request via `sprk_dataverseenvironmentid` lookup; then delete `DemoProvisioning__Environments__*` + `__DefaultEnvironment` from Azure (closes criterion 10) |
+| Live provisioning sign-off | Criteria 5, 8, 9, 11 — one approve per environment + bulk grid approve, operator-supervised |
+| Doc drift | `auth-azure-resources.md` App Service names stale (`spe-api-dev-67e2xz` → `spaarke-bff-dev`/`rg-spaarke-dev`) |
+| Spec data-model names | Update spec.md/design.md column names to deployed reality (`sprk_envaccountdomain`, `sprk_mdaappid`) |
+| Lookup type filtering | Filter Target Environment lookup by environment type (deferred from r1 scope) |
+| Azure resource automation | Entra group / Conditional Access / SPE container setup per environment is still manual (r1 out-of-scope) |

--- a/projects/spaarke-environment-provisioning-app/tasks/040-e2e-testing-checklist.poml
+++ b/projects/spaarke-environment-provisioning-app/tasks/040-e2e-testing-checklist.poml
@@ -4,7 +4,7 @@
     <phase>5</phase>
     <tags>testing</tags>
     <estimate>2h</estimate>
-    <status>pending</status>
+    <status>completed</status>
     <dependencies>032</dependencies>
     <parallel-safe>false</parallel-safe>
   </metadata>
@@ -41,4 +41,14 @@
     <criterion>All 11 success criteria from spec verified</criterion>
     <criterion>Test results documented</criterion>
   </acceptance-criteria>
+
+  <notes>
+    Completed 2026-06-12. 7 of 11 criteria verified (programmatic + static); 4 require live
+    provisioning (operator sign-off) — documented as manual items. Criterion 10 BLOCKED by
+    DemoExpirationService dependency on obsolete Environments config (carry to r2).
+    Two defects found and fixed: D-040-01 (FR-11 per-env licenses never passed to license
+    assignment — fixed across 4 files + 6 unit tests) and D-040-02 (seed records had empty
+    license SKU IDs — populated from Azure values). Full results:
+    notes/e2e-test-results.md.
+  </notes>
 </task>

--- a/projects/spaarke-environment-provisioning-app/tasks/090-project-wrap-up.poml
+++ b/projects/spaarke-environment-provisioning-app/tasks/090-project-wrap-up.poml
@@ -4,7 +4,7 @@
     <phase>5</phase>
     <tags>docs, cleanup</tags>
     <estimate>30m</estimate>
-    <status>pending</status>
+    <status>completed</status>
     <dependencies>040</dependencies>
     <parallel-safe>false</parallel-safe>
   </metadata>
@@ -43,4 +43,12 @@
     <criterion>Lessons-learned documented</criterion>
     <criterion>Repo passes cleanup audit</criterion>
   </acceptance-criteria>
+
+  <notes>
+    Completed 2026-06-12. README status Complete with graduation criteria dispositioned
+    (9/10 met; criterion "remove Azure Environments config" carried to r2 — blocked by
+    DemoExpirationService). notes/lessons-learned.md written (5 lessons + 6 carry-overs).
+    Hygiene check: working tree contains only intended files; deploy/api-publish output is
+    gitignored. Carry-overs feed the environment-factory-r1 design.
+  </notes>
 </task>

--- a/projects/spaarke-environment-provisioning-app/tasks/TASK-INDEX.md
+++ b/projects/spaarke-environment-provisioning-app/tasks/TASK-INDEX.md
@@ -1,7 +1,7 @@
 # Task Index — spaarke-environment-provisioning-app
 
 > **Total Tasks**: 17
-> **Last Updated**: 2026-04-06
+> **Last Updated**: 2026-06-12
 
 ## Status Overview
 
@@ -27,8 +27,8 @@
 | 030 | Remove Environments from Options | 4 | ✅ | 016 |
 | 031 | Refactor RegistrationDataverseService URL | 4 | ✅ | 030 |
 | 032 | Update Documentation | 4 | ✅ | 031 |
-| 040 | E2E Testing Checklist | 5 | 🔲 | 032 |
-| 090 | Project Wrap-Up | 5 | 🔲 | 040 |
+| 040 | E2E Testing Checklist | 5 | ✅ | 032 |
+| 090 | Project Wrap-Up | 5 | ✅ | 040 |
 
 ## Parallel Execution Groups
 

--- a/src/server/api/Sprk.Bff.Api/Configuration/DemoProvisioningOptions.cs
+++ b/src/server/api/Sprk.Bff.Api/Configuration/DemoProvisioningOptions.cs
@@ -98,6 +98,12 @@ public class DemoEnvironmentConfig
     /// Default demo access duration in days. Admin can adjust per record.
     /// </summary>
     public int DefaultDemoDurationDays { get; set; } = 14;
+
+    /// <summary>
+    /// Per-environment license SKUs (FR-11), populated from sprk_licenseconfigjson at
+    /// approval time. Null or all-empty falls back to DemoProvisioningOptions.Licenses.
+    /// </summary>
+    public LicenseSkuConfig? Licenses { get; set; }
 }
 
 /// <summary>

--- a/src/server/api/Sprk.Bff.Api/Endpoints/RegistrationEndpoints.cs
+++ b/src/server/api/Sprk.Bff.Api/Endpoints/RegistrationEndpoints.cs
@@ -298,7 +298,15 @@ public static class RegistrationEndpoints
                 TeamName = environment.TeamName ?? throw new InvalidOperationException("Environment is missing TeamName"),
                 SpeContainerId = environment.SpeContainerId ?? throw new InvalidOperationException("Environment is missing SpeContainerId"),
                 AppId = environment.AppId,
-                DefaultDemoDurationDays = environment.DefaultDurationDays ?? 14
+                DefaultDemoDurationDays = environment.DefaultDurationDays ?? 14,
+                // FR-11: per-environment license SKUs; GraphUserService falls back to
+                // global DemoProvisioning:Licenses when null or all-empty
+                Licenses = licenseConfig == null ? null : new LicenseSkuConfig
+                {
+                    PowerAppsPlan2TrialSkuId = licenseConfig.PowerAppsPlan2TrialSkuId ?? string.Empty,
+                    FabricFreeSkuId = licenseConfig.FabricFreeSkuId ?? string.Empty,
+                    PowerAutomateFreeSkuId = licenseConfig.PowerAutomateFreeSkuId ?? string.Empty
+                }
             };
 
             logger.LogInformation(

--- a/src/server/api/Sprk.Bff.Api/Services/Registration/DemoProvisioningService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Registration/DemoProvisioningService.cs
@@ -135,7 +135,7 @@ public sealed class DemoProvisioningService
 
             // ── Step 5: Assign licenses ──
             _logger.LogInformation("[Step 5/9] Assigning licenses to user {UserId}", entraUserId);
-            await _graphUserService.AssignLicensesAsync(entraUserId, ct);
+            await _graphUserService.AssignLicensesAsync(entraUserId, environment.Licenses, ct);
             completedSteps.Add("AssignLicenses");
             _logger.LogInformation("[Step 5/9] Licenses assigned");
 

--- a/src/server/api/Sprk.Bff.Api/Services/Registration/GraphUserService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Registration/GraphUserService.cs
@@ -169,14 +169,16 @@ public sealed class GraphUserService
     /// <summary>
     /// Assigns the configured demo licenses to a user.
     /// Idempotent: skips licenses already assigned.
-    /// SKU IDs are sourced from DemoProvisioningOptions.Licenses.
+    /// SKU IDs come from the per-environment license config (FR-11) when it specifies
+    /// at least one SKU; otherwise falls back to the tenant-wide DemoProvisioningOptions.Licenses.
     /// </summary>
     /// <param name="userId">Entra ID user object ID.</param>
+    /// <param name="environmentLicenses">Per-environment license SKUs from sprk_licenseconfigjson; null or all-empty falls back to global config.</param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task AssignLicensesAsync(string userId, CancellationToken ct = default)
+    public async Task AssignLicensesAsync(string userId, LicenseSkuConfig? environmentLicenses = null, CancellationToken ct = default)
     {
         var graphClient = _graphClientFactory.ForApp();
-        var licenses = _options.Licenses;
+        var licenses = ResolveLicenses(_options.Licenses, environmentLicenses);
 
         var skuIds = new[]
         {
@@ -214,6 +216,23 @@ public sealed class GraphUserService
             cancellationToken: ct);
 
         _logger.LogInformation("Successfully assigned licenses to user {UserId}", userId);
+    }
+
+    /// <summary>
+    /// Resolves which license set to assign: the per-environment config wins when it
+    /// specifies at least one SKU; a null or all-empty per-environment config falls back
+    /// to the global config so legacy environment records keep working.
+    /// </summary>
+    internal static LicenseSkuConfig ResolveLicenses(LicenseSkuConfig global, LicenseSkuConfig? perEnvironment)
+    {
+        if (perEnvironment is null)
+            return global;
+
+        var hasAnySku = !string.IsNullOrWhiteSpace(perEnvironment.PowerAppsPlan2TrialSkuId)
+            || !string.IsNullOrWhiteSpace(perEnvironment.FabricFreeSkuId)
+            || !string.IsNullOrWhiteSpace(perEnvironment.PowerAutomateFreeSkuId);
+
+        return hasAnySku ? perEnvironment : global;
     }
 
     /// <summary>

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Registration/LicenseResolutionTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Registration/LicenseResolutionTests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using FluentAssertions;
+using Sprk.Bff.Api.Configuration;
+using Sprk.Bff.Api.Services.Registration;
+using Xunit;
+
+namespace Sprk.Bff.Api.Tests.Services.Registration;
+
+/// <summary>
+/// Unit tests for FR-11 (per-environment license SKUs) and FR-12 (malformed
+/// license JSON rejected) in the environment provisioning flow.
+/// </summary>
+/// <remarks>
+/// Covers:
+/// <list type="bullet">
+///   <item><see cref="GraphUserService.ResolveLicenses"/> fallback rule: per-environment wins only when it has at least one SKU</item>
+///   <item><see cref="DataverseEnvironmentRecord.ParseLicenseConfig"/>: valid JSON, malformed JSON throws, empty returns null</item>
+/// </list>
+/// </remarks>
+public class LicenseResolutionTests
+{
+    private static LicenseSkuConfig GlobalLicenses() => new()
+    {
+        PowerAppsPlan2TrialSkuId = "11111111-1111-1111-1111-111111111111",
+        FabricFreeSkuId = "22222222-2222-2222-2222-222222222222",
+        PowerAutomateFreeSkuId = "33333333-3333-3333-3333-333333333333"
+    };
+
+    [Fact]
+    public void ResolveLicenses_NullPerEnvironment_ReturnsGlobal()
+    {
+        var global = GlobalLicenses();
+
+        var result = GraphUserService.ResolveLicenses(global, null);
+
+        result.Should().BeSameAs(global);
+    }
+
+    [Fact]
+    public void ResolveLicenses_AllEmptyPerEnvironment_FallsBackToGlobal()
+    {
+        var global = GlobalLicenses();
+        var perEnv = new LicenseSkuConfig
+        {
+            PowerAppsPlan2TrialSkuId = "",
+            FabricFreeSkuId = "",
+            PowerAutomateFreeSkuId = ""
+        };
+
+        var result = GraphUserService.ResolveLicenses(global, perEnv);
+
+        result.Should().BeSameAs(global);
+    }
+
+    [Fact]
+    public void ResolveLicenses_PerEnvironmentWithAnySku_WinsOverGlobal()
+    {
+        var global = GlobalLicenses();
+        var perEnv = new LicenseSkuConfig
+        {
+            PowerAppsPlan2TrialSkuId = "44444444-4444-4444-4444-444444444444",
+            FabricFreeSkuId = "",
+            PowerAutomateFreeSkuId = ""
+        };
+
+        var result = GraphUserService.ResolveLicenses(global, perEnv);
+
+        result.Should().BeSameAs(perEnv);
+    }
+
+    [Fact]
+    public void ParseLicenseConfig_ValidJson_ReturnsTypedConfig()
+    {
+        var record = new DataverseEnvironmentRecord
+        {
+            LicenseConfigJson =
+                "{\"PowerAppsPlan2TrialSkuId\":\"44444444-4444-4444-4444-444444444444\"," +
+                "\"FabricFreeSkuId\":\"55555555-5555-5555-5555-555555555555\"," +
+                "\"PowerAutomateFreeSkuId\":\"66666666-6666-6666-6666-666666666666\"}"
+        };
+
+        var config = record.ParseLicenseConfig();
+
+        config.Should().NotBeNull();
+        config!.PowerAppsPlan2TrialSkuId.Should().Be("44444444-4444-4444-4444-444444444444");
+        config.FabricFreeSkuId.Should().Be("55555555-5555-5555-5555-555555555555");
+        config.PowerAutomateFreeSkuId.Should().Be("66666666-6666-6666-6666-666666666666");
+    }
+
+    [Fact]
+    public void ParseLicenseConfig_MalformedJson_ThrowsJsonException()
+    {
+        var record = new DataverseEnvironmentRecord
+        {
+            LicenseConfigJson = "{not valid json"
+        };
+
+        var act = () => record.ParseLicenseConfig();
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void ParseLicenseConfig_EmptyOrWhitespace_ReturnsNull()
+    {
+        new DataverseEnvironmentRecord { LicenseConfigJson = null }.ParseLicenseConfig().Should().BeNull();
+        new DataverseEnvironmentRecord { LicenseConfigJson = "" }.ParseLicenseConfig().Should().BeNull();
+        new DataverseEnvironmentRecord { LicenseConfigJson = "   " }.ParseLicenseConfig().Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- **Task 040 (E2E)**: 7/11 spec criteria verified; 4 live-provisioning items documented for operator sign-off; criterion 10 (remove Azure `DemoProvisioning__Environments__*`) blocked by `DemoExpirationService` dependency — carried to r2. Full disposition: `projects/spaarke-environment-provisioning-app/notes/e2e-test-results.md`
- **Defect fix D-040-01 (FR-11)**: per-environment license config was validated but never used — `AssignLicensesAsync` now accepts per-environment licenses with fallback-to-global rule; 6 new unit tests pass
- **Defect fix D-040-02**: Dev + Demo 1 environment seed records' license SKU IDs populated from real Azure values (Dataverse data fix)
- **Task 090 (wrap-up)**: README → Complete, lessons-learned, project closed (22/22 tasks)
- **New**: `projects/spaarke-environment-factory-r1/design.md` — unified new-environment provisioning + deployment process design (successor program)

## BFF governance (CLAUDE.md §10)
- **Placement**: modification of existing Registration services only — no new endpoints, packages, DI registrations, or background work
- **Publish size (NFR-01)**: 46.02 MB compressed vs ~45.65 MB baseline (2026-05-26) — no threshold crossed
- **Tests**: `tests/unit/Sprk.Bff.Api.Tests/Services/Registration/LicenseResolutionTests.cs` (6/6 pass); `dotnet build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)