### PR TITLE
ci+fix: declare eslint as direct devDep in src/client/pcf (root-cause fix; ends Client Quality whack-a-mole)

### DIFF
--- a/.github/workflows/sdap-ci.yml
+++ b/.github/workflows/sdap-ci.yml
@@ -207,8 +207,17 @@ jobs:
         # (window.top usage in Power Apps integration code, unused-vars in catch blocks).
         # Mirrors the WarningsNotAsErrors policy applied to C# (visible but non-blocking).
         # Follow-on cleanup tracked per docs/assessments/bff-warning-suppression-analysis-2026-06-01.md.
+        #
+        # `node_modules/.bin/eslint` instead of `npx eslint` per PR #393 root-cause
+        # fix (2026-06-18): `npx eslint` silently auto-fetches `eslint` from the
+        # registry when the local copy is missing, masking install bugs. Using the
+        # local path forces resolution from the just-installed node_modules — if
+        # eslint is ever missing again, this step fails loudly with "ENOENT" rather
+        # than confusing `Cannot find module 'eslint/package.json'` errors deep in
+        # an ESLint plugin's require chain. See d-widget-parity-audit-2026-06-18.md
+        # follow-up + PR #393 commit message for the full root-cause analysis.
         working-directory: src/client/pcf
-        run: npx eslint .
+        run: node_modules/.bin/eslint .
 
       # Spaarke.AI.Widgets tsc gate (R4 task 061 / B-2 / NFR-05)
       # AI.Widgets tsconfig path-maps four @spaarke/* sibling packages to their

--- a/projects/smart-todo-r4/current-task.md
+++ b/projects/smart-todo-r4/current-task.md
@@ -14,11 +14,11 @@
 | **PR #377** | ✅ MERGED to master as squash `eed39e40a` (Phases 0 + 1 + Wave 2a + followups; 13 tasks) |
 | **PR #384** | ✅ MERGED to master 2026-06-11 (Waves A + B + C; 14 tasks) |
 | **Wave D** | ✅ COMPLETE on branch (NOT yet on master): 099 widget chrome + Pattern D, 101 useKanbanColumns hoist, 100 openTodo launch + BroadcastChannel refetch. 4 commits on branch (`c50690be8` planning + `6074d42b9` 099 + `afb6ac6cc` 101 + `f593292c2` 100). Closes UAT issues 1-6 from 2026-06-18 screenshot. |
-| **Worktree branch** | `work/smart-todo-r4-wave2` @ `f593292c2` — pushed to origin; 0 behind master |
-| **Active task** | none — Wave D closeout done |
-| **Working tree** | clean |
-| **Next Action** | **Three remaining tasks**, recommended order: (a) push 092 to ✅ — golden-path smoke test on spaarkedev1 of the 2026-06-18 deploy (still actionable; the new Wave D code is NOT in that deploy though, so a re-deploy will be required after Wave D merges); (b) 093 UI tests (can use `npm run dev` smoke; some Wave D tests in the new POMLs need real deploy); (c) 098 wrap-up + open follow-up PR. Could also open the Wave D PR now and let 092 redeploy happen after. |
-| **PR strategy** | PR #384 already covered Waves A+B+C. Wave D + 092 + 093 + 098 should land in a SINGLE follow-up PR titled "Wave D widget parity + Phase 3/4 closeout" (or two PRs: Wave D parity first, then a 098 close-out PR after). User to decide. |
+| **Worktree branch** | `work/smart-todo-r4-wave2` — synced to master tip `a93fbebf6` (post-PR-391 + PR-392) |
+| **Active task** | **R4-092 deploy** — IN-PROGRESS (Wave D + CI hardening deployed to spaarkedev1 2026-06-18; awaiting user UAT sign-off on golden-path) |
+| **Working tree** | clean (Wave D POMLs all ✅; 092 has detailed notes block; CI hardening landed via PR #392) |
+| **Next Action** | **User UAT**: walk the 6 widget-parity acceptance points (issues 1-6 from `notes/d-widget-parity-audit-2026-06-18.md`) against the live spaarkedev1 deploy. After sign-off: flip R4-092 to ✅, run R4-093 (UI test suite) if desired, then proceed to R4-098 wrap-up. |
+| **PR strategy** | Wave D shipped via PR #391 (merge commit `e4e91a3ec`); CI hardening shipped via PR #392 (`a93fbebf6`). Remaining 092 closeout + 093 + 098 will be one final PR after UAT sign-off. R4-098 wrap-up + PR-close HELD until UAT acceptance per user instruction. |
 
 ### Critical context for resume
 

--- a/projects/smart-todo-r4/tasks/092-deploy-all-affected-solutions.poml
+++ b/projects/smart-todo-r4/tasks/092-deploy-all-affected-solutions.poml
@@ -95,4 +95,46 @@ Build + deploy every affected solution to spaarkedev1. Confirm zero `sprk_todofl
     <criterion testable="true">Golden-path smoke test passes</criterion>
     <criterion testable="true">PR description lists all deployed surfaces + smoke-test result</criterion>
   </acceptance-criteria>
+
+  <notes>
+## Deploy session 2026-06-18 (Wave D)
+
+Post-PR #391 (Wave D widget parity) + PR #392 (CI hardening) — both merged to master at e4e91a3ec + a93fbebf6 respectively. This deploy supersedes the in-flight 2026-06-18 pre-Wave-D deploy logged in commit c5b5938bd (that session deployed 6 surfaces but did NOT include Wave D widget changes).
+
+### Surfaces deployed (3)
+
+| Surface | Web Resource | Bundle | Why |
+|---|---|---|---|
+| SmartTodo Code Page | `sprk_smarttodo` | 1706 KB | Carries Wave D changes to SmartTodoApp.tsx + useLaunchContext.ts (R4-100 openTodo auto-mount) |
+| SpaarkeAi workspace (embeds LW workspace shell) | `sprk_spaarkeai` | 3752 KB | Carries Wave D LW shim changes (R4-099 chrome consolidation + R4-100 onOpenTodo rewrite + R4-101 grouped widget). LW Code Page is RETIRED per OC-R4-05; SpaarkeAi is the deployable for LW-embedded UI. |
+| CreateTodoWizard Code Page | `sprk_createtodowizard` | 1620 KB | Carries R4-100 BroadcastChannel producer (`sprk_todo:created` channel). Required for UAT issue 1 (refetch after wizard close). Deploy-WizardCodePages.ps1 republished all 12 wizards as a batch — no harm; sprk_createtodowizard is the only one with Wave D delta. |
+
+### Surfaces NOT deployed (intentional)
+
+- **RegardingResolver PCF v1.1.0** — untouched in Wave D; v1.1.0 from prior 2026-06-18 deploy stays
+- **sprk_todo_dirty_check.js web resource** — untouched in Wave D; from R4-041, already on master from PR #384
+- **BFF API** — untouched in Wave D
+- **CorporateWorkspace** (`sprk_corporateworkspace`) — RETIRED per OC-R4-05; Deploy-CorporateWorkspace.ps1 is now a no-op skip
+
+### Pre-deploy verification
+
+- All builds green on the local main repo on master tip e4e91a3ec → a93fbebf6
+- npm install with `--legacy-peer-deps --no-audit --no-fund` (matches CI's new pattern per PR #392)
+- DATAVERSE_URL = https://spaarkedev1.crm.dynamics.com; az auth valid (ralph.schroeder@spaarke.com / Spaarke Devlopment Environment)
+
+### Deploy results
+
+All 3 deploy scripts reported `Publishing customizations... Published`. No errors. Total deploy session ~5 minutes wall-clock for build + deploy + publish across all 3 surfaces.
+
+### Acceptance criteria status
+
+- [x] All affected solutions deployed to spaarkedev1 (3/3)
+- [x] sprk_todoflag in source: 0 functional hits (confirmed R4-094 grep gate 2026-06-12)
+- [ ] Golden-path smoke test — DELEGATED to user UAT checklist; awaiting sign-off
+- [ ] PR description — Wave D landed via PR #391; CI hardening via PR #392; runbook recorded in commit 44fcffc21 + this notes block
+
+### Status
+
+`in-progress` until user UAT sign-off confirms golden-path. Per user instruction "do not close the PR or project until testing and acceptance are signed off on" — R4-092 stays open; R4-098 wrap-up is held; PR-close is held.
+  </notes>
 </task>

--- a/src/client/pcf/package-lock.json
+++ b/src/client/pcf/package-lock.json
@@ -12,6 +12,7 @@
         "@microsoft/eslint-plugin-power-apps": "^0.2.51",
         "@types/node": "^18.19.86",
         "@types/powerapps-component-framework": "^1.3.16",
+        "eslint": "^9.39.4",
         "eslint-plugin-promise": "^7.1.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -1889,7 +1890,6 @@
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -1905,7 +1905,6 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -1919,7 +1918,6 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1933,7 +1931,6 @@
       "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.14.0",
         "debug": "^4.3.2",
@@ -1958,7 +1955,6 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1985,7 +1981,6 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1996,7 +1991,6 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -2011,7 +2005,6 @@
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/types": "^0.15.0"
       },
@@ -2025,7 +2018,6 @@
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.2",
         "@humanfs/types": "^0.15.0",
@@ -2041,7 +2033,6 @@
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -2052,7 +2043,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2067,7 +2057,6 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -3290,7 +3279,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -3311,7 +3299,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3364,6 +3351,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3442,8 +3442,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -4079,7 +4078,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4353,7 +4351,6 @@
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4509,8 +4506,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -5006,7 +5002,6 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5020,7 +5015,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5153,7 +5147,6 @@
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -5171,7 +5164,6 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5185,7 +5177,6 @@
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -5204,7 +5195,6 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -5284,16 +5274,14 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -5312,13 +5300,30 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -5408,7 +5413,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -5422,8 +5426,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -5639,7 +5642,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5921,7 +5923,6 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5942,7 +5943,6 @@
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -5973,7 +5973,6 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -6476,8 +6475,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -6561,7 +6559,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6587,24 +6584,21 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6664,7 +6658,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -6685,7 +6678,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -6756,8 +6748,7 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -7123,7 +7114,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -7192,7 +7182,6 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -7226,7 +7215,6 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7485,7 +7473,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -7508,7 +7495,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7743,7 +7729,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7991,19 +7976,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/schema-utils/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
       }
     },
     "node_modules/schema-utils/node_modules/json-schema-traverse": {
@@ -8283,7 +8255,6 @@
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -8297,7 +8268,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8667,7 +8637,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -8829,24 +8798,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -8949,7 +8900,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -9227,7 +9177,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -9398,7 +9347,6 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -9511,7 +9459,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/src/client/pcf/package.json
+++ b/src/client/pcf/package.json
@@ -17,6 +17,7 @@
     "@microsoft/eslint-plugin-power-apps": "^0.2.51",
     "@types/node": "^18.19.86",
     "@types/powerapps-component-framework": "^1.3.16",
+    "eslint": "^9.39.4",
     "eslint-plugin-promise": "^7.1.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",


### PR DESCRIPTION
## Summary

Second follow-up to PR #391 + #392 that addresses the **actual root cause** of the recurring Client Quality CI failures. This ends the whack-a-mole cycle.

### What the prior fixes did vs. what they missed

| PR | Symptom treated | Latent bug exposed |
|---|---|---|
| **#391** | Original wave |  |
| **#392** | `npm ci` "Missing eslint@9.39.4 from lock file" → swapped to `npm install --legacy-peer-deps` | Switched install command broke the implicit peer-install crutch that was masking the missing direct dep |
| **#393 (this)** | `Cannot find module 'eslint/package.json'` → declare eslint explicitly | Removes the defect itself |

### Root cause (definitive)

`src/client/pcf/package.json` declares ESLint **plugins** (`@eslint/js`, `eslint-plugin-react`, `typescript-eslint`, etc.) but does NOT declare `eslint` itself. The lockfile recorded eslint with `"peer": true` (line 5023). When my PR #392 swapped `npm ci` → `npm install --legacy-peer-deps`, peer-deps stopped auto-installing → eslint was absent from `node_modules` → `npx eslint .` silently auto-fetched eslint@10.5.0 from the registry into npx's temp cache → when an ESLint plugin's `require('eslint/package.json')` resolved from `pcf/node_modules/`, it failed.

12/14 per-PCF subdirectories + Spaarke.UI.Components + Spaarke.Auth ALL already declare `eslint` explicitly. The root PCF package was the only lint-running package without it.

### Two-part fix

**Primary**: Added `"eslint": "^9.39.4"` to `src/client/pcf/package.json` devDependencies. Regenerated `src/client/pcf/package-lock.json` so eslint becomes a normal direct entry (no longer `"peer": true`).

**Secondary (fail-loud)**: `.github/workflows/sdap-ci.yml` line 211: `npx eslint .` → `node_modules/.bin/eslint .`. Forces local resolution. If a future package.json edit removes eslint again, this step fails with `ENOENT` instead of the confusing plugin require error. Inline comment documents the rationale + PR #393 cross-reference.

### Why this won't be the third whack-a-mole

After this fix, eslint is independent of:
- `npm ci` vs `npm install` (it's a normal direct dep either way)
- `--legacy-peer-deps` (peer-dep flag becomes irrelevant for a direct dep)
- npx auto-fetch fallback (CI uses local binary path; would fail loudly if missing)

Three orthogonal install-behavior dimensions all become irrelevant. The fix aligns with the existing explicit-deps convention used everywhere else in the repo.

## Verification

Local install + verify (`src/client/pcf/`):
- ✅ 643 packages installed (vs. 587 with the missing peer)
- ✅ `node_modules/eslint/package.json` exists at v9.39.4
- ✅ `node_modules/.bin/eslint`, `.bin/eslint.cmd`, `.bin/eslint.ps1` all present
- ✅ `npm exec --no -- eslint --version` returns `v9.39.4`
- ✅ Lockfile entry for eslint shows `"dev": true` — no longer `"peer": true`

## Out of scope (follow-ups noted in commit message but not addressed here)

- `DrillThroughWorkspace` + `ScopeConfigEditor` per-PCF packages also don't declare `eslint` — could trip same wire if lint-staged ever runs on those (currently doesn't)
- CI cache key uses `package-lock.json` hash but install command can mutate the lockfile — minor indeterminism risk
- Some shared-lib `node_modules/` subdirs have stale `eslint.config.mjs` from transitive deps — `ignores: ["**/node_modules/"]` rule handles it at root

🤖 Generated with [Claude Code](https://claude.com/claude-code)