### PR TITLE
refactor(daily-update-r2): Option D — registry-as-composition factory replaces R2 task 002 module-mutation slot

### DIFF
--- a/projects/spaarke-daily-update-service-r2/current-task.md
+++ b/projects/spaarke-daily-update-service-r2/current-task.md
@@ -1,7 +1,7 @@
 # Current Task State
 
 > **Auto-updated by task-execute and context-handoff skills**
-> **Last Updated**: 2026-06-18 (project initialization)
+> **Last Updated**: 2026-06-18 (Option D mid-flight)
 > **Protocol**: [Context Recovery](../../docs/procedures/context-recovery.md)
 
 ---
@@ -10,31 +10,41 @@
 
 | Field | Value |
 |-------|-------|
-| **Task** | 024 — P2a unit + visual tests + dark-mode parity check (NarrativeBullet sub-list + SubRow*) |
-| **Step** | COMPLETE — 7 cases pass; 5 suites / 26 tests total |
-| **Status** | completed (no commit per task constraints; TASK-INDEX update deferred) |
-| **Next Action** | Awaiting orchestrator instruction for next task |
-| **Rigor Level** | FULL (.tsx test file, ADR-021 dark-mode, 7 test cases, mocks Xrm + callbacks) |
-| **Slot pattern** | 3 separate slot files (`SubRowLink.tsx`, `SubRowTodo.tsx`, `SubRowDismiss.tsx`) — enables Wave 9 parallel edits |
-| **Rigor Level** | FULL (refactoring tag, .ts modifications across 14 files, ADR-012 + ADR-024 + ADR-028) |
-| **Knowledge loaded** | task POML 015, project CLAUDE.md, project spec.md (FR-07), all 11 files in new package src/, source types/notifications.ts + notificationService.ts + preferencesService.ts + toastUtils.ts in solutions/DailyBriefing/, Spaarke.Auth/package.json (peer dep target), package.json of new package, sibling shared-lib tsconfigs (Smart Todo + Events for pattern parity) |
-| **Files hoisted (3 new in package)** | `src/client/shared/Spaarke.DailyBriefing.Components/src/types/notifications.ts` (323 LOC); `services/notificationService.ts` (330 LOC); `services/preferencesService.ts` (176 LOC); `utils/toastUtils.ts` (15 LOC) + `utils/index.ts` barrel |
-| **Files modified in new package** | `package.json` (added `@spaarke/auth` peer dep + `./utils` export); `src/index.ts` (added utils barrel re-export); `types/index.ts` (added `BriefingDependencies` interface + re-exported notifications surface); `services/index.ts` (added notification/preferences exports); `services/briefingService.ts` (`@spaarke/auth` direct import + intra-package `ChannelFetchResult`); 5 hooks (`useBriefingActions`, `useBriefingNarration`, `useBriefingNotifications`, `useBriefingPreferences`, `useInlineTodoCreate` — intra-package import paths); 3 components (`DailyBriefingApp`, `ActivityNotesSection`, `PreferencesDropdown` — intra-package import paths) |
-| **Shim files (4 in solutions/DailyBriefing)** | `types/notifications.ts` → `export * from "@spaarke/daily-briefing-components/types/notifications"`; `services/notificationService.ts` → re-export 5 funcs from `@spaarke/daily-briefing-components/services`; `services/preferencesService.ts` → re-export 2 funcs; `utils/toastUtils.ts` → `export { TOASTER_ID } from "@spaarke/daily-briefing-components/utils"` |
-| **package.json peer dep additions** | `@spaarke/auth: ^2.0.0` (per ADR-028; legit peer dep that task 010 scaffold should have included but didn't — orchestrator brief explicitly authorized this in task 015 scope) |
-| **`BriefingDependencies` interface (types/index.ts)** | `{ authenticatedFetch: AuthenticatedFetch, webApi: IWebApi, userId: string, tenantId: string, onRateLimitError?: (info) => void, onRecordOpen?: (info) => void }` — structural; concrete consumer wiring lives at standalone main.tsx + SpaarkeAi widget shell |
-| **Grep result** | `grep -rE "from\s+[\"'][^\"']*solutions/" src/client/shared/Spaarke.DailyBriefing.Components/src/` returns ZERO matches (clean). Also zero `Spaarke.Auth` back-pointer paths. All `solutions/` text in new package is JSDoc-comment-only (intentional hoist-origin history). |
-| **Build verification** | `npm run build` (`tsc --noEmit`) in new package returns 3 errors, all cross-package alias errors (`@spaarke/ui-components`, `@spaarke/ui-components/services`, `@spaarke/auth`) — same architectural pattern as sibling shared libs (Smart Todo + Events have identical `node` type-def errors when tsc-checked package-locally). Cross-package aliases resolve only at consumer site (Vite bundler resolution). ZERO new back-pointer errors. ZERO regressions in hoisted logic (byte-identical preservation). |
-| **Pattern chosen** | Hoist + re-export shim (Calendar + Smart Todo precedent). New package owns: types/notifications.ts, services/{notificationService,preferencesService,briefingService}.ts, utils/toastUtils.ts. Originals become 3-15 line shim files with `export * from "@spaarke/daily-briefing-components/…"`. Added `@spaarke/auth` peer dep + import path. Defined `BriefingDependencies` in types/index.ts. ADR-024 `TODO_REGARDING_CATALOG` in useInlineTodoCreate preserved verbatim (only `IWebApi`/`NotificationItem`/`NotificationPriority` type-import path rewritten). |
-| **Scope adherence** | Only files in `src/client/shared/Spaarke.DailyBriefing.Components/` + `src/solutions/DailyBriefing/` touched. NO BFF, LegalWorkspace, SpaarkeAi, authInit.ts, runtimeConfig.ts, MicrosoftToDoIcon, or TASK-INDEX.md touched (verified via git status). |
+| **Task** | Option D — replace module-mutation slot from R2 task 002 with registry-as-composition factory |
+| **Step** | 8 of 12 — design + Phase 7b POMLs done; implementing the 5-file refactor + 3 tests now |
+| **Status** | in-progress |
+| **Next Action** | Execute refactor on 6 source files per `notes/option-d-registry-as-composition.md` §3; add 3 unit tests; commit + push to PR #396 |
+| **Rigor Level** | FULL — touches LegalWorkspaceApp + SpaarkeAi/main.tsx + WorkspaceGrid + sectionRegistry; high-impact architectural change |
+| **Branch** | `work/spaarke-daily-update-service-r2` |
+| **Active PR** | [#396](https://github.com/spaarke-dev/spaarke/pull/396) — auto-merge armed; will re-fire when CI re-runs after Option D push |
 
-### Files Modified This Session
+### Files Modified Already This Session (Option D)
 
-- None for task 001 — the `loadNotificationContext?: () => Promise<NarrateRequest | null>` option was already added to `dailyBriefing.registration.ts`, `DailyBriefingSection.tsx`, and `useDailyBriefing.ts` in a prior project (task 086 / Round 4 Fix 3, per file headers). All FR-01 acceptance criteria are already met on the current `work/spaarke-daily-update-service-r2` branch.
+- `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md` — Created — design rationale + alternatives + cookbook + speculative-design discipline
+- `projects/spaarke-daily-update-service-r2/tasks/070-pattern-doc-workspace-section-registry-composition.poml` — Created
+- `projects/spaarke-daily-update-service-r2/tasks/071-update-architecture-docs-for-registry-composition.poml` — Created
+- `projects/spaarke-daily-update-service-r2/tasks/072-adr-workspace-section-registry-composition.poml` — Created
+- `projects/spaarke-daily-update-service-r2/current-task.md` — Modified (this file)
+
+### Pending implementation changes (next 6 files + tests)
+
+| File | Change |
+|---|---|
+| `src/solutions/LegalWorkspace/src/sectionRegistry.ts` | Add `createLegalWorkspaceSectionRegistry(options)` factory + `LegalWorkspaceSectionRegistryOptions` interface; `SECTION_REGISTRY = createLegalWorkspaceSectionRegistry()`; extract dev-guards into `runRegistryDevGuards(registry)` helper |
+| `src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts` | REMOVE `_globalNotificationLoader`, `setLegalWorkspaceDailyBriefingNotificationLoader`, `lateBoundNotificationLoader`; `dailyBriefingRegistration = createLegalWorkspaceDailyBriefingRegistration()` (no loader) |
+| `src/solutions/LegalWorkspace/src/index.ts` | REMOVE setter re-export; ADD factory + options + SECTION_REGISTRY + SectionRegistration type re-exports |
+| `src/solutions/LegalWorkspace/src/LegalWorkspaceApp.tsx` | Add `sections?: readonly SectionRegistration[]` to `ILegalWorkspaceAppProps`; pass to `WorkspaceGrid` |
+| `src/solutions/LegalWorkspace/src/components/Shell/WorkspaceGrid.tsx` | Accept `sections` prop (default → imported SECTION_REGISTRY); replace direct usage |
+| `src/solutions/SpaarkeAi/src/main.tsx` | REMOVE setter import + call; build `customSections = createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext: loadSpaarkeAiNotificationContext } })`; define `SpaarkeAiWorkspaceRenderer = (props) => <LegalWorkspaceApp {...props} sections={customSections} />`; register via existing `setDefaultWorkspaceRenderer(SpaarkeAiWorkspaceRenderer)` |
+| **Tests** | 3 new tests: no-options equivalence; loader threading; legacy setter API removed |
 
 ### Critical Context
 
-Wave 1 orchestrated execution. Task 001 = pre-existing no-op: the seam already exists. Required types (`NarrateRequest`, `CreateDailyBriefingRegistrationOptions`) are exported from `@spaarke/ui-components` via `src/components/WorkspaceShell/index.ts`. Build verification (npm run build) passes on the three dailyBriefing files in isolation; an unrelated `@spaarke/sdap-client` resolution error in `EntityCreationService.ts` is pre-existing and outside task 001 scope. Task 002 (SpaarkeAi main.tsx) can proceed.
+PR #396 is OPEN with auto-merge armed. Option D is being ADDED to this PR so the band-aid module-mutation pattern from R2 task 002 (Wave 8) is REPLACED, not layered. After Option D commits land, CI re-runs and auto-merge fires.
+
+R6 PR #395 is open in parallel with ZERO file-level overlap (verified via `git -C r6-worktree log --oneline origin/master..HEAD -- <files>`). Either PR can merge first; both will apply cleanly.
+
+3 Phase 7b documentation alignment tasks (070/071/072) are CREATED but NOT EXECUTED in this PR — they're queued for post-merge execution so the docs review can be holistic and not block the implementation merge.
 
 ---
 
@@ -42,13 +52,13 @@ Wave 1 orchestrated execution. Task 001 = pre-existing no-op: the seam already e
 
 | Field | Value |
 |-------|-------|
-| **Task ID** | 001 |
-| **Task File** | tasks/001-add-load-notification-context-factory-option.poml |
-| **Title** | Add `loadNotificationContext` factory option to dailyBriefingRegistration |
-| **Phase** | P1: Wiring Seam Fix |
-| **Status** | completed-no-op (already implemented) |
-| **Started** | 2026-06-18 (Wave 1 parallel batch) |
-| **Rigor Level** | FULL (per `<rigor-hint>FULL</rigor-hint>`; tags include `frontend/react/fluent-ui`; downstream blocks 002/003/010) |
+| **Task ID** | Option D (no POML — emerged from PR #396 architectural review) |
+| **Design rationale** | `notes/option-d-registry-as-composition.md` (canonical spec for the refactor) |
+| **Title** | Replace module-mutation slot from R2 task 002 with registry-as-composition factory |
+| **Phase** | P1 (architectural follow-up to task 002) |
+| **Status** | in-progress (design done; implementation next) |
+| **Started** | 2026-06-18 (mid-session, after user code review feedback) |
+| **Rigor Level** | FULL |
 
 ---
 
@@ -56,41 +66,68 @@ Wave 1 orchestrated execution. Task 001 = pre-existing no-op: the seam already e
 
 ### Completed Steps
 
-*No steps completed yet*
+- [x] **Step 1**: Diagnose the band-aid pattern (R2 task 002 / Wave 8 Option B module-mutation)
+- [x] **Step 2**: Evaluate alternatives (A: replace registry, B: shipped band-aid, C: React Context, D: registry-as-composition factory)
+- [x] **Step 3**: User authorization for Option D after rejecting C as too narrow for the SpaarkeAi-as-critical-core-surface vision
+- [x] **Step 4**: R6 review (zero file-level overlap confirmed via git diff against branches)
+- [x] **Step 5**: Author comprehensive design rationale in `notes/option-d-registry-as-composition.md`
+- [x] **Step 6**: Create Phase 7b POML tasks 070/071/072 for documentation alignment follow-ups
+- [x] **Step 7**: Update this `current-task.md` with full Option D context
 
 ### Current Step
 
-*No active task*
+**Step 8**: Implement the 6-file refactor + 3 unit tests
 
-### Files Modified (All Task)
+**What this step involves**:
+- Refactor `src/solutions/LegalWorkspace/src/sectionRegistry.ts` to expose `createLegalWorkspaceSectionRegistry(options)` factory + `LegalWorkspaceSectionRegistryOptions` interface. Default `SECTION_REGISTRY` becomes `createLegalWorkspaceSectionRegistry()` (no options). Dev-mode duplicate/drift guards extracted into a reusable `runRegistryDevGuards(registry)` helper that runs for every registry built.
+- In `dailyBriefing.registration.ts`: REMOVE `_globalNotificationLoader`, `setLegalWorkspaceDailyBriefingNotificationLoader`, `lateBoundNotificationLoader`. Default `dailyBriefingRegistration` const becomes `createLegalWorkspaceDailyBriefingRegistration()` (no loader → empty contract preserved for standalone consumers).
+- In `LegalWorkspace/src/index.ts`: REMOVE `setLegalWorkspaceDailyBriefingNotificationLoader` re-export. ADD `createLegalWorkspaceSectionRegistry` + `LegalWorkspaceSectionRegistryOptions` + (re-export of) `SECTION_REGISTRY` re-exports.
+- In `LegalWorkspaceApp.tsx`: ADD optional `sections?: readonly SectionRegistration[]` prop to `ILegalWorkspaceAppProps`. Pass through to `WorkspaceGrid`.
+- In `WorkspaceGrid.tsx`: accept `sections` prop (defaults to imported `SECTION_REGISTRY`). Replace direct usage with the prop variable.
+- In `SpaarkeAi/main.tsx`: REPLACE setter import + call with `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext: loadSpaarkeAiNotificationContext } })`. Define `SpaarkeAiWorkspaceRenderer: WorkspaceRenderer = (props) => <LegalWorkspaceApp {...props} sections={customSections} />`. Register via existing `setDefaultWorkspaceRenderer(SpaarkeAiWorkspaceRenderer)`.
+- Add 3 tests (no-options equivalence; loader threading; legacy setter API removed).
 
-*No files modified yet*
+### Subsequent Steps
+
+- **Step 9**: Build verify (`tsc --noEmit` on LegalWorkspace + new package + SpaarkeAi surface gate)
+- **Step 10**: Test verify (`npm test` in `Spaarke.DailyBriefing.Components` — 5 suites / 26 tests must still pass; new tests bring total to 5 suites / 29 tests)
+- **Step 11**: Update TASK-INDEX.md noting Option D as Wave 11 (post-Wave-10/task-024); commit
+- **Step 12**: Push to `work/spaarke-daily-update-service-r2`; auto-merge re-evaluates when CI re-runs
 
 ### Decisions Made
 
-- 2026-06-18: Use existing `work/spaarke-daily-update-service-r2` branch — Reason: matches Spaarke `work/` convention; current branch already set up.
-- 2026-06-18: Stop after task generation (no auto-execute) — Reason: 6-workstream project benefits from review before execution.
-- 2026-06-18: Skip env-provisioning-app lessons-learned carryforward — Reason: different domain.
+- **2026-06-18 (Option D session)**: Use Option D (registry-as-composition factory) instead of Option C (per-widget React Context). Reason: SpaarkeAi is a critical core surface that must support N widgets + two-way Assistant⇄Workspace⇄Context flows; Option C scales linearly with widget count, Option D scales O(1). Who: user (explicit authorization).
+- **2026-06-18**: NO speculative options added to `LegalWorkspaceSectionRegistryOptions` (no `paneEventBus`/`agentClient`/`contextProvider` until first real consumer). Reason: per CLAUDE.md "Don't add features beyond what the task requires"; the interface is extensible additively when concrete needs arrive. Who: design rationale §5.
+- **2026-06-18**: Documentation alignment (pattern doc + architecture docs + ADR) deferred to 3 separate Phase 7b POML tasks (070/071/072) executed post-merge. Reason: keep the implementation PR focused on the refactor; review the documentation holistically without it gating the merge. Who: user request ("include task(s) to review and update related documentation").
+- **2026-06-18**: NO changes to `@spaarke/ui-components` public API (e.g., NOT adding `sections` to `WorkspaceRendererProps`). Reason: SpaarkeAi can register a custom RENDERER (a wrapper function over `LegalWorkspaceApp`) via the existing `setDefaultWorkspaceRenderer` slot, which already accepts arbitrary renderers. This preserves the shared-lib boundary. Who: design rationale §3.6.
+- **2026-06-18 (R6 coordination)**: Proceed with Option D without coordinating with R6 team. Reason: R6 PR #395 makes ZERO commits to the files Option D touches; R6's Pillar 9 operates on a sibling `WorkspaceWidgetRegistry` at the AI-widgets layer, not `SECTION_REGISTRY` at the LegalWorkspace layer. Who: design rationale §6 + Explore-agent review.
 
 ---
 
 ## Next Action
 
-**Next Step**: Run `task-create projects/spaarke-daily-update-service-r2` to generate POML task files
+**Next Step**: Step 8 — execute the 6-file implementation refactor + 3 unit tests
 
 **Pre-conditions**:
-- `plan.md` and `CLAUDE.md` exist with discovered resources ✓
-- `tasks/` directory created (empty) ✓
+- Design rationale documented ✓
+- Phase 7b doc-alignment POMLs created ✓
+- User authorization received ✓
+- R6 zero-overlap confirmed ✓
+- current-task.md updated (this file) ✓
 
 **Key Context**:
-- Refer to `plan.md` §4 Phase Breakdown for the 6-workstream structure (P1, P2, P2a, P2b, P3, DD + Phase 7 deploy + Phase 8 wrap-up)
-- Refer to `CLAUDE.md` "Applicable ADRs" for the 11 ADRs each task must reference
-- Refer to `spec.md` FR-01..FR-21 for granular requirements per task
+- `notes/option-d-registry-as-composition.md` §3 has the exact target file shapes — implement to those shapes
+- The implementation MUST preserve `SECTION_REGISTRY` as a top-level export (consumer compatibility) — it just becomes a default-options factory call instead of a literal const
+- The legacy setter API (`setLegalWorkspaceDailyBriefingNotificationLoader`) MUST be REMOVED, not deprecated — the whole point is eliminating the band-aid
+- After implementation, all 5 Jest 30 suites + 26 tests from R2 must continue to pass (the new tests bring total to ~29)
+- After commit + push to `work/spaarke-daily-update-service-r2`, auto-merge on PR #396 re-fires when CI re-runs
 
 **Expected Output**:
-- 30–45 POML task files in `tasks/`
-- `tasks/TASK-INDEX.md` with parallel groups + critical path
-- BFF publish-size baseline in `notes/bff-baseline.md` (post-task-create)
+- 6 source files modified per notes/option-d-registry-as-composition.md §3
+- 3 new unit tests added
+- BFF build still green (no impact — only TypeScript files touched)
+- Jest suites still green
+- 1 commit pushed to PR #396
 
 ---
 
@@ -103,36 +140,57 @@ Wave 1 orchestrated execution. Task 001 = pre-existing no-op: the seam already e
 ## Session Notes
 
 ### Current Session
-- Started: 2026-06-18 (project initialization via `/project-pipeline`)
-- Focus: Generate project artifacts (README, plan, CLAUDE.md, task files)
+
+- Started: 2026-06-18 (continuation from R2 31/36 ship state)
+- Focus: Option D architectural refactor (replaces R2 task 002 band-aid)
 
 ### Key Learnings
 
-- R1 (`spaarke-daily-update-service`) has no `lessons-learned.md` — gap. Author one during R2 Phase 8 wrap-up to capture both R1 retrospective and R2 lessons.
-- Pre-flight: BFF builds clean on baseline (warnings pre-existing); master is current; worktree clean except for `projects/spaarke-daily-update-service-r2/` untracked dir.
+- The user's code-review eye caught the module-mutation band-aid before merge. The orchestration agent's framing ("Option B works, file as debt later") was too narrow. The right answer at architectural-review time is "fix it now if the cost is small relative to the strategic blast radius."
+- The pattern (one factory + typed options interface) is the right primitive for N widgets even when only 1 widget needs it today. Adding the pattern doesn't speculatively design future widgets; it just makes adding them cheap when they arrive.
+- `notes/option-d-registry-as-composition.md` is the persistent record. Future maintainers don't have to re-derive the alternatives evaluation.
+- **Speculative-design discipline**: do NOT add `paneEventBus`/`agentClient`/`contextProvider` to `LegalWorkspaceSectionRegistryOptions` today. Add them when the first concrete consumer needs them. The interface is extensible additively.
 
 ### Handoff Notes
 
-*No handoff notes (initialization session)*
+If this session is interrupted before Option D implementation completes:
+
+1. Read `notes/option-d-registry-as-composition.md` §3 for the exact target file shapes — those are the canonical implementation plan
+2. Read this `current-task.md` "Pending implementation changes" list for the 6 files to modify
+3. Read `notes/task-002-blocker.md` for the original architectural analysis that led here
+4. Read the existing `src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts` to see Option B's current code (the band-aid being removed)
+5. Read `src/solutions/SpaarkeAi/src/main.tsx` lines 60-75 + 229-241 to see Option B's setter call (being removed)
+6. After implementing: run `npm test` in `src/client/shared/Spaarke.DailyBriefing.Components/` (existing 5 suites / 26 tests should still pass; new tests bring total to ~29)
+7. Commit + push to `work/spaarke-daily-update-service-r2`; auto-merge on PR #396 will re-evaluate when CI runs
 
 ---
 
 ## Quick Reference
 
 ### Project Context
+
 - **Project**: `spaarke-daily-update-service-r2`
 - **Project CLAUDE.md**: [`CLAUDE.md`](./CLAUDE.md)
-- **Task Index**: [`tasks/TASK-INDEX.md`](./tasks/TASK-INDEX.md) (pending creation)
+- **Task Index**: [`tasks/TASK-INDEX.md`](./tasks/TASK-INDEX.md)
+- **Active PR**: [#396](https://github.com/spaarke-dev/spaarke/pull/396)
+- **Companion design rationale**: [`notes/option-d-registry-as-composition.md`](./notes/option-d-registry-as-composition.md)
+- **Phase 7b POMLs (post-merge follow-ups)**: tasks 070 (pattern), 071 (architecture docs), 072 (ADR-033)
 
-### Applicable ADRs
+### Applicable ADRs (Option D specifically)
 
-(See [`CLAUDE.md`](./CLAUDE.md) §Applicable ADRs for the full table; 11 ADRs total.)
+- **ADR-006** — UI Surface Architecture (Pattern D dual-use baseline; new ADR-033 will reference)
+- **ADR-012** — Shared Component Library (per-widget factory pattern Option D builds on; new ADR-033 will reference)
+- **ADR-022** — React 19 (the prop-drilling vs context decision; Option D prefers props at this layer)
+- **ADR-026** — Code Page Build Standard (no changes; the shrunk standalone host shell still works)
 
-- ADR-001, ADR-006, ADR-008, ADR-010, ADR-012, ADR-013, ADR-021, ADR-024, ADR-026, ADR-027, ADR-028
+(See `CLAUDE.md` "Applicable ADRs" for the full R2 ADR table; Option D adds ADR-033 as a follow-up via task 072.)
 
 ### Knowledge Files Loaded
 
-(Will be populated per task by task-execute Step 1.)
+- `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md` — comprehensive design
+- `projects/spaarke-daily-update-service-r2/notes/task-002-blocker.md` — original architectural analysis
+- R6 worktree at `C:/code_files/spaarke-wt-spaarke-ai-platform-unification-r6` — reviewed for overlap
+- The 6 source files listed under "Pending implementation changes" — read in main session before implementation
 
 ---
 
@@ -142,8 +200,8 @@ Wave 1 orchestrated execution. Task 001 = pre-existing no-op: the seam already e
 
 1. **Quick Recovery**: Read the "Quick Recovery" section above (< 30 seconds)
 2. **If more context needed**: Read Active Task and Progress sections
-3. **Load task file**: `tasks/{task-id}-*.poml` (once tasks exist)
-4. **Load knowledge files**: From task's `<knowledge>` section
+3. **Load design rationale**: `notes/option-d-registry-as-composition.md` §3 (target file shapes) is the canonical implementation plan
+4. **Knowledge**: the 6 implementation files are listed under "Pending implementation changes" — read them before editing
 5. **Resume**: From the "Next Action" section
 
 **Commands**:

--- a/projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md
+++ b/projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md
@@ -1,0 +1,441 @@
+# Option D — Registry-as-Composition Factory for LegalWorkspace Sections
+
+> **Project**: `spaarke-daily-update-service-r2`
+> **Status**: ACTIVE — implementation in progress on PR #396
+> **Decision date**: 2026-06-18
+> **Supersedes**: the module-mutation slot pattern introduced by R2 task 002 (Wave 8)
+> **Reach**: foundational pattern for ALL future SpaarkeAi workspace customization
+
+## Why this document exists
+
+The user explicitly flagged that:
+1. The SpaarkeAi workspace is a critical core surface for the entire platform
+2. It must support **two-way interaction between Assistant ⇄ Workspace ⇄ Context**
+3. The module-mutation pattern landed in R2 task 002 was a band-aid that doesn't scale to that vision
+4. We need the COMPREHENSIVE fix now, not the dailyBriefing-only patch
+
+This document captures the problem, the alternatives we evaluated, the chosen design, the cookbook for future widgets, and the speculative-design discipline.
+
+---
+
+## 1. The architectural problem
+
+### 1.1 What broke (functional)
+
+For ~7 weeks before R2 daily-update-service-r2 task 002, the SpaarkeAi workspace pane showed an empty Daily Briefing for users who clearly had unread `appnotification` rows. The widget code worked. The BFF `/narrate` endpoint worked. The standalone Daily Briefing Code Page rendered correctly. But the embedded copy inside SpaarkeAi always rendered the "Nothing to see right now" empty state.
+
+### 1.2 Why it broke (architectural)
+
+The render path inside SpaarkeAi looks like this:
+
+```
+SpaarkeAi main.tsx
+  → setDefaultWorkspaceRenderer(LegalWorkspaceRenderer)
+  → renders <App />
+       → renders <WorkspaceLayoutWidget /> from @spaarke/ai-widgets
+       → that widget reads the renderer slot, instantiates <LegalWorkspaceRenderer {...props} />
+       → LegalWorkspaceApp imports `SECTION_REGISTRY` directly from ./sectionRegistry
+            → SECTION_REGISTRY is a `readonly SectionRegistration[]` const
+              built at module-load time with a STATIC `dailyBriefingRegistration`
+              that has no `loadNotificationContext` option supplied
+       → WorkspaceGrid reads SECTION_REGISTRY, finds `dailyBriefingRegistration`,
+         mounts DailyBriefingSection which calls useDailyBriefing with no loader
+            → useDailyBriefing's empty-payload contract fires
+            → BFF /narrate returns empty bullets → empty state UI
+```
+
+The root cause is **`SECTION_REGISTRY` is a hard-coded `readonly` const built at module-load time, with NO seam for consumers to inject per-widget options**. Every host that consumes `LegalWorkspaceApp` gets the same static registry, with no way to override per-widget construction.
+
+SpaarkeAi needed to inject ONE function (`loadSpaarkeAiNotificationContext`) for ONE widget (Daily Briefing). The architectural primitive forced us to either:
+- Change `SECTION_REGISTRY` (touches every consumer of LegalWorkspace — out of scope)
+- Bypass it with a back-channel
+
+R2 task 002 chose the back-channel — a module-mutable slot with a setter + wrapper. **That works for one widget once, but it's not a pattern.**
+
+### 1.3 Why this matters beyond Daily Briefing
+
+The user surfaced the strategic vision: SpaarkeAi is a critical core surface that must support arbitrary widgets and **two-way Assistant ⇄ Workspace ⇄ Context flows**. Concrete examples on the horizon:
+
+- A chat panel widget that needs an `AgentClient` reference (Assistant ↔ Workspace)
+- A Context-aware widget that needs a `ContextProvider` for the current matter/record (Context → Workspace)
+- Widget-to-widget messaging via `PaneEventBus` (Workspace ↔ Workspace cross-cuts)
+- A widget that needs to be configured differently in SpaarkeAi vs standalone LegalWorkspace (e.g., a Calendar that defaults to a different filter)
+- Per-host visibility policy (R6 Pillar 9 — `getAgentVisibleState` callbacks)
+
+If we leave the module-mutation pattern in place, **every one of those will require its own bespoke setter/slot/wrapper**. N widgets → N global setters → N opportunities for order-of-initialization bugs → N maintenance debts. The architecture should make adding the next widget cheap and discoverable; today it makes adding the next widget a new ad-hoc piece of infrastructure.
+
+---
+
+## 2. Alternatives evaluated
+
+### Option A — Replace SpaarkeAi's section registration entry directly
+
+What it would look like: SpaarkeAi imports the SECTION_REGISTRY array, swaps out the entry it wants, registers the modified copy.
+
+**Why we rejected it**: `SECTION_REGISTRY` is `readonly` and `as const`. It can't be mutated. Even if we made it mutable, we'd be exposing array slot positions as a public API — fragile.
+
+### Option B — Module-mutable slot + setter (R2 task 002 — what we shipped first)
+
+What we did: LegalWorkspace shim file holds `let _globalNotificationLoader`. SpaarkeAi `main.tsx` calls `setLegalWorkspaceDailyBriefingNotificationLoader(loader)` at bootstrap. The default `dailyBriefingRegistration` const wraps a `lateBoundNotificationLoader` function that consults the slot at every fetch.
+
+**Why it's a band-aid**:
+- Global singleton — exactly one consumer can register at a time
+- Order-dependent — if anything renders before main.tsx's setter call, the bullet renders empty (silent failure)
+- 3 layers of indirection (slot + setter + wrapper) to deliver one function value
+- Doesn't scale — every future widget needs its own setter
+- It's a service-locator anti-pattern bolted onto a system that already has proper DI primitives (the factory option `loadNotificationContext` exists; we're bypassing it)
+
+### Option C — React Context for the loader
+
+What it would look like: Define `NotificationLoaderContext` in `@spaarke/daily-briefing-components`. `useDailyBriefing` reads `useContext`. SpaarkeAi `main.tsx` wraps its tree in `<NotificationLoaderContext.Provider value={loadSpaarkeAiNotificationContext}>`.
+
+**Why we rejected it** (the user's correction — they were right):
+- Solves Daily Briefing's specific instance of the problem; doesn't address the broader pattern
+- Every future widget needs its own Context type and its own Provider wrap — scales linearly with widget count
+- Doesn't naturally model two-way comms (Context is read-only injection, not bidirectional)
+- No type-level discoverability of "what host options does this widget accept?"
+- Forces the wiring to live INSIDE the widget package rather than at the workspace assembly layer where it belongs
+
+It's strictly better than Option B for Daily Briefing alone, but it sets the wrong precedent for the codebase.
+
+### Option D — Registry-as-Composition Factory ← CHOSEN
+
+What it looks like:
+
+- `LegalWorkspace` exports `createLegalWorkspaceSectionRegistry(options: LegalWorkspaceSectionRegistryOptions): readonly SectionRegistration[]` — a factory function
+- `LegalWorkspaceSectionRegistryOptions` is a typed contract — the canonical interface for "what knobs are configurable per widget"
+- `SECTION_REGISTRY` (the existing top-level const) becomes `createLegalWorkspaceSectionRegistry()` with no arguments — preserves all current behavior for standalone consumers byte-identically
+- `LegalWorkspaceApp` accepts an optional `sections?: readonly SectionRegistration[]` prop, defaulting to the bare const
+- SpaarkeAi `main.tsx` builds its own registry: `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext: loadSpaarkeAiNotificationContext } })` — passes it to the renderer via a small wrapper function registered through the existing `setDefaultWorkspaceRenderer` slot
+- The module-mutation slot from Option B is DELETED entirely
+
+**Why this is the correct architecture**:
+
+1. **One pattern, all widgets**: every per-widget customization SpaarkeAi (or any future host) needs becomes an entry in `LegalWorkspaceSectionRegistryOptions`. No new setters, no new global state, no new contexts.
+
+2. **Type-safe discoverability**: `LegalWorkspaceSectionRegistryOptions` IS the contract. A maintainer adding a new widget sees the interface and knows exactly what knobs exist. Reviewing a host bootstrap, you see one `createLegalWorkspaceSectionRegistry(...)` call and immediately know what's customized.
+
+3. **Standalone behavior preserved**: `createLegalWorkspaceSectionRegistry()` with no options returns a registry byte-identical to today's `SECTION_REGISTRY`. Standalone LegalWorkspace bundle is unchanged (FR-25 / NFR-10).
+
+4. **Composable**: SpaarkeAi can override Daily Briefing only and take defaults for Calendar, Smart Todo, etc. Or it can override several. Or none. The default is the no-options registry.
+
+5. **Aligns with the strategic vision**: when the first concrete consumer needs `paneEventBus` or `agentClient` or `contextProvider`, those become NEW entries in `LegalWorkspaceSectionRegistryOptions`. The pattern absorbs them without architectural change. We don't speculatively add them today (see §5 below).
+
+6. **No global state, no order-dependency**: the registry is built when the consumer constructs it, then passed as a prop. There's no module mutation, no setter sequence to remember.
+
+7. **Test-friendly**: a test can build a registry with mocks (`createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext: () => Promise.resolve(mockEnvelope) } })`) and pass it to a rendered `<LegalWorkspaceApp sections={testRegistry} />`. Today's module-mutation pattern requires test-fixture coordination on the setter call order.
+
+8. **Removes 3 layers of indirection**: the slot, the setter, the late-bound wrapper all go away. The factory option is consumed directly via dependency injection at construction time, which is what it was designed for.
+
+---
+
+## 3. The design (target file shapes)
+
+### 3.1 `src/solutions/LegalWorkspace/src/sectionRegistry.ts`
+
+```ts
+import type { SectionRegistration, SectionCategory, NarrateRequest } from "@spaarke/ui-components";
+import { SECTION_METADATA_CATALOG } from "@spaarke/ui-components";
+import { createLegalWorkspaceDailyBriefingRegistration } from "./sections/dailyBriefing/dailyBriefing.registration";
+import { calendarRegistration } from "./sections/calendar.registration";
+// ... other registrations stay imported as static consts (they don't have per-host knobs YET)
+
+/**
+ * Per-widget customization options for the LegalWorkspace section registry.
+ *
+ * Each property targets ONE widget's factory and exposes ONLY the knobs that
+ * widget's factory accepts. Adding a new knob = add it here + thread it through.
+ *
+ * Speculative-design discipline: only widgets that have a real consumer-driven
+ * customization need appear here. When the first concrete consumer demands a
+ * new knob, add it. Until then, the widget's static registration suffices.
+ */
+export interface LegalWorkspaceSectionRegistryOptions {
+  /**
+   * Daily Briefing customization. Currently exposes the notification-context
+   * loader — used by SpaarkeAi to flow `loadSpaarkeAiNotificationContext` into
+   * the BFF /narrate envelope so the embedded copy renders real bullets.
+   *
+   * Standalone consumers omit this → empty-payload contract preserved.
+   */
+  dailyBriefing?: {
+    loadNotificationContext?: () => Promise<NarrateRequest | null>;
+  };
+
+  // Future per-widget customizations live here. Examples we are NOT adding
+  // today (no real consumer):
+  //   calendar?: { initialFilter?: CalendarFilter; onDayClick?: (date: Date) => void };
+  //   smartTodo?: { /* future knobs */ };
+  //
+  // Future cross-widget primitives (e.g. paneEventBus, agentClient,
+  // contextProvider) also live here when the first concrete consumer arrives.
+}
+
+/**
+ * Build a LegalWorkspace section registry, optionally customizing per-widget
+ * construction. With no options, returns a registry byte-identical to the
+ * standalone-LegalWorkspace SECTION_REGISTRY (preserves FR-25 / NFR-10).
+ */
+export function createLegalWorkspaceSectionRegistry(
+  options: LegalWorkspaceSectionRegistryOptions = {},
+): readonly SectionRegistration[] {
+  const registry: readonly SectionRegistration[] = [
+    getStartedRegistration,
+    quickSummaryRegistration,
+    latestUpdatesRegistration,
+    todoRegistration,
+    documentsRegistration,
+    mattersRegistration,
+    projectsRegistration,
+    invoicesRegistration,
+    workAssignmentsRegistration,
+    createLegalWorkspaceDailyBriefingRegistration(options.dailyBriefing ?? {}),
+    calendarRegistration,
+  ];
+
+  // Dev-mode duplicate / metadata-drift guards run for every constructed
+  // registry (not just the default one) so custom registries are also checked.
+  if (process.env.NODE_ENV !== "production") {
+    runRegistryDevGuards(registry);
+  }
+
+  return registry;
+}
+
+/**
+ * The default LegalWorkspace section registry — built once with no overrides.
+ * Standalone LegalWorkspace imports this directly; embedding consumers
+ * (SpaarkeAi) build their own via `createLegalWorkspaceSectionRegistry({...})`.
+ */
+export const SECTION_REGISTRY: readonly SectionRegistration[] =
+  createLegalWorkspaceSectionRegistry();
+
+// Lookup helpers continue to operate on SECTION_REGISTRY (default).
+export function getSectionById(id: string): SectionRegistration | undefined { ... }
+export function getSectionsByCategory(category: SectionCategory): SectionRegistration[] { ... }
+
+// runRegistryDevGuards(registry) extracted from the existing dev-guard block
+// at the module bottom — now reusable for any custom registry built via the
+// factory (custom registries get the same drift detection as the default).
+```
+
+### 3.2 `src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts`
+
+```ts
+// REMOVE:
+//   - _globalNotificationLoader: ... | null = null;
+//   - export function setLegalWorkspaceDailyBriefingNotificationLoader(...)
+//   - function lateBoundNotificationLoader(): Promise<NarrateRequest | null>
+//
+// KEEP:
+//   - CreateLegalWorkspaceDailyBriefingRegistrationOptions (unchanged)
+//   - routeRateLimitTelemetry (unchanged)
+//   - createLegalWorkspaceDailyBriefingRegistration(options) (unchanged)
+//
+// CHANGE:
+//   - dailyBriefingRegistration: stop wrapping lateBoundNotificationLoader;
+//     just call the factory with no loader (no options)
+
+export const dailyBriefingRegistration: SectionRegistration =
+  createLegalWorkspaceDailyBriefingRegistration();  // no loader → empty payload
+```
+
+### 3.3 `src/solutions/LegalWorkspace/src/index.ts`
+
+```ts
+// REMOVE:
+//   - export { setLegalWorkspaceDailyBriefingNotificationLoader } from ...
+//
+// ADD:
+//   - export {
+//       createLegalWorkspaceSectionRegistry,
+//       SECTION_REGISTRY,
+//       type LegalWorkspaceSectionRegistryOptions,
+//     } from "./sectionRegistry";
+//   - re-export SectionRegistration type for ergonomics
+```
+
+### 3.4 `src/solutions/LegalWorkspace/src/LegalWorkspaceApp.tsx`
+
+```ts
+// Add to ILegalWorkspaceAppProps:
+interface ILegalWorkspaceAppProps {
+  // ... existing props
+  /**
+   * Optional custom section registry. When omitted, the default
+   * SECTION_REGISTRY is used (standalone LegalWorkspace behavior).
+   * Embedding consumers (SpaarkeAi) pass a registry built via
+   * createLegalWorkspaceSectionRegistry({...}).
+   */
+  sections?: readonly SectionRegistration[];
+}
+
+// Thread sections down to WorkspaceGrid. WorkspaceGrid currently imports
+// SECTION_REGISTRY directly — change it to accept the registry as a prop.
+```
+
+### 3.5 `src/solutions/LegalWorkspace/src/components/Shell/WorkspaceGrid.tsx`
+
+```ts
+// REMOVE:
+//   - import { SECTION_REGISTRY } from "../../sectionRegistry";
+//
+// CHANGE: accept sections as a prop (or via a new shell context if many
+// nested components consume it). Default to the imported SECTION_REGISTRY
+// at the entry point.
+```
+
+### 3.6 `src/solutions/SpaarkeAi/src/main.tsx`
+
+```ts
+// REMOVE:
+//   - import { setLegalWorkspaceDailyBriefingNotificationLoader } from "@spaarke/legal-workspace";
+//   - setLegalWorkspaceDailyBriefingNotificationLoader(loadSpaarkeAiNotificationContext);
+//
+// ADD:
+//   import { createLegalWorkspaceSectionRegistry, LegalWorkspaceApp } from "@spaarke/legal-workspace";
+//   import type { WorkspaceRenderer } from "@spaarke/ui-components";
+//
+//   const sectionsForSpaarkeAi = createLegalWorkspaceSectionRegistry({
+//     dailyBriefing: {
+//       loadNotificationContext: loadSpaarkeAiNotificationContext,
+//     },
+//   });
+//
+//   const SpaarkeAiWorkspaceRenderer: WorkspaceRenderer = (props) => (
+//     <LegalWorkspaceApp {...props} sections={sectionsForSpaarkeAi} />
+//   );
+//
+//   setDefaultWorkspaceRenderer(SpaarkeAiWorkspaceRenderer);
+```
+
+---
+
+## 4. Cookbook — adding a new widget under this pattern
+
+When a future widget (Calendar, Smart Todo, future chat panel, future document viewer, etc.) needs per-host customization:
+
+1. **Author the widget's factory** in the shared lib or its own package. The factory accepts a typed options object and returns a `SectionRegistration`. Example: `createCalendarRegistration(options)`.
+
+2. **Wrap it in a LegalWorkspace shim** (mirrors `dailyBriefing.registration.ts`) — closes over LegalWorkspace-local concerns (auth, telemetry) and exposes a `createLegalWorkspaceXxxRegistration(options)` factory.
+
+3. **Add an entry to `LegalWorkspaceSectionRegistryOptions`** in `sectionRegistry.ts`:
+   ```ts
+   export interface LegalWorkspaceSectionRegistryOptions {
+     dailyBriefing?: { loadNotificationContext?: ... };
+     calendar?: { initialFilter?: CalendarFilter; onDayClick?: (date: Date) => void };
+     // ... newly added
+   }
+   ```
+
+4. **Thread the option through** in `createLegalWorkspaceSectionRegistry`:
+   ```ts
+   createLegalWorkspaceCalendarRegistration(options.calendar ?? {})
+   ```
+
+5. **No other changes needed**. SpaarkeAi (or any embedding host) can immediately customize the new widget by adding to its `createLegalWorkspaceSectionRegistry({...})` call. Standalone LegalWorkspace continues to work — it just uses the no-options default.
+
+6. **Tests**: add one test asserting that the new widget's customization option threads through to its registration entry.
+
+---
+
+## 5. Speculative-design discipline — what we do NOT add today
+
+The CLAUDE.md "Don't add features, refactor, or introduce abstractions beyond what the task requires" guidance applies. We add the registry-as-composition pattern (one factory + one options interface) because daily-update-r2 demands it. We do NOT add speculative entries that have no real consumer:
+
+| Not added today | Why not | When to add |
+|---|---|---|
+| `calendar?: { ... }` | No SpaarkeAi-side Calendar customization is requested in current scope | When the first SpaarkeAi feature request needs Calendar customization, or when ai-spaarke-ai-workspace-UI-r1 starts adding Calendar knobs |
+| `smartTodo?: { ... }` | Same — no current consumer | Same — when first concrete consumer needs it |
+| `paneEventBus?: PaneEventBus` (cross-widget) | The bus may not exist yet as a typed primitive in any package; speculative | When PaneEventBus lands as a real cross-widget primitive (R6 Pillar 6 + future work) |
+| `agentClient?: AgentClient` (Assistant flows) | The agent-client interface for widget-level binding doesn't exist yet | When the first chat-aware widget needs construction-time agent binding |
+| `contextProvider?: ContextProvider` (Context flows) | Context flows still resolve via Xrm frame-walk + StandaloneAiProvider's useEntityResolver | When the first widget needs a host-supplied context provider instead of Xrm fallback |
+| Per-widget `visibilityPolicy` (R6 Pillar 9 hook) | Pillar 9 currently lives at `WorkspaceWidgetRegistry` (a different registry, AI-widgets layer); coupling them is premature | When R6+ wants section-level visibility policy to compose with the AI-widgets layer |
+
+**The interface is the contract**. When any of those concrete needs arrives, the change is small and additive — one new property in `LegalWorkspaceSectionRegistryOptions` + one new thread-through call. The architecture absorbs new requirements without restructuring; today's no-options default keeps all existing consumers byte-identical.
+
+---
+
+## 6. R6 coordination
+
+R6 (`spaarke-ai-platform-unification-r6`) is in flight via open PR #395. Verified 2026-06-18:
+
+- R6 makes ZERO commits touching `src/solutions/SpaarkeAi/src/main.tsx`
+- R6 makes ZERO commits touching `src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/`
+- R6's Pillar 9 (`getAgentVisibleState`) operates on `WorkspaceWidgetRegistry` (a sibling registry in `@spaarke/ai-widgets`), NOT `SECTION_REGISTRY` in LegalWorkspace
+- R6 makes no assumption about `SECTION_REGISTRY` being a const
+
+**File-level overlap with Option D: zero.** Both PRs can merge in any order with no conflict resolution.
+
+Two non-blocking forward-design questions worth asking the R6 team (R7+ planning, not coordination blockers):
+
+1. Once Option D ships, should the `dailyBriefing.notificationLoader` option pattern be propagated to other per-widget options the R6 team would add? (Answer: yes — that's the whole point of the pattern.)
+2. Should R6 Pillar 9's `getAgentVisibleState` callback eventually compose into `LegalWorkspaceSectionRegistryOptions` so hosts can configure per-widget visibility policy at registry-construction time? (Open design question for R7+.)
+
+---
+
+## 7. Test coverage
+
+Two new unit tests in the new package (Jest 30 suite added by task 019):
+
+### Test 1: no-options factory returns standalone-equivalent registry
+
+```ts
+test('createLegalWorkspaceSectionRegistry() returns same widget IDs as SECTION_REGISTRY const', () => {
+  const fromFactory = createLegalWorkspaceSectionRegistry();
+  expect(fromFactory.map(r => r.id)).toEqual(SECTION_REGISTRY.map(r => r.id));
+  expect(fromFactory.length).toBe(SECTION_REGISTRY.length);
+});
+```
+
+### Test 2: dailyBriefing.loadNotificationContext threads through to the entry's factory
+
+```ts
+test('createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } }) threads loader', async () => {
+  const loader = jest.fn().mockResolvedValue({ /* mock NarrateRequest */ });
+  const registry = createLegalWorkspaceSectionRegistry({
+    dailyBriefing: { loadNotificationContext: loader }
+  });
+  const dailyBriefingEntry = registry.find(r => r.id === 'dailyBriefing');
+  expect(dailyBriefingEntry).toBeDefined();
+  // The entry's factory should have wired the loader through. The exact
+  // assertion depends on what shape SectionRegistration exposes — either
+  // verify by mounting and observing the fetch call, or by inspecting
+  // a captured options object on the registration.
+});
+```
+
+A third test verifies that R2 task 002's module-mutation API is GONE:
+
+```ts
+test('legacy setLegalWorkspaceDailyBriefingNotificationLoader API is removed', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const legacyApi = (require('@spaarke/legal-workspace') as any).setLegalWorkspaceDailyBriefingNotificationLoader;
+  expect(legacyApi).toBeUndefined();
+});
+```
+
+---
+
+## 8. Documentation alignment tasks (follow-up POMLs)
+
+Three new tasks land in this PR to ensure the pattern is documented for reuse:
+
+- **Task 070** — Pattern doc: `.claude/patterns/ui/workspace-section-registry-composition.md` codifying this pattern as the canonical Spaarke approach for per-host workspace customization
+- **Task 071** — Architecture docs: update `docs/architecture/SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md` and `docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md` to describe the composition factory + cookbook for adding a new widget
+- **Task 072** — ADR: draft (or extend) an ADR codifying the decision. Most likely a new ADR ("Workspace Section Registry as Composition Factory") because this is a genuinely new architectural decision separate from ADR-006 (UI Surface Architecture), ADR-012 (Shared Component Library), and ADR-022 (React 19). The ADR captures: problem, considered alternatives (A/B/C), decision (D), consequences, related ADRs
+
+These tasks are NOT in PR #396's commit (the implementation is). They are scheduled as Phase 7b follow-ups so the docs land separately and can be reviewed by the team holistically.
+
+---
+
+## 9. References
+
+- **PR #396**: `feat(daily-update-r2): Daily Briefing — SpaarkeAi Pattern D Migration (R2)` — landing the implementation
+- **R2 task 002 (Wave 8)**: the Option B module-mutation pattern this supersedes — commit `189f668eb`
+- **R2 task 018 (Wave 7)**: the LegalWorkspace shim that replaced the static `SectionRegistration` const — commit `2d5eefb90`
+- **R6 PR #395**: `spaarke-ai-platform-unification-r6` — verified no conflict with this work
+- **R4 task 052 / C-4**: introduced `setDefaultWorkspaceRenderer` slot pattern — the same renderer-slot mechanism Option D piggybacks on for SpaarkeAi's custom-renderer-wrapper
+- **ADR-006**: UI Surface Architecture — Pattern D dual-use baseline
+- **ADR-012**: Shared Component Library — the per-widget factory pattern that Option D builds on
+- **`notes/task-002-blocker.md`**: the original analysis from R2 Wave 2a that surfaced the architectural problem

--- a/projects/spaarke-daily-update-service-r2/tasks/070-pattern-doc-workspace-section-registry-composition.poml
+++ b/projects/spaarke-daily-update-service-r2/tasks/070-pattern-doc-workspace-section-registry-composition.poml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<task id="070" project="spaarke-daily-update-service-r2">
+  <metadata>
+    <title>Pattern doc — `workspace-section-registry-composition.md` codifying Option D for reuse</title>
+    <phase>Phase7b: Documentation Alignment (post-Option D)</phase>
+    <status>not-started</status>
+    <estimated-hours>1</estimated-hours>
+    <dependencies>none</dependencies>
+    <blocks>071, 072</blocks>
+    <tags>documentation, pattern</tags>
+    <rigor-hint>MINIMAL</rigor-hint>
+    <rigor-reason>Pattern doc authoring; no code; follows existing .claude/patterns/ conventions</rigor-reason>
+    <parallel-group>F</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Touches `.claude/` paths — main-session-only per CLAUDE.md sub-agent write boundary</parallel-reason>
+  </metadata>
+
+  <prompt>
+    Create a new pattern file `.claude/patterns/ui/workspace-section-registry-composition.md` (≤25 lines per `.claude/patterns/` convention) that points readers to the canonical implementation files for the Option D registry-as-composition pattern. This is the Spaarke canonical answer for "how does a host customize a per-widget option in the LegalWorkspace section registry?" Any future widget that needs per-host customization MUST follow this pattern; the pattern file is the entry point that tells reviewers + ai-assistants where to look.
+  </prompt>
+
+  <role>SPAARKE platform developer. Author concise pattern-pointer files under .claude/patterns/ following the existing conventions.</role>
+
+  <goal>One new pattern file under `.claude/patterns/ui/` codifying registry-as-composition. Reviewers + future task authors can find it via the .claude/patterns/INDEX (or grep) when adding a new widget that needs host customization.</goal>
+
+  <context>
+    <background>
+      Option D landed in PR #396 as a foundational architectural pattern for SpaarkeAi workspace customization. Future widgets (Calendar, Smart Todo, future chat panel, future document viewer) that need per-host customization will follow the same pattern. The pattern file codifies it as canonical so we don't re-litigate the design every time a new widget needs customization.
+    </background>
+    <relevant-files>
+      <file>.claude/patterns/ui/</file>
+      <file>.claude/patterns/ui/fluent-v9-component-authoring.md</file>
+      <file>projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md</file>
+      <file>src/solutions/LegalWorkspace/src/sectionRegistry.ts</file>
+      <file>src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts</file>
+      <file>src/solutions/SpaarkeAi/src/main.tsx</file>
+    </relevant-files>
+  </context>
+
+  <constraints>
+    <constraint source="project">Pattern files are 25-line pointer files per CLAUDE.md §3 — DON'T re-explain Option D's full rationale; point to `option-d-registry-as-composition.md` for the deep dive.</constraint>
+    <constraint source="project">Pattern files MUST list the canonical implementation file paths (sectionRegistry.ts, dailyBriefing.registration.ts, SpaarkeAi main.tsx) so reviewers can find the working example.</constraint>
+    <constraint source="project">Follow the format of an existing pattern file (e.g., `fluent-v9-component-authoring.md`) as the template.</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>.claude/patterns/ui/fluent-v9-component-authoring.md</file>
+      <file>.claude/patterns/ui/fluent-v9-theming.md</file>
+      <file>projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md</file>
+      <file>projects/spaarke-daily-update-service-r2/CLAUDE.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Read 2-3 existing `.claude/patterns/ui/*.md` files to understand the format/length convention.</step>
+    <step order="2">Read `option-d-registry-as-composition.md` to confirm what the canonical pattern is.</step>
+    <step order="3">Author `.claude/patterns/ui/workspace-section-registry-composition.md` (≤25 lines) with: one-paragraph problem statement, link to design rationale, list of canonical files (paths with line ranges if known), one-sentence cookbook ("To add a new per-host widget option: add to LegalWorkspaceSectionRegistryOptions + thread through the factory + done").</step>
+    <step order="4">Update `.claude/patterns/INDEX.md` if it exists, adding the new pattern entry.</step>
+    <step order="5">Update TASK-INDEX.md: change task 070 status from 🔲 to ✅.</step>
+  </steps>
+
+  <tools>
+    <tool name="terminal">File ops.</tool>
+  </tools>
+
+  <outputs>
+    <output type="docs">.claude/patterns/ui/workspace-section-registry-composition.md</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">New file exists at `.claude/patterns/ui/workspace-section-registry-composition.md` and is ≤25 lines.</criterion>
+    <criterion testable="true">File links to `notes/option-d-registry-as-composition.md` (or the equivalent merged location) for the full rationale.</criterion>
+    <criterion testable="true">File lists `sectionRegistry.ts` + `dailyBriefing.registration.ts` + `SpaarkeAi main.tsx` as the canonical implementations.</criterion>
+    <criterion testable="true">File contains a one-sentence cookbook for adding a new per-host widget option.</criterion>
+  </acceptance-criteria>
+
+  <notes>
+    This task touches `.claude/` paths, which sub-agents CANNOT write to per CLAUDE.md §3 Sub-Agent Write Boundary. Main session must execute this task.
+  </notes>
+
+  <execution>
+    <skill>.claude/skills/task-execute/SKILL.md</skill>
+    <protocol>Before starting this task, load all files listed in &lt;knowledge&gt;&lt;files&gt;. Follow the task-execute skill for mandatory pre-execution checklist.</protocol>
+  </execution>
+</task>

--- a/projects/spaarke-daily-update-service-r2/tasks/071-update-architecture-docs-for-registry-composition.poml
+++ b/projects/spaarke-daily-update-service-r2/tasks/071-update-architecture-docs-for-registry-composition.poml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<task id="071" project="spaarke-daily-update-service-r2">
+  <metadata>
+    <title>Update SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL + BUILD-A-NEW-WORKSPACE-WIDGET for registry-as-composition</title>
+    <phase>Phase7b: Documentation Alignment (post-Option D)</phase>
+    <status>not-started</status>
+    <estimated-hours>2</estimated-hours>
+    <dependencies>070</dependencies>
+    <blocks>072</blocks>
+    <tags>documentation</tags>
+    <rigor-hint>MINIMAL</rigor-hint>
+    <rigor-reason>Documentation update; surgical edits to existing docs</rigor-reason>
+    <parallel-group>none</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Sequential after 070 (pattern doc must exist for cross-referencing)</parallel-reason>
+  </metadata>
+
+  <prompt>
+    Update two architecture docs to describe Option D's registry-as-composition pattern + the cookbook for adding a new widget under it:
+
+    1. `docs/architecture/SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md` — add a new subsection describing the registry-as-composition factory pattern. Reference how SpaarkeAi customizes per-widget construction (via `createLegalWorkspaceSectionRegistry({...})` + a wrapper renderer) vs how standalone LegalWorkspace uses the default `SECTION_REGISTRY` const. Cross-reference the pattern file from task 070.
+
+    2. `docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md` — add the registry-customization cookbook to §1 (or wherever the dual-use pattern cookbook lives). Steps:
+       a. Author the widget's factory
+       b. Wrap it in a LegalWorkspace shim
+       c. Add an entry to `LegalWorkspaceSectionRegistryOptions`
+       d. Thread through `createLegalWorkspaceSectionRegistry`
+       e. Test the threading
+  </prompt>
+
+  <role>SPAARKE platform developer. Surgical edits to architecture/guide docs following existing tone + structure.</role>
+
+  <goal>Both docs now describe the Option D pattern + cookbook. Reviewers + future task authors find the canonical doc when looking up "how do I customize a widget per host?"</goal>
+
+  <context>
+    <background>
+      Wave 7 task 063 already added R2's hoist + Pattern D dual-use updates to these docs. This task layers ON TOP, adding the per-host customization pattern that Option D introduces.
+    </background>
+    <relevant-files>
+      <file>docs/architecture/SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md</file>
+      <file>docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md</file>
+      <file>docs/architecture/SPAARKEAI-COMPONENT-MODEL.md</file>
+      <file>docs/architecture/SPAARKEAI-WORKSPACE-ARCHITECTURE.md</file>
+      <file>.claude/patterns/ui/workspace-section-registry-composition.md</file>
+      <file>projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md</file>
+    </relevant-files>
+  </context>
+
+  <constraints>
+    <constraint source="project">SURGICAL edits — don't re-author entire docs. Insert/update only the registry-customization section.</constraint>
+    <constraint source="project">Cross-references must resolve (the pattern file from task 070 must exist).</constraint>
+    <constraint source="project">Match existing doc tone + structure.</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>docs/architecture/SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md</file>
+      <file>docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md</file>
+      <file>projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md</file>
+      <file>projects/spaarke-daily-update-service-r2/CLAUDE.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Read both target docs to find the right insertion point (likely §1.1 dual-use archetypes in BUILD-A-NEW-WORKSPACE-WIDGET; the "Composition + customization" section in SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL).</step>
+    <step order="2">Read `option-d-registry-as-composition.md` for the canonical content.</step>
+    <step order="3">Insert/update SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md with a "Per-host customization via registry-as-composition" subsection. Reference SpaarkeAi as the canonical example, LegalWorkspace standalone as the no-customization baseline.</step>
+    <step order="4">Insert the cookbook into BUILD-A-NEW-WORKSPACE-WIDGET.md.</step>
+    <step order="5">Verify cross-references resolve (pattern file path, design-rationale path).</step>
+    <step order="6">Update TASK-INDEX.md: change task 071 status from 🔲 to ✅.</step>
+  </steps>
+
+  <tools>
+    <tool name="terminal">File ops.</tool>
+  </tools>
+
+  <outputs>
+    <output type="docs">docs/architecture/SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md</output>
+    <output type="docs">docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md has a section describing registry-as-composition (≤30 lines added).</criterion>
+    <criterion testable="true">BUILD-A-NEW-WORKSPACE-WIDGET.md has the 5-step cookbook for customizing a widget per host.</criterion>
+    <criterion testable="true">Both docs cross-reference the pattern file + design-rationale.</criterion>
+  </acceptance-criteria>
+
+  <notes>
+    Task 063 (Wave 7) already updated these docs for R2's Pattern D hoist. This task is a layered addition on top — don't duplicate task 063's content; layer the customization story above it.
+  </notes>
+
+  <execution>
+    <skill>.claude/skills/task-execute/SKILL.md</skill>
+    <protocol>Before starting this task, load all files listed in &lt;knowledge&gt;&lt;files&gt;. Follow the task-execute skill for mandatory pre-execution checklist.</protocol>
+  </execution>
+</task>

--- a/projects/spaarke-daily-update-service-r2/tasks/072-adr-workspace-section-registry-composition.poml
+++ b/projects/spaarke-daily-update-service-r2/tasks/072-adr-workspace-section-registry-composition.poml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<task id="072" project="spaarke-daily-update-service-r2">
+  <metadata>
+    <title>Draft ADR — Workspace Section Registry as Composition Factory (Option D)</title>
+    <phase>Phase7b: Documentation Alignment (post-Option D)</phase>
+    <status>not-started</status>
+    <estimated-hours>2</estimated-hours>
+    <dependencies>071</dependencies>
+    <blocks>090</blocks>
+    <tags>documentation, architecture</tags>
+    <rigor-hint>STANDARD</rigor-hint>
+    <rigor-reason>ADR authoring — standardized template; requires architectural judgment about ADR number + relationship to existing ADRs</rigor-reason>
+    <parallel-group>none</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Sequential after 071 (architecture docs must already reference the pattern)</parallel-reason>
+  </metadata>
+
+  <prompt>
+    Draft an Architecture Decision Record (ADR) for the registry-as-composition pattern. The next ADR number after ADR-032 is ADR-033. The ADR captures the architectural decision so that:
+    - Future maintainers understand WHY the pattern exists
+    - Future projects know to follow it instead of inventing band-aids
+    - The decision has an explicit owner sign-off trail
+
+    ADR location: `docs/adr/ADR-033-workspace-section-registry-composition.md` (and a concise `.claude/adr/ADR-033-*.md` for AI-consumption).
+
+    Structure (per existing ADR conventions in `docs/adr/` and `.claude/adr/`):
+    1. Status: Accepted (2026-06-18)
+    2. Context: the problem (module-mutation band-aid; SpaarkeAi as critical core surface; need for two-way Assistant ⇄ Workspace ⇄ Context flows)
+    3. Decision: Option D — `createLegalWorkspaceSectionRegistry(options)` factory with `LegalWorkspaceSectionRegistryOptions` typed contract
+    4. Considered alternatives: Options A (replace), B (module-mutation — shipped first), C (React Context per widget)
+    5. Consequences: positive (one pattern N widgets, type-safe discoverability, no global state, test-friendly); negative/trade-offs (slightly more boilerplate at registry construction site vs static const)
+    6. Related ADRs: ADR-006 (UI Surface Architecture), ADR-012 (Shared Component Library), ADR-022 (React 19), ADR-026 (Code Page Build Standard)
+    7. References: PR #396, task 002 retro, task 018 retro, notes/option-d-registry-as-composition.md
+  </prompt>
+
+  <role>SPAARKE platform developer / architect. Author a focused ADR following existing conventions.</role>
+
+  <goal>ADR-033 published in both full (`docs/adr/`) and AI-concise (`.claude/adr/`) forms. ADR-INDEX.md updated. Cross-references to/from ADR-006, ADR-012 added so reviewers find it from the existing ADRs.</goal>
+
+  <context>
+    <background>
+      The decision IS the pattern + the no-speculative-additions discipline. The ADR formalizes both so future projects don't relitigate (and don't speculatively add `paneEventBus`/`agentClient`/`contextProvider` before a real consumer arrives).
+    </background>
+    <relevant-files>
+      <file>docs/adr/</file>
+      <file>.claude/adr/</file>
+      <file>.claude/adr/INDEX.md</file>
+      <file>docs/adr/ADR-INDEX.md</file>
+      <file>docs/adr/ADR-006-ui-surface-architecture.md</file>
+      <file>docs/adr/ADR-012-shared-component-library.md</file>
+      <file>projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md</file>
+    </relevant-files>
+  </context>
+
+  <constraints>
+    <constraint source="project">Follow existing ADR templates. Look at ADR-028 or another recent ADR for the latest template shape.</constraint>
+    <constraint source="project">The full ADR lives at `docs/adr/ADR-033-*.md`; the concise AI-consumption version lives at `.claude/adr/ADR-033-*.md` (100-150 lines per CLAUDE.md §13).</constraint>
+    <constraint source="project">Update `docs/adr/ADR-INDEX.md` AND `.claude/adr/INDEX.md` with the new entry.</constraint>
+    <constraint source="project">Cross-link ADR-006 + ADR-012 (back-reference) so the new ADR is discoverable from related ADRs.</constraint>
+    <constraint source="project">.claude/ paths require main-session execution per CLAUDE.md §3.</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>docs/adr/ADR-006-ui-surface-architecture.md</file>
+      <file>docs/adr/ADR-012-shared-component-library.md</file>
+      <file>docs/adr/ADR-028-spaarke-auth-architecture.md</file>
+      <file>.claude/adr/ADR-006-ui-surface-architecture.md</file>
+      <file>.claude/adr/ADR-012-shared-component-library.md</file>
+      <file>.claude/adr/INDEX.md</file>
+      <file>projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md</file>
+      <file>projects/spaarke-daily-update-service-r2/CLAUDE.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Read recent ADRs (ADR-028 or later, both full and AI-concise versions) to pin down the current template.</step>
+    <step order="2">Verify ADR-033 is the next available number (`ls docs/adr/ | grep "ADR-0" | sort` and look for the next gap).</step>
+    <step order="3">Author `docs/adr/ADR-033-workspace-section-registry-composition.md` (full).</step>
+    <step order="4">Author `.claude/adr/ADR-033-workspace-section-registry-composition.md` (AI-concise, 100-150 lines).</step>
+    <step order="5">Update `docs/adr/ADR-INDEX.md` with the new entry.</step>
+    <step order="6">Update `.claude/adr/INDEX.md` with the new entry.</step>
+    <step order="7">Add a "See also: ADR-033" back-reference to `docs/adr/ADR-006-ui-surface-architecture.md` and `docs/adr/ADR-012-shared-component-library.md` (and their `.claude/adr/` counterparts).</step>
+    <step order="8">Update TASK-INDEX.md: change task 072 status from 🔲 to ✅.</step>
+  </steps>
+
+  <tools>
+    <tool name="terminal">File ops.</tool>
+  </tools>
+
+  <outputs>
+    <output type="docs">docs/adr/ADR-033-workspace-section-registry-composition.md</output>
+    <output type="docs">.claude/adr/ADR-033-workspace-section-registry-composition.md</output>
+    <output type="docs">docs/adr/ADR-INDEX.md</output>
+    <output type="docs">.claude/adr/INDEX.md</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">Both ADR-033 files exist (full + concise) following the existing ADR template.</criterion>
+    <criterion testable="true">Both INDEX files updated with the new ADR entry.</criterion>
+    <criterion testable="true">ADR-006 and ADR-012 have "See also: ADR-033" back-references in both full and concise versions.</criterion>
+    <criterion testable="true">ADR explicitly captures the "no speculative options until first concrete consumer" discipline.</criterion>
+  </acceptance-criteria>
+
+  <notes>
+    The ADR is the LASTING record of this decision. The notes file (`option-d-registry-as-composition.md`) is a per-project artifact; the ADR is the codebase-level constraint that future projects must comply with.
+  </notes>
+
+  <execution>
+    <skill>.claude/skills/task-execute/SKILL.md</skill>
+    <protocol>Before starting this task, load all files listed in &lt;knowledge&gt;&lt;files&gt;. Follow the task-execute skill for mandatory pre-execution checklist.</protocol>
+  </execution>
+</task>

--- a/projects/spaarke-daily-update-service-r2/tasks/TASK-INDEX.md
+++ b/projects/spaarke-daily-update-service-r2/tasks/TASK-INDEX.md
@@ -2,7 +2,7 @@
 
 > **Project**: `spaarke-daily-update-service-r2`
 > **Last Updated**: 2026-06-18
-> **Status**: 31 / 36 complete; remaining 5 are manual operator tasks (003 P1 smoke, 060 BFF deploy, 061 code-page redeploy, 062 E2E SC1–SC14, 090 wrap-up)
+> **Status**: 31 / 39 complete + Option D (registry-as-composition refactor) LANDED — 3 new follow-up tasks (070/071/072 doc-alignment); 5 manual operator tasks remain (003 P1 smoke, 060 BFF deploy, 061 code-page redeploy, 062 E2E SC1–SC14, 090 wrap-up)
 > **Branch**: `work/spaarke-daily-update-service-r2`
 
 ---
@@ -46,6 +46,10 @@
 | 061 | Redeploy standalone Daily Briefing code page via `code-page-deploy` | Phase7 | 🔲 | 017,055 | E | FULL |
 | 062 | E2E verification — SC1–SC14 in spaarkedev1 | Phase7 | 🔲 | 060,061,024,018 | — | STANDARD |
 | 063 | Update architecture docs (SPAARKEAI-COMPONENT-MODEL, SPAARKEAI-WORKSPACE-ARCHITECTURE, BUILD-A-NEW-WORKSPACE-WIDGET) | Phase7 | ✅ 3 docs + cross-ref fix | 016 | — | MINIMAL |
+| **Option D** | **Registry-as-composition factory** — replaces R2 task 002 module-mutation slot with `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } })` + custom-renderer wrapper in SpaarkeAi `main.tsx`. 6 files refactored; legacy setter API REMOVED. Design rationale in [`notes/option-d-registry-as-composition.md`](../notes/option-d-registry-as-composition.md). | P1+ | ✅ committed mid-PR-396 | 002 (supersedes) | — | FULL |
+| 070 | Pattern doc — `.claude/patterns/ui/workspace-section-registry-composition.md` codifying Option D for reuse | Phase7b | 🔲 | Option D | F | MINIMAL |
+| 071 | Update SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL + BUILD-A-NEW-WORKSPACE-WIDGET docs for registry composition + cookbook | Phase7b | 🔲 | 070 | — | MINIMAL |
+| 072 | Draft ADR-033 — Workspace Section Registry as Composition Factory (full + concise + ADR-INDEX updates + back-refs to ADR-006/012) | Phase7b | 🔲 | 071 | — | STANDARD |
 | 090 | Project wrap-up (code-review + adr-check + repo-cleanup + README status + lessons-learned) | Phase8 | 🔲 | 062,063 | — | FULL |
 
 ---
@@ -57,6 +61,8 @@
 **Task 010 unblocked → deps cleared (was 003)**. Reason: scaffolding the new `@spaarke/daily-briefing-components` package has no functional dependency on P1 verification. P2 hoist can proceed in parallel with the P1 deferral.
 
 **Task 053 acceptance interpreted, not literal**. The DailyBriefing solution's `authInit.ts` was REWRITTEN as a thin factory consumer with lazy-singleton wrapping (49 LOC) rather than deleted outright — the JSDoc canonical example pattern keeps `services/authInit.ts` as the encapsulation point. The spirit of FR-20 is met: no per-solution auth init *logic* remains; only a thin call-site wrapper. Lazy-singleton needed because DailyBriefing's runtime-config getters aren't available at module load (`setRuntimeConfig` must fire first). Task 054 should verify whether LegalWorkspace + SpaarkeAi need the same pattern (likely don't). See `notes/task-053-factory-config-timing.md`.
+
+**Option D — Registry-as-Composition Factory (post-Wave-10, mid-PR-396 architectural review 2026-06-18)**. The user code-review caught that R2 task 002's Wave 8 fix (module-mutable slot + setter + late-bound wrapper) was a band-aid that doesn't scale to SpaarkeAi's strategic vision as a critical core surface supporting N widgets + two-way Assistant ⇄ Workspace ⇄ Context flows. Option D refactors the LegalWorkspace section-registry primitive from a hard-coded `readonly` const into a `createLegalWorkspaceSectionRegistry(options: LegalWorkspaceSectionRegistryOptions): readonly SectionRegistration[]` factory. `LegalWorkspaceApp` accepts an optional `sections?` prop (defaulting to standalone). SpaarkeAi registers a custom-renderer wrapper that injects per-widget options at construction time. Legacy setter API REMOVED. 6 files refactored + 3 new tests (29 total pass). FR-25/NFR-10 preserved (standalone LegalWorkspace bundle byte-identical). Design rationale: [`notes/option-d-registry-as-composition.md`](../notes/option-d-registry-as-composition.md). Documentation alignment follow-ups land separately via tasks 070 (pattern), 071 (architecture docs), 072 (ADR-033) post-merge. NO speculative options (`paneEventBus`/`agentClient`/`contextProvider`) added today per CLAUDE.md "don't design for hypothetical future requirements" — interface is extensible additively.
 
 ---
 

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/__mocks__/spaarke-ui-components.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/__mocks__/spaarke-ui-components.tsx
@@ -6,6 +6,15 @@
  *   The smoke test transitively mounts that component, so we stub the icon as a
  *   no-op SVG. This keeps the test independent of the @spaarke/ui-components
  *   peer dep (which isn't installed at the daily-briefing-components package level).
+ *
+ * R2 Option D (2026-06-18):
+ *   `legalWorkspaceSectionRegistry.test.ts` imports
+ *   `src/solutions/LegalWorkspace/src/sectionRegistry.ts` which references
+ *   `SectionRegistration`, `SectionCategory`, `NarrateRequest`, and
+ *   `SECTION_METADATA_CATALOG` from `@spaarke/ui-components`. We provide
+ *   minimal stand-ins so ts-jest can type-check; runtime values are also
+ *   provided so the dev-mode metadata-drift guard inside the registry
+ *   factory has a non-empty catalog to compare against.
  */
 import * as React from 'react';
 
@@ -13,3 +22,41 @@ import * as React from 'react';
 export const MicrosoftToDoIcon: React.FC<any> = props => (
   <svg role="img" aria-label="Microsoft To Do" className={props?.className} width={16} height={16} />
 );
+
+// ---------------------------------------------------------------------------
+// Types referenced by the LegalWorkspace registry factory under test
+// (`createLegalWorkspaceSectionRegistry`, R2 Option D).
+// ---------------------------------------------------------------------------
+
+export type SectionCategory = string;
+
+export interface SectionRegistration {
+  id: string;
+  category: SectionCategory;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  factory: (...args: any[]) => any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [k: string]: any;
+}
+
+export interface NarrateRequest {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [k: string]: any;
+}
+
+// Metadata catalog stand-in. Contains entries for every section the factory
+// builds (matching the ids the per-section mocks emit in the test) so the
+// dev-mode metadata-drift guard finds no drift in tests.
+export const SECTION_METADATA_CATALOG: ReadonlyArray<{ id: string }> = [
+  { id: "get-started" },
+  { id: "quick-summary" },
+  { id: "latest-updates" },
+  { id: "todo" },
+  { id: "documents" },
+  { id: "matters" },
+  { id: "projects" },
+  { id: "invoices" },
+  { id: "work-assignments" },
+  { id: "daily-briefing" },
+  { id: "calendar" },
+];

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/__mocks__/spaarke-ui-components.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/__mocks__/spaarke-ui-components.tsx
@@ -48,15 +48,15 @@ export interface NarrateRequest {
 // builds (matching the ids the per-section mocks emit in the test) so the
 // dev-mode metadata-drift guard finds no drift in tests.
 export const SECTION_METADATA_CATALOG: ReadonlyArray<{ id: string }> = [
-  { id: "get-started" },
-  { id: "quick-summary" },
-  { id: "latest-updates" },
-  { id: "todo" },
-  { id: "documents" },
-  { id: "matters" },
-  { id: "projects" },
-  { id: "invoices" },
-  { id: "work-assignments" },
-  { id: "daily-briefing" },
-  { id: "calendar" },
+  { id: 'get-started' },
+  { id: 'quick-summary' },
+  { id: 'latest-updates' },
+  { id: 'todo' },
+  { id: 'documents' },
+  { id: 'matters' },
+  { id: 'projects' },
+  { id: 'invoices' },
+  { id: 'work-assignments' },
+  { id: 'daily-briefing' },
+  { id: 'calendar' },
 ];

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/legalWorkspaceSectionRegistry.test.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/legalWorkspaceSectionRegistry.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for `createLegalWorkspaceSectionRegistry` — R2 Option D
+ * (2026-06-18, replaces R2 task 002 module-mutation slot pattern).
+ *
+ * Contract under test:
+ *   1. `createLegalWorkspaceSectionRegistry()` with NO options returns a
+ *      registry equivalent to the default `SECTION_REGISTRY` const (same
+ *      widget IDs, same length, same order). Standalone LegalWorkspace
+ *      behavior preserved byte-identically (FR-25 / NFR-10).
+ *
+ *   2. `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } })`
+ *      threads the loader through to the dailyBriefing entry's factory.
+ *      We assert the registry build does not throw and the dailyBriefing
+ *      entry has the correct id — verifying the option is at least accepted
+ *      by the factory signature (the loader's actual fetch-time invocation
+ *      is exercised by the existing useBriefingNotifications + smoke tests).
+ *
+ *   3. The legacy band-aid API `setLegalWorkspaceDailyBriefingNotificationLoader`
+ *      from R2 task 002 (Wave 8) is REMOVED from the LegalWorkspace barrel.
+ *      This locks in the migration so a future commit can't accidentally
+ *      re-introduce the module-mutation slot.
+ *
+ * # Why this test lives here
+ *
+ * LegalWorkspace has no Jest setup (it's a Vite-built standalone Code Page).
+ * Spaarke.DailyBriefing.Components has Jest 30 + ts-jest already configured
+ * (R2 task 019 / NFR-05), and the import-side mocks for `@spaarke/ui-components`
+ * and `@spaarke/auth` already exist. We import LegalWorkspace sources via
+ * relative path and pre-mock LegalWorkspace's heavyweight transitive imports
+ * (authInit, telemetry, individual section factories) so this test stays
+ * focused on the registry factory contract.
+ *
+ * See `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md` §7.
+ */
+
+// ---------------------------------------------------------------------------
+// Pre-import mocks (must come BEFORE the LegalWorkspace imports below).
+//
+// LegalWorkspace's `sectionRegistry.ts` imports 11 individual section
+// registrations. Each of those transitively imports React, services, hooks,
+// etc. We mock every section registration to a trivial `SectionRegistration`
+// shape so the factory can build without dragging in the whole app.
+//
+// `dailyBriefing.registration` is mocked to expose
+// `createLegalWorkspaceDailyBriefingRegistration` as a `jest.fn()` so test 2
+// can verify the loader is threaded into the factory call.
+// ---------------------------------------------------------------------------
+
+// Stub every static section registration. Each must satisfy the minimal
+// `SectionRegistration` contract (just an `id` + `category` + `factory`).
+// NOTE: `jest.mock` factory bodies are hoisted, so the helper has to be
+// inlined inside each factory closure. We use string-literal paths (no
+// template literals or constants) to keep Jest's static-hoist analysis happy.
+
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/getStarted.registration", () => ({
+  getStartedRegistration: { id: "get-started", category: "core", factory: () => ({ id: "get-started" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/quickSummary.registration", () => ({
+  quickSummaryRegistration: { id: "quick-summary", category: "core", factory: () => ({ id: "quick-summary" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/latestUpdates.registration", () => ({
+  latestUpdatesRegistration: { id: "latest-updates", category: "core", factory: () => ({ id: "latest-updates" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/todo.registration", () => ({
+  todoRegistration: { id: "todo", category: "core", factory: () => ({ id: "todo" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/documents.registration", () => ({
+  documentsRegistration: { id: "documents", category: "core", factory: () => ({ id: "documents" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/calendar.registration", () => ({
+  calendarRegistration: { id: "calendar", category: "core", factory: () => ({ id: "calendar" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/projects.registration", () => ({
+  projectsRegistration: { id: "projects", category: "core", factory: () => ({ id: "projects" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/invoices.registration", () => ({
+  invoicesRegistration: { id: "invoices", category: "core", factory: () => ({ id: "invoices" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/workAssignments.registration", () => ({
+  workAssignmentsRegistration: { id: "work-assignments", category: "core", factory: () => ({ id: "work-assignments" }) },
+}));
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/matters.registration", () => ({
+  mattersRegistration: { id: "matters", category: "core", factory: () => ({ id: "matters" }) },
+}));
+
+// Mock the dailyBriefing registration. `createLegalWorkspaceDailyBriefingRegistration`
+// is the seam under test (test 2 asserts the loader is threaded through). We
+// stash the jest.fn on `globalThis` so the test body can introspect it after
+// the mock is hoisted above the imports.
+jest.mock("../../../../solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration", () => {
+  const factoryMock = jest.fn(
+    (_options?: { loadNotificationContext?: () => Promise<unknown> }) => ({
+      id: "daily-briefing",
+      category: "core",
+      factory: () => ({ id: "daily-briefing" }),
+    }),
+  );
+  // Expose the mock for test assertions.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).__createDailyBriefingMock = factoryMock;
+  return {
+    createLegalWorkspaceDailyBriefingRegistration: factoryMock,
+    dailyBriefingRegistration: {
+      id: "daily-briefing",
+      category: "core",
+      factory: () => ({ id: "daily-briefing" }),
+    },
+  };
+});
+
+// `@spaarke/ui-components` is routed to a local mock via the Jest
+// moduleNameMapper (see jest.config.cjs). The mock at
+// `test/__mocks__/spaarke-ui-components.tsx` provides `SectionRegistration`,
+// `SectionCategory`, `NarrateRequest`, and `SECTION_METADATA_CATALOG`
+// stand-ins matching every section id stubbed below — so the dev-mode
+// metadata-drift guard inside `runRegistryDevGuards` finds no drift in tests.
+
+// ---------------------------------------------------------------------------
+// Now import the LegalWorkspace factory under test.
+// ---------------------------------------------------------------------------
+
+import {
+  createLegalWorkspaceSectionRegistry,
+  SECTION_REGISTRY,
+} from "../../../../solutions/LegalWorkspace/src/sectionRegistry";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getDailyBriefingMock = (): jest.Mock<any, any> =>
+  (globalThis as any).__createDailyBriefingMock as jest.Mock;
+
+describe("createLegalWorkspaceSectionRegistry (R2 Option D)", () => {
+  beforeEach(() => {
+    getDailyBriefingMock().mockClear();
+  });
+
+  test("createLegalWorkspaceSectionRegistry() returns same widget IDs as SECTION_REGISTRY const", () => {
+    const fromFactory = createLegalWorkspaceSectionRegistry();
+    // Same length
+    expect(fromFactory.length).toBe(SECTION_REGISTRY.length);
+    // Same IDs in same order
+    expect(fromFactory.map((r) => r.id)).toEqual(
+      SECTION_REGISTRY.map((r) => r.id),
+    );
+  });
+
+  test("createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } }) threads loader", () => {
+    const loader = jest.fn().mockResolvedValue(null);
+    const mock = getDailyBriefingMock();
+    mock.mockClear();
+
+    const registry = createLegalWorkspaceSectionRegistry({
+      dailyBriefing: { loadNotificationContext: loader },
+    });
+
+    // dailyBriefing entry exists in the registry
+    const dailyBriefingEntry = registry.find((r) => r.id === "daily-briefing");
+    expect(dailyBriefingEntry).toBeDefined();
+
+    // The factory was called WITH the supplied loader (Option D contract).
+    expect(mock).toHaveBeenCalled();
+    const lastCallArg = mock.mock.calls.at(-1)?.[0];
+    expect(lastCallArg).toBeDefined();
+    expect(lastCallArg?.loadNotificationContext).toBe(loader);
+  });
+
+  test("legacy setLegalWorkspaceDailyBriefingNotificationLoader API is removed", () => {
+    // Read the LegalWorkspace barrel source text. The R2 task 002 band-aid
+    // setter MUST NOT be re-exported. This locks in the Option D migration:
+    // a future commit accidentally re-exporting the setter (or re-introducing
+    // the module-mutation slot) will fail this assertion.
+    //
+    // We check source text rather than require()-ing the barrel because the
+    // barrel transitively imports the React component tree (LegalWorkspaceApp,
+    // FluentProvider, etc.), which would force this test to spin up jsdom
+    // for what is fundamentally an API-surface contract check.
+    const fs = require("fs");
+    const path = require("path");
+    const barrelPath = path.resolve(
+      __dirname,
+      "../../../../solutions/LegalWorkspace/src/index.ts",
+    );
+    const barrelSource: string = fs.readFileSync(barrelPath, "utf8");
+
+    // The band-aid setter export should be gone (both `export {...}` and
+    // re-export forms). The name is allowed to appear in DOCBLOCK COMMENTS
+    // documenting the removal — we only fail on actual export/import lines.
+    const exportRegex =
+      /^[^/\n]*\b(?:export\s*\{[^}]*\b|export\s+(?:const|function|let|var)\s+)setLegalWorkspaceDailyBriefingNotificationLoader\b/m;
+
+    expect(barrelSource).not.toMatch(exportRegex);
+
+    // Also assert no live re-export from the dailyBriefing.registration module
+    // (which used to export the setter pre-Option D).
+    const dailyBriefingPath = path.resolve(
+      __dirname,
+      "../../../../solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts",
+    );
+    const dailyBriefingSource: string = fs.readFileSync(
+      dailyBriefingPath,
+      "utf8",
+    );
+    expect(dailyBriefingSource).not.toMatch(exportRegex);
+
+    // And no live var declaration of the module-mutable slot.
+    const slotRegex =
+      /^[^/\n]*\b(?:let|const|var)\s+_globalNotificationLoader\b/m;
+    expect(dailyBriefingSource).not.toMatch(slotRegex);
+  });
+});

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/legalWorkspaceSectionRegistry.test.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/legalWorkspaceSectionRegistry.test.ts
@@ -52,58 +52,60 @@
 // inlined inside each factory closure. We use string-literal paths (no
 // template literals or constants) to keep Jest's static-hoist analysis happy.
 
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/getStarted.registration", () => ({
-  getStartedRegistration: { id: "get-started", category: "core", factory: () => ({ id: "get-started" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/getStarted.registration', () => ({
+  getStartedRegistration: { id: 'get-started', category: 'core', factory: () => ({ id: 'get-started' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/quickSummary.registration", () => ({
-  quickSummaryRegistration: { id: "quick-summary", category: "core", factory: () => ({ id: "quick-summary" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/quickSummary.registration', () => ({
+  quickSummaryRegistration: { id: 'quick-summary', category: 'core', factory: () => ({ id: 'quick-summary' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/latestUpdates.registration", () => ({
-  latestUpdatesRegistration: { id: "latest-updates", category: "core", factory: () => ({ id: "latest-updates" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/latestUpdates.registration', () => ({
+  latestUpdatesRegistration: { id: 'latest-updates', category: 'core', factory: () => ({ id: 'latest-updates' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/todo.registration", () => ({
-  todoRegistration: { id: "todo", category: "core", factory: () => ({ id: "todo" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/todo.registration', () => ({
+  todoRegistration: { id: 'todo', category: 'core', factory: () => ({ id: 'todo' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/documents.registration", () => ({
-  documentsRegistration: { id: "documents", category: "core", factory: () => ({ id: "documents" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/documents.registration', () => ({
+  documentsRegistration: { id: 'documents', category: 'core', factory: () => ({ id: 'documents' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/calendar.registration", () => ({
-  calendarRegistration: { id: "calendar", category: "core", factory: () => ({ id: "calendar" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/calendar.registration', () => ({
+  calendarRegistration: { id: 'calendar', category: 'core', factory: () => ({ id: 'calendar' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/projects.registration", () => ({
-  projectsRegistration: { id: "projects", category: "core", factory: () => ({ id: "projects" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/projects.registration', () => ({
+  projectsRegistration: { id: 'projects', category: 'core', factory: () => ({ id: 'projects' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/invoices.registration", () => ({
-  invoicesRegistration: { id: "invoices", category: "core", factory: () => ({ id: "invoices" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/invoices.registration', () => ({
+  invoicesRegistration: { id: 'invoices', category: 'core', factory: () => ({ id: 'invoices' }) },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/workAssignments.registration", () => ({
-  workAssignmentsRegistration: { id: "work-assignments", category: "core", factory: () => ({ id: "work-assignments" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/workAssignments.registration', () => ({
+  workAssignmentsRegistration: {
+    id: 'work-assignments',
+    category: 'core',
+    factory: () => ({ id: 'work-assignments' }),
+  },
 }));
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/matters.registration", () => ({
-  mattersRegistration: { id: "matters", category: "core", factory: () => ({ id: "matters" }) },
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/matters.registration', () => ({
+  mattersRegistration: { id: 'matters', category: 'core', factory: () => ({ id: 'matters' }) },
 }));
 
 // Mock the dailyBriefing registration. `createLegalWorkspaceDailyBriefingRegistration`
 // is the seam under test (test 2 asserts the loader is threaded through). We
 // stash the jest.fn on `globalThis` so the test body can introspect it after
 // the mock is hoisted above the imports.
-jest.mock("../../../../solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration", () => {
-  const factoryMock = jest.fn(
-    (_options?: { loadNotificationContext?: () => Promise<unknown> }) => ({
-      id: "daily-briefing",
-      category: "core",
-      factory: () => ({ id: "daily-briefing" }),
-    }),
-  );
+jest.mock('../../../../solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration', () => {
+  const factoryMock = jest.fn((_options?: { loadNotificationContext?: () => Promise<unknown> }) => ({
+    id: 'daily-briefing',
+    category: 'core',
+    factory: () => ({ id: 'daily-briefing' }),
+  }));
   // Expose the mock for test assertions.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).__createDailyBriefingMock = factoryMock;
   return {
     createLegalWorkspaceDailyBriefingRegistration: factoryMock,
     dailyBriefingRegistration: {
-      id: "daily-briefing",
-      category: "core",
-      factory: () => ({ id: "daily-briefing" }),
+      id: 'daily-briefing',
+      category: 'core',
+      factory: () => ({ id: 'daily-briefing' }),
     },
   };
 });
@@ -122,28 +124,25 @@ jest.mock("../../../../solutions/LegalWorkspace/src/sections/dailyBriefing/daily
 import {
   createLegalWorkspaceSectionRegistry,
   SECTION_REGISTRY,
-} from "../../../../solutions/LegalWorkspace/src/sectionRegistry";
+} from '../../../../solutions/LegalWorkspace/src/sectionRegistry';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getDailyBriefingMock = (): jest.Mock<any, any> =>
-  (globalThis as any).__createDailyBriefingMock as jest.Mock;
+const getDailyBriefingMock = (): jest.Mock<any, any> => (globalThis as any).__createDailyBriefingMock as jest.Mock;
 
-describe("createLegalWorkspaceSectionRegistry (R2 Option D)", () => {
+describe('createLegalWorkspaceSectionRegistry (R2 Option D)', () => {
   beforeEach(() => {
     getDailyBriefingMock().mockClear();
   });
 
-  test("createLegalWorkspaceSectionRegistry() returns same widget IDs as SECTION_REGISTRY const", () => {
+  test('createLegalWorkspaceSectionRegistry() returns same widget IDs as SECTION_REGISTRY const', () => {
     const fromFactory = createLegalWorkspaceSectionRegistry();
     // Same length
     expect(fromFactory.length).toBe(SECTION_REGISTRY.length);
     // Same IDs in same order
-    expect(fromFactory.map((r) => r.id)).toEqual(
-      SECTION_REGISTRY.map((r) => r.id),
-    );
+    expect(fromFactory.map(r => r.id)).toEqual(SECTION_REGISTRY.map(r => r.id));
   });
 
-  test("createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } }) threads loader", () => {
+  test('createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } }) threads loader', () => {
     const loader = jest.fn().mockResolvedValue(null);
     const mock = getDailyBriefingMock();
     mock.mockClear();
@@ -153,7 +152,7 @@ describe("createLegalWorkspaceSectionRegistry (R2 Option D)", () => {
     });
 
     // dailyBriefing entry exists in the registry
-    const dailyBriefingEntry = registry.find((r) => r.id === "daily-briefing");
+    const dailyBriefingEntry = registry.find(r => r.id === 'daily-briefing');
     expect(dailyBriefingEntry).toBeDefined();
 
     // The factory was called WITH the supplied loader (Option D contract).
@@ -163,7 +162,7 @@ describe("createLegalWorkspaceSectionRegistry (R2 Option D)", () => {
     expect(lastCallArg?.loadNotificationContext).toBe(loader);
   });
 
-  test("legacy setLegalWorkspaceDailyBriefingNotificationLoader API is removed", () => {
+  test('legacy setLegalWorkspaceDailyBriefingNotificationLoader API is removed', () => {
     // Read the LegalWorkspace barrel source text. The R2 task 002 band-aid
     // setter MUST NOT be re-exported. This locks in the Option D migration:
     // a future commit accidentally re-exporting the setter (or re-introducing
@@ -173,13 +172,10 @@ describe("createLegalWorkspaceSectionRegistry (R2 Option D)", () => {
     // barrel transitively imports the React component tree (LegalWorkspaceApp,
     // FluentProvider, etc.), which would force this test to spin up jsdom
     // for what is fundamentally an API-surface contract check.
-    const fs = require("fs");
-    const path = require("path");
-    const barrelPath = path.resolve(
-      __dirname,
-      "../../../../solutions/LegalWorkspace/src/index.ts",
-    );
-    const barrelSource: string = fs.readFileSync(barrelPath, "utf8");
+    const fs = require('fs');
+    const path = require('path');
+    const barrelPath = path.resolve(__dirname, '../../../../solutions/LegalWorkspace/src/index.ts');
+    const barrelSource: string = fs.readFileSync(barrelPath, 'utf8');
 
     // The band-aid setter export should be gone (both `export {...}` and
     // re-export forms). The name is allowed to appear in DOCBLOCK COMMENTS
@@ -193,17 +189,13 @@ describe("createLegalWorkspaceSectionRegistry (R2 Option D)", () => {
     // (which used to export the setter pre-Option D).
     const dailyBriefingPath = path.resolve(
       __dirname,
-      "../../../../solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts",
+      '../../../../solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts'
     );
-    const dailyBriefingSource: string = fs.readFileSync(
-      dailyBriefingPath,
-      "utf8",
-    );
+    const dailyBriefingSource: string = fs.readFileSync(dailyBriefingPath, 'utf8');
     expect(dailyBriefingSource).not.toMatch(exportRegex);
 
     // And no live var declaration of the module-mutable slot.
-    const slotRegex =
-      /^[^/\n]*\b(?:let|const|var)\s+_globalNotificationLoader\b/m;
+    const slotRegex = /^[^/\n]*\b(?:let|const|var)\s+_globalNotificationLoader\b/m;
     expect(dailyBriefingSource).not.toMatch(slotRegex);
   });
 });

--- a/src/solutions/LegalWorkspace/src/LegalWorkspaceApp.tsx
+++ b/src/solutions/LegalWorkspace/src/LegalWorkspaceApp.tsx
@@ -12,6 +12,7 @@ import {
   getUserThemePreference,
   THEME_CHANGE_EVENT,
 } from "@spaarke/ui-components";
+import type { SectionRegistration } from "@spaarke/ui-components";
 import { PageHeader } from "./components/Shell/PageHeader";
 import { WorkspaceGrid } from "./components/Shell/WorkspaceGrid";
 import type { WorkspaceHeaderState } from "./components/Shell/WorkspaceGrid";
@@ -45,6 +46,18 @@ export interface ILegalWorkspaceAppProps {
    * preserving FR-25 / NFR-10 (byte-identical bundle behaviour).
    */
   embedded?: boolean;
+  /**
+   * Optional custom section registry (R2 Option D, 2026-06-18). When omitted,
+   * the default `SECTION_REGISTRY` is used (standalone LegalWorkspace behavior).
+   * Embedding consumers (SpaarkeAi) pass a registry built via
+   * `createLegalWorkspaceSectionRegistry({...})` to inject per-widget
+   * customization (e.g. SpaarkeAi's `loadSpaarkeAiNotificationContext` for
+   * Daily Briefing).
+   *
+   * Replaces the R2 task 002 module-mutation slot pattern — see
+   * `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md`.
+   */
+  sections?: readonly SectionRegistration[];
 }
 
 const useStyles = makeStyles({
@@ -86,6 +99,7 @@ export const LegalWorkspaceApp: React.FC<ILegalWorkspaceAppProps> = ({
   userId,
   initialWorkspaceId,
   embedded = false,
+  sections,
 }) => {
   const { theme } = useTheme();
   const styles = useStyles();
@@ -164,6 +178,7 @@ export const LegalWorkspaceApp: React.FC<ILegalWorkspaceAppProps> = ({
             userId={userId}
             initialWorkspaceId={initialWorkspaceId}
             embedded={embedded}
+            sections={sections}
             onHeaderReady={!embedded ? setHeaderState : undefined}
           />
         </main>

--- a/src/solutions/LegalWorkspace/src/components/Shell/WorkspaceGrid.tsx
+++ b/src/solutions/LegalWorkspace/src/components/Shell/WorkspaceGrid.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import { tokens, Spinner } from "@fluentui/react-components";
 import { WorkspaceShell } from "@spaarke/ui-components";
-import type { SectionFactoryContext, NavigateTarget, DialogOptions } from "@spaarke/ui-components";
+import type {
+  SectionFactoryContext,
+  NavigateTarget,
+  DialogOptions,
+  SectionRegistration,
+} from "@spaarke/ui-components";
 import { useDataverseService } from "../../hooks/useDataverseService";
 import { useWorkspaceLayouts } from "../../hooks/useWorkspaceLayouts";
 import { navigateToEntityList } from "../../utils/navigation";
@@ -119,6 +124,13 @@ export interface IWorkspaceGridProps {
    * byte-identical bundle behaviour.
    */
   embedded?: boolean;
+  /**
+   * Optional custom section registry (R2 Option D, 2026-06-18). When omitted,
+   * the default `SECTION_REGISTRY` is used (standalone LegalWorkspace behavior).
+   * Embedding consumers (SpaarkeAi) pass a registry built via
+   * `createLegalWorkspaceSectionRegistry({...})` via `<LegalWorkspaceApp sections={...} />`.
+   */
+  sections?: readonly SectionRegistration[];
 }
 
 // ---------------------------------------------------------------------------
@@ -133,6 +145,7 @@ export const WorkspaceGrid: React.FC<IWorkspaceGridProps> = ({
   onHeaderReady,
   initialWorkspaceId,
   embedded = false,
+  sections = SECTION_REGISTRY,
 }) => {
   // -------------------------------------------------------------------------
   // DataverseService for DocumentsTab
@@ -653,7 +666,13 @@ export const WorkspaceGrid: React.FC<IWorkspaceGridProps> = ({
   }, [webApi, userId, service, businessUnitId, handleNavigate, handleOpenWizardGeneric, handleOpenDocumentsDialog]);
 
   // -------------------------------------------------------------------------
-  // Build dynamic WorkspaceConfig from active layout + SECTION_REGISTRY
+  // Build dynamic WorkspaceConfig from active layout + sections registry
+  //
+  // The `sections` prop defaults to the imported `SECTION_REGISTRY` so
+  // standalone LegalWorkspace behavior is byte-identical (FR-25 / NFR-10).
+  // Embedding consumers (SpaarkeAi) pass a CUSTOM registry built via
+  // `createLegalWorkspaceSectionRegistry({...})` — R2 Option D (2026-06-18).
+  //
   // Falls back to old buildWorkspaceConfig on error for graceful degradation
   // -------------------------------------------------------------------------
 
@@ -661,7 +680,7 @@ export const WorkspaceGrid: React.FC<IWorkspaceGridProps> = ({
     try {
       return buildDynamicWorkspaceConfig(
         activeLayoutJson,
-        SECTION_REGISTRY,
+        sections,
         factoryContext,
       );
     } catch (err) {
@@ -699,6 +718,7 @@ export const WorkspaceGrid: React.FC<IWorkspaceGridProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     activeLayoutJson,
+    sections,
     factoryContext,
     webApi,
     userId,

--- a/src/solutions/LegalWorkspace/src/index.ts
+++ b/src/solutions/LegalWorkspace/src/index.ts
@@ -95,17 +95,28 @@ export const LegalWorkspaceRenderer: WorkspaceRenderer = _LegalWorkspaceApp;
 export { setRuntimeConfig as setLegalWorkspaceRuntimeConfig } from "./config/runtimeConfig";
 
 /**
- * Daily Briefing notification-loader injection seam (R2 task 002, FR-01 / FR-02).
+ * Section registry composition factory (R2 Option D, 2026-06-18).
  *
- * SpaarkeAi `main.tsx` calls this at bootstrap with
- * `loadSpaarkeAiNotificationContext` to flow real notification context into
- * the BFF `/narrate` envelope. Without this call (standalone LegalWorkspace +
- * standalone Daily Briefing Code Page), the slot stays unset and the embedded
- * Daily Briefing falls back to the empty-payload contract.
+ * Post-Option D: the legacy `setLegalWorkspaceDailyBriefingNotificationLoader`
+ * setter is gone. Embedding consumers (SpaarkeAi) build a custom registry via
+ *   `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } })`
+ * and pass it to `<LegalWorkspaceApp sections={...} />` via a wrapper renderer
+ * registered through the existing `setDefaultWorkspaceRenderer` slot.
  *
- * Pattern: module-mutable slot — mirrors `setDefaultWorkspaceRenderer` from
- * `@spaarke/ui-components`. The default `dailyBriefingRegistration` consumed
- * by `sectionRegistry.ts` uses a late-bound wrapper that reads from this slot
- * at fetch time, so SECTION_REGISTRY can stay a static `readonly` array.
+ * Standalone LegalWorkspace uses `SECTION_REGISTRY` (the no-options default) —
+ * byte-identical behavior preserved (FR-25 / NFR-10).
+ *
+ * See `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md`
+ * for the full design rationale and cookbook for adding a new widget.
  */
-export { setLegalWorkspaceDailyBriefingNotificationLoader } from "./sections/dailyBriefing/dailyBriefing.registration";
+export {
+  SECTION_REGISTRY,
+  createLegalWorkspaceSectionRegistry,
+  getSectionById,
+  getSectionsByCategory,
+} from "./sectionRegistry";
+export type { LegalWorkspaceSectionRegistryOptions } from "./sectionRegistry";
+
+// Ergonomic re-export so consumers building a custom registry can type their
+// own `sections` prop without re-importing from `@spaarke/ui-components`.
+export type { SectionRegistration } from "@spaarke/ui-components";

--- a/src/solutions/LegalWorkspace/src/sectionRegistry.ts
+++ b/src/solutions/LegalWorkspace/src/sectionRegistry.ts
@@ -6,19 +6,40 @@
  *
  * Adding a new section requires only:
  *   1. Create a new {name}.registration.ts in sections/
- *   2. Import and add it to SECTION_REGISTRY below
+ *   2. Import and add it to the factory body in `createLegalWorkspaceSectionRegistry` below
+ *
+ * # Registry-as-Composition Factory (R2 Option D, 2026-06-18)
+ *
+ * Post-R2: the registry is built by `createLegalWorkspaceSectionRegistry(options)`
+ * — a factory exposing per-widget customization knobs through a typed
+ * `LegalWorkspaceSectionRegistryOptions` interface. The default `SECTION_REGISTRY`
+ * const is now `createLegalWorkspaceSectionRegistry()` (no options), preserving
+ * standalone-LegalWorkspace bundle behavior byte-identically (FR-25 / NFR-10).
+ *
+ * Embedding hosts (SpaarkeAi) build a CUSTOM registry by passing options:
+ *   `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } })`
+ * and feed it into `<LegalWorkspaceApp sections={...} />` via the renderer slot.
+ *
+ * This replaces the R2 task 002 module-mutation slot pattern (Wave 8) — the
+ * `setLegalWorkspaceDailyBriefingNotificationLoader` setter is gone. See
+ * `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md`
+ * for the full design rationale + speculative-design discipline.
  *
  * Standards: ADR-012 (shared components)
  */
 
-import type { SectionRegistration, SectionCategory } from "@spaarke/ui-components";
+import type {
+  SectionRegistration,
+  SectionCategory,
+  NarrateRequest,
+} from "@spaarke/ui-components";
 import { SECTION_METADATA_CATALOG } from "@spaarke/ui-components";
 import { getStartedRegistration } from "./sections/getStarted.registration";
 import { quickSummaryRegistration } from "./sections/quickSummary.registration";
 import { latestUpdatesRegistration } from "./sections/latestUpdates.registration";
 import { todoRegistration } from "./sections/todo.registration";
 import { documentsRegistration } from "./sections/documents.registration";
-import { dailyBriefingRegistration } from "./sections/dailyBriefing/dailyBriefing.registration";
+import { createLegalWorkspaceDailyBriefingRegistration } from "./sections/dailyBriefing/dailyBriefing.registration";
 import { calendarRegistration } from "./sections/calendar.registration";
 // ai-spaarke-ai-workspace-UI-r1 #4 (2026-06-08): three new Dataverse entity-view
 // sections that share <DataverseEntityViewWidget> with the (already-modified)
@@ -29,23 +50,77 @@ import { invoicesRegistration } from "./sections/invoices.registration";
 import { workAssignmentsRegistration } from "./sections/workAssignments.registration";
 import { mattersRegistration } from "./sections/matters.registration";
 
-/** All available workspace sections in default display order. */
-export const SECTION_REGISTRY: readonly SectionRegistration[] = [
-  getStartedRegistration,
-  quickSummaryRegistration,
-  latestUpdatesRegistration,
-  todoRegistration,
-  documentsRegistration,
-  mattersRegistration,
-  projectsRegistration,
-  invoicesRegistration,
-  workAssignmentsRegistration,
-  dailyBriefingRegistration,
-  calendarRegistration,
-] as const;
+/**
+ * Per-widget customization options for the LegalWorkspace section registry.
+ *
+ * Each property targets ONE widget's factory and exposes ONLY the knobs that
+ * widget's factory accepts. Adding a new knob = add it here + thread it through
+ * `createLegalWorkspaceSectionRegistry` below.
+ *
+ * # Speculative-design discipline (R2 Option D §5)
+ *
+ * Only widgets that have a real consumer-driven customization need appear here.
+ * Examples we explicitly do NOT add today (no concrete consumer):
+ *   - `calendar?: { initialFilter?: CalendarFilter; onDayClick?: (date: Date) => void }`
+ *   - `smartTodo?: { ... }`
+ *   - `paneEventBus?: PaneEventBus` (cross-widget messaging primitive)
+ *   - `agentClient?: AgentClient` (Assistant ⇄ Workspace binding)
+ *   - `contextProvider?: ContextProvider` (Context → Workspace binding)
+ *   - per-widget `visibilityPolicy` (R6 Pillar 9 hook)
+ *
+ * When the first concrete consumer needs any of those, add a new property here
+ * + thread it through the factory. No restructuring required — the architecture
+ * absorbs new requirements additively.
+ */
+export interface LegalWorkspaceSectionRegistryOptions {
+  /**
+   * Daily Briefing customization. Currently exposes the notification-context
+   * loader — used by SpaarkeAi to flow `loadSpaarkeAiNotificationContext` into
+   * the BFF `/narrate` envelope so the embedded copy renders real bullets.
+   *
+   * Standalone consumers omit this → empty-payload contract preserved
+   * (BFF returns empty bullets → empty-state UI). FR-25 / NFR-10.
+   */
+  dailyBriefing?: {
+    loadNotificationContext?: () => Promise<NarrateRequest | null>;
+  };
+}
+
+/**
+ * Build a LegalWorkspace section registry, optionally customizing per-widget
+ * construction. With no options, returns a registry byte-identical in behavior
+ * to the standalone-LegalWorkspace `SECTION_REGISTRY` const (FR-25 / NFR-10).
+ *
+ * Dev-mode duplicate-ID + metadata-drift guards run for every registry built
+ * via this factory — custom registries get the same drift detection as the
+ * default one.
+ */
+export function createLegalWorkspaceSectionRegistry(
+  options: LegalWorkspaceSectionRegistryOptions = {},
+): readonly SectionRegistration[] {
+  const registry: readonly SectionRegistration[] = [
+    getStartedRegistration,
+    quickSummaryRegistration,
+    latestUpdatesRegistration,
+    todoRegistration,
+    documentsRegistration,
+    mattersRegistration,
+    projectsRegistration,
+    invoicesRegistration,
+    workAssignmentsRegistration,
+    createLegalWorkspaceDailyBriefingRegistration(options.dailyBriefing ?? {}),
+    calendarRegistration,
+  ] as const;
+
+  if (process.env.NODE_ENV !== "production") {
+    runRegistryDevGuards(registry);
+  }
+
+  return registry;
+}
 
 // ---------------------------------------------------------------------------
-// Development guard: detect duplicate section IDs + drift vs the shared
+// Development guards: detect duplicate section IDs + drift vs the shared
 // SECTION_METADATA_CATALOG (the single source of truth for wizard pickability).
 //
 // R4 W-3 (task 040, 2026-05-26): the wizard's picker reads
@@ -53,11 +128,17 @@ export const SECTION_REGISTRY: readonly SectionRegistration[] = [
 // added HERE without a matching metadata entry would not appear in the wizard
 // (and vice versa: a metadata entry without a registration would render
 // nothing). This guard catches both directions of drift in dev builds.
+//
+// R2 Option D (2026-06-18): extracted into a reusable helper so CUSTOM
+// registries built by embedding hosts (SpaarkeAi) get the same drift checks
+// as the default registry. Called from inside the factory above.
 // ---------------------------------------------------------------------------
-if (process.env.NODE_ENV !== "production") {
+function runRegistryDevGuards(
+  registry: readonly SectionRegistration[],
+): void {
   // (a) Duplicate IDs across registrations.
   const seen = new Set<string>();
-  for (const reg of SECTION_REGISTRY) {
+  for (const reg of registry) {
     if (seen.has(reg.id)) {
       console.error(
         `[sectionRegistry] Duplicate section ID detected: "${reg.id}". ` +
@@ -68,7 +149,7 @@ if (process.env.NODE_ENV !== "production") {
   }
 
   // (b) Registry vs metadata catalog drift.
-  const registryIds = new Set(SECTION_REGISTRY.map((r) => r.id));
+  const registryIds = new Set(registry.map((r) => r.id));
   const metadataIds = new Set(SECTION_METADATA_CATALOG.map((m) => m.id));
 
   for (const id of registryIds) {
@@ -92,8 +173,20 @@ if (process.env.NODE_ENV !== "production") {
   }
 }
 
+/**
+ * The default LegalWorkspace section registry — built once with no overrides.
+ * Standalone LegalWorkspace imports this directly; embedding consumers
+ * (SpaarkeAi) build their own via `createLegalWorkspaceSectionRegistry({...})`.
+ *
+ * Pre-R2 Option D: this was a literal `as const` array.
+ * Post-R2 Option D: this is the no-options factory call — byte-identical
+ * behavior preserved (FR-25 / NFR-10).
+ */
+export const SECTION_REGISTRY: readonly SectionRegistration[] =
+  createLegalWorkspaceSectionRegistry();
+
 // ---------------------------------------------------------------------------
-// Lookup helpers
+// Lookup helpers (continue to operate on the default SECTION_REGISTRY)
 // ---------------------------------------------------------------------------
 
 /** Look up a section registration by ID. Returns undefined if not found. */

--- a/src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts
+++ b/src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts
@@ -7,13 +7,24 @@
  * closes over LegalWorkspace-local `authenticatedFetch` + `trackEvent`
  * telemetry — preserving FR-25 / NFR-10.
  *
+ * # History of the customization seam
+ *
  * Pre-R2: STATIC `SectionRegistration` const that lost the factory's
- * `loadNotificationContext` option entirely (see `notes/task-002-blocker.md`).
- * Post-R2: thin shim that (1) re-exports a default static registration for
- * `sectionRegistry.ts` (standalone — loader omitted; empty-payload contract)
- * and (2) exposes a factory so SpaarkeAi `main.tsx` (task 002) can supply
- * `loadSpaarkeAiNotificationContext`. This is the P1 seam this task activates
- * (FR-01 / FR-02).
+ *   `loadNotificationContext` option entirely (see `notes/task-002-blocker.md`).
+ *
+ * Pre-Option D (R2 task 002 / Wave 8): module-mutable slot pattern. The default
+ *   registration wrapped a late-bound loader that read from a module-level
+ *   `_globalNotificationLoader`; SpaarkeAi `main.tsx` mutated the slot at
+ *   bootstrap via `setLegalWorkspaceDailyBriefingNotificationLoader`. That was
+ *   a band-aid that did not scale beyond one widget.
+ *
+ * Post-Option D (R2, 2026-06-18): the slot is gone. Per-host customization
+ *   happens via
+ *     `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } })`
+ *   in `sectionRegistry.ts` — the registry-as-composition factory pattern. See
+ *   `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md`.
+ *   This file now exposes only the per-widget factory + a no-loader default
+ *   registration for standalone consumers.
  *
  * Standards: ADR-012 (shared components), ADR-021 (Fluent v9 tokens),
  *            ADR-022 (React 19), ADR-028 (function-based auth contract).
@@ -31,9 +42,10 @@ import { trackEvent } from "../../services/telemetry";
  * Options for `createLegalWorkspaceDailyBriefingRegistration`.
  *
  * `loadNotificationContext` is the P1 seam (FR-01 / FR-02): supplied by
- * SpaarkeAi to flow real notification context into the BFF `/narrate`
- * envelope so embedded Daily Briefing renders real bullets on cold load.
- * Omitted by standalone LegalWorkspace → empty-payload contract preserved.
+ * SpaarkeAi (via `createLegalWorkspaceSectionRegistry`) to flow real
+ * notification context into the BFF `/narrate` envelope so embedded Daily
+ * Briefing renders real bullets on cold load. Omitted by standalone
+ * LegalWorkspace → empty-payload contract preserved.
  */
 export interface CreateLegalWorkspaceDailyBriefingRegistrationOptions {
   loadNotificationContext?: () => Promise<NarrateRequest | null>;
@@ -46,60 +58,6 @@ function routeRateLimitTelemetry(properties: Record<string, unknown>): void {
     stringProps[k] = String(v);
   }
   trackEvent(TELEMETRY_EVENT_DAILY_BRIEFING_429, stringProps);
-}
-
-// ---------------------------------------------------------------------------
-// Module-mutable notification-loader slot (R2 task 002 — FR-01 / FR-02).
-//
-// Why a module slot?
-//   `sectionRegistry.ts` consumes `dailyBriefingRegistration` as a STATIC
-//   `readonly` array entry built at module-load time. The default factory
-//   below runs ONCE at module-load with no loader. SpaarkeAi's `main.tsx`
-//   needs to inject `loadSpaarkeAiNotificationContext` AFTER bootstrap
-//   without rewriting `sectionRegistry.ts` (FR-25 / NFR-10 — standalone
-//   LegalWorkspace bundle byte-identical).
-//
-// Pattern (mirrors `setDefaultWorkspaceRenderer` from @spaarke/ui-components):
-//   - SpaarkeAi `main.tsx` calls `setLegalWorkspaceDailyBriefingNotificationLoader(loader)`
-//     before React renders.
-//   - The default registration's factory forwards a STABLE function reference
-//     to the shared factory that reads `_globalNotificationLoader` at
-//     call-time (per render fetch). The shared factory's closure captures
-//     this reference once, but the function itself is a thin lookup against
-//     the mutable slot — so the loader is "late-bound" at fetch time.
-//
-// Standalone LegalWorkspace + standalone Daily Briefing Code Page do NOT
-// call the setter — the slot stays `null`, the wrapper returns `null`,
-// `useDailyBriefing` falls back to the empty-payload contract (BFF returns
-// empty bullets → empty-state UI). FR-25 / NFR-10 preserved.
-// ---------------------------------------------------------------------------
-
-let _globalNotificationLoader:
-  | (() => Promise<NarrateRequest | null>)
-  | null = null;
-
-/**
- * Set the global notification-context loader for the DEFAULT Daily Briefing
- * registration consumed by `sectionRegistry.ts`. Call this BEFORE rendering
- * any tree that mounts `WorkspaceGrid` so the first fetch picks up the loader.
- *
- * Used by SpaarkeAi `main.tsx` to inject `loadSpaarkeAiNotificationContext`
- * (R2 task 002 — FR-02). Standalone LegalWorkspace does NOT call this.
- */
-export function setLegalWorkspaceDailyBriefingNotificationLoader(
-  loader: (() => Promise<NarrateRequest | null>) | null,
-): void {
-  _globalNotificationLoader = loader;
-}
-
-/**
- * Late-bound loader passed to the shared factory. The shared `useDailyBriefing`
- * hook calls `loadNotificationContext()` at fetch time — by then the SpaarkeAi
- * bootstrap has already set `_globalNotificationLoader`. Returns `null` when
- * no loader is configured (preserves empty-payload contract for standalone).
- */
-function lateBoundNotificationLoader(): Promise<NarrateRequest | null> {
-  return _globalNotificationLoader ? _globalNotificationLoader() : Promise.resolve(null);
 }
 
 /**
@@ -120,19 +78,18 @@ export function createLegalWorkspaceDailyBriefingRegistration(
 }
 
 /**
- * Default LegalWorkspace registration: standalone path uses a late-bound
- * loader that reads from the module-mutable slot above. When the slot is
- * unset (standalone LegalWorkspace + standalone Daily Briefing), the wrapper
- * returns `null` → empty-payload contract preserved. When SpaarkeAi sets
- * the slot at bootstrap, the wrapper forwards to the supplied loader →
- * Daily Briefing renders real bullets on cold load (FR-02).
+ * Default LegalWorkspace Daily Briefing registration: no loader supplied →
+ * the standalone empty-payload contract is preserved (BFF `/narrate` returns
+ * empty bullets → empty-state UI). FR-25 / NFR-10.
  *
- * Consumed by `sectionRegistry.ts` unchanged.
+ * Embedding consumers (SpaarkeAi) do NOT use this const directly — they build
+ * a custom registry via
+ * `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } })`
+ * which calls `createLegalWorkspaceDailyBriefingRegistration(options.dailyBriefing)`
+ * with their loader. See `sectionRegistry.ts` and Option D design rationale.
  */
 export const dailyBriefingRegistration: SectionRegistration =
-  createLegalWorkspaceDailyBriefingRegistration({
-    loadNotificationContext: lateBoundNotificationLoader,
-  });
+  createLegalWorkspaceDailyBriefingRegistration();
 
 export default dailyBriefingRegistration;
 

--- a/src/solutions/SpaarkeAi/src/main.tsx
+++ b/src/solutions/SpaarkeAi/src/main.tsx
@@ -57,14 +57,16 @@ import type { IRuntimeConfig } from "@spaarke/auth";
 // Both singletons receive the SAME `IRuntimeConfig` so they agree on bffBaseUrl
 // / scope / clientId / tenantId. The two are distinct in-process instances by
 // design — embedding does not collapse them; it just keeps both warm.
+//
+// R2 Option D (2026-06-18): replaces the R2 task 002 module-mutation slot.
+// SpaarkeAi builds a CUSTOM section registry that injects its notification-
+// context loader into the Daily Briefing widget, then registers a wrapper
+// renderer that passes the registry to `LegalWorkspaceApp` via the new
+// `sections` prop. See `notes/option-d-registry-as-composition.md`.
 import {
-  LegalWorkspaceRenderer,
+  LegalWorkspaceApp,
+  createLegalWorkspaceSectionRegistry,
   setLegalWorkspaceRuntimeConfig,
-  // R2 task 002 (FR-01 / FR-02): inject SpaarkeAi's notification-context loader
-  // into the LegalWorkspace Daily Briefing registration consumed by
-  // SECTION_REGISTRY. Without this, the embedded Daily Briefing fetches with
-  // an empty payload and renders the "Nothing to see right now" empty state.
-  setLegalWorkspaceDailyBriefingNotificationLoader,
 } from "@spaarke/legal-workspace";
 // R2 task 002 (FR-02): loadSpaarkeAiNotificationContext queries `appnotification`
 // via Xrm.WebApi and builds the populated NarrateRequest envelope (categories +
@@ -72,15 +74,17 @@ import {
 // TL;DR + channel bullets. Mirrors the standalone Daily Briefing Code Page
 // data path (see file header for cross-reference).
 import { loadSpaarkeAiNotificationContext } from "./services/notificationContextLoader";
-// R4 task 052 (C-4): register LegalWorkspaceApp as the default workspace
-// renderer. `WorkspaceLayoutWidget` in `@spaarke/ai-widgets` consults this
-// slot at render time instead of importing `@spaarke/legal-workspace` directly.
-// Zero behavioural change today — `LegalWorkspaceRenderer` IS `LegalWorkspaceApp`.
+// R4 task 052 (C-4) + R2 Option D (2026-06-18): register a workspace renderer
+// that wraps `LegalWorkspaceApp` with a SpaarkeAi-specific section registry.
+// `WorkspaceLayoutWidget` in `@spaarke/ai-widgets` consults `setDefaultWorkspaceRenderer`
+// at render time instead of importing `@spaarke/legal-workspace` directly.
+// `WorkspaceRenderer` is the function signature contract the slot accepts.
 import {
   setDefaultWorkspaceRenderer,
   AppErrorBoundary,
   AppInsightsService,
 } from "@spaarke/ui-components";
+import type { WorkspaceRenderer } from "@spaarke/ui-components";
 
 // ---------------------------------------------------------------------------
 // BFF base URL baked in at build time via Vite env var (AIPU-091).
@@ -216,29 +220,33 @@ async function bootstrap(): Promise<void> {
   // See the docblock above this bootstrap() definition for full rationale.
   suppressLegalWorkspaceDailyDigestAutoPopup();
 
-  // R4 task 052 (C-4): register LegalWorkspaceApp as the default workspace
-  // renderer BEFORE rendering the React tree. `WorkspaceLayoutWidget`
-  // (registered into WorkspaceWidgetRegistry by @spaarke/ai-widgets) consults
-  // `getDefaultWorkspaceRenderer()` at render time. Without this call, the
-  // widget would render a "no renderer registered" empty state.
+  // R4 task 052 (C-4) + R2 Option D (2026-06-18): register a SpaarkeAi-specific
+  // workspace renderer that wraps `LegalWorkspaceApp` with a custom section
+  // registry. `WorkspaceLayoutWidget` (registered into WorkspaceWidgetRegistry
+  // by @spaarke/ai-widgets) consults `getDefaultWorkspaceRenderer()` at render
+  // time. Without this call, the widget would render a "no renderer registered"
+  // empty state.
   //
-  // Zero behavioural change vs pre-C-4 (Risk R-4): `LegalWorkspaceRenderer`
-  // IS `LegalWorkspaceApp` — the rename is a typed re-export, not a wrapper.
-  setDefaultWorkspaceRenderer(LegalWorkspaceRenderer);
-
-  // R2 task 002 (FR-01 / FR-02): inject SpaarkeAi's notification-context loader
-  // into the LegalWorkspace Daily Briefing registration BEFORE rendering the
-  // React tree. The default `dailyBriefingRegistration` (built at module-load
-  // with a late-bound loader wrapper) reads this slot at fetch time. Without
-  // this call the wrapper returns null → useDailyBriefing falls back to the
-  // empty-payload contract → operator sees "Nothing to see right now" instead
-  // of real bullets.
+  // The custom section registry injects `loadSpaarkeAiNotificationContext`
+  // into the Daily Briefing widget so the embedded copy renders real bullets
+  // on cold load (FR-01 / FR-02) — replaces the R2 task 002 module-mutation
+  // slot pattern. The wrapper renderer preserves the `setDefaultWorkspaceRenderer`
+  // slot mechanism: WorkspaceLayoutWidget still sees a `WorkspaceRenderer`
+  // function, it just renders an instance with custom `sections`. See
+  // `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md`.
   //
   // FR-25 / NFR-10 preserved: standalone LegalWorkspace + standalone Daily
-  // Briefing Code Page do NOT call this setter (their bundles never import
-  // this module), so the slot stays unset there and the empty-payload
-  // contract is preserved for those surfaces.
-  setLegalWorkspaceDailyBriefingNotificationLoader(loadSpaarkeAiNotificationContext);
+  // Briefing Code Page do NOT import this module, so the no-options
+  // SECTION_REGISTRY default is used there → empty-payload contract preserved.
+  const sectionsForSpaarkeAi = createLegalWorkspaceSectionRegistry({
+    dailyBriefing: {
+      loadNotificationContext: loadSpaarkeAiNotificationContext,
+    },
+  });
+  const SpaarkeAiWorkspaceRenderer: WorkspaceRenderer = (props) => (
+    <LegalWorkspaceApp {...props} sections={sectionsForSpaarkeAi} />
+  );
+  setDefaultWorkspaceRenderer(SpaarkeAiWorkspaceRenderer);
 
   // -------------------------------------------------------------------------
   // 1. Resolve runtime config


### PR DESCRIPTION
## Summary

**Architectural follow-up to PR #396** (merged 10 minutes ago, 2026-06-18T22:01:20Z). PR #396 shipped R2's 31/36 tasks including R2 task 002's Wave 8 *module-mutable slot* pattern (`_globalNotificationLoader` + `setLegalWorkspaceDailyBriefingNotificationLoader` + late-bound wrapper). User code review immediately after caught that the slot pattern is a band-aid that doesn't scale to SpaarkeAi's strategic vision as the critical core surface supporting N widgets + two-way Assistant ⇄ Workspace ⇄ Context flows. This PR is the proper architecture — landing right after #396 so the band-aid lives on master for the minimum time.

**Net effect on the codebase:** band-aid OUT, registry-as-composition IN. 1 commit; 6 source files refactored; 3 new tests (6 suites / 29 total pass); zero behavioral regression for standalone consumers.

## Changes

### Refactor (6 files)
- `src/solutions/LegalWorkspace/src/sectionRegistry.ts` — Add `createLegalWorkspaceSectionRegistry(options)` factory + `LegalWorkspaceSectionRegistryOptions` typed interface. `SECTION_REGISTRY` becomes `createLegalWorkspaceSectionRegistry()` (no-options default). Dev-mode duplicate-ID + metadata-drift guards extracted into a `runRegistryDevGuards(registry)` helper that runs for any custom registry built by embedding hosts.
- `src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts` — **REMOVED** `_globalNotificationLoader`, `setLegalWorkspaceDailyBriefingNotificationLoader`, `lateBoundNotificationLoader`. Default registration is now plain `createLegalWorkspaceDailyBriefingRegistration()` (no loader → standalone empty-payload contract preserved).
- `src/solutions/LegalWorkspace/src/index.ts` — **REMOVED** setter re-export. **ADDED** `createLegalWorkspaceSectionRegistry`, `SECTION_REGISTRY`, `LegalWorkspaceSectionRegistryOptions`, `SectionRegistration` type re-exports.
- `src/solutions/LegalWorkspace/src/LegalWorkspaceApp.tsx` — Added `sections?: readonly SectionRegistration[]` to `ILegalWorkspaceAppProps`. Threaded to `WorkspaceGrid`.
- `src/solutions/LegalWorkspace/src/components/Shell/WorkspaceGrid.tsx` — Accepts `sections` prop (default = imported `SECTION_REGISTRY`). FR-25 / NFR-10 preserved.
- `src/solutions/SpaarkeAi/src/main.tsx` — **REMOVED** setter import + call. **REPLACED** `setDefaultWorkspaceRenderer(LegalWorkspaceRenderer)` with: build `customSections` via `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext: loadSpaarkeAiNotificationContext } })`, define `SpaarkeAiWorkspaceRenderer = (props) => <LegalWorkspaceApp {...props} sections={customSections} />`, register via existing `setDefaultWorkspaceRenderer` slot.

### Tests (3 new)
`src/client/shared/Spaarke.DailyBriefing.Components/test/legalWorkspaceSectionRegistry.test.ts`:
1. `createLegalWorkspaceSectionRegistry()` returns same widget IDs as `SECTION_REGISTRY` const
2. `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext } })` threads loader
3. Legacy `setLegalWorkspaceDailyBriefingNotificationLoader` API is removed (text-based assertion locks in band-aid removal)

### Documentation
- `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md` — comprehensive design rationale: problem statement, 4 alternatives evaluated (A/B/C rejected, D chosen), target file shapes, cookbook for adding new widgets under this pattern, speculative-design discipline (no `paneEventBus`/`agentClient`/`contextProvider` added today — interface is additively extensible), R6 coordination notes
- 3 follow-up POML tasks for documentation alignment (executed post-merge):
  - **070** — Pattern doc `.claude/patterns/ui/workspace-section-registry-composition.md`
  - **071** — Update `SPAARKEAI-DASHBOARD-AND-WIDGET-MODEL.md` + `BUILD-A-NEW-WORKSPACE-WIDGET.md` with cookbook
  - **072** — Draft ADR-033 (full + AI-concise + INDEX updates + back-refs to ADR-006/012)

## Verification

| Check | Result |
|---|---|
| LegalWorkspace `tsc --noEmit` | Same 6 pre-existing errors as baseline (verified via stash/unstash); zero new |
| SpaarkeAi `tsc --noEmit` | Zero errors in `main.tsx`; only transitive pre-existing |
| `npm test` in `@spaarke/daily-briefing-components` | **6 suites / 29 tests pass** (was 5 / 26) |
| `grep -r "setLegalWorkspaceDailyBriefingNotificationLoader" src/` (live code) | **0 matches** — all 6 remaining hits are in docblocks/test names documenting removal |
| `grep -r "_globalNotificationLoader\|lateBoundNotificationLoader" src/solutions/LegalWorkspace/` (live code) | **0 matches** |

## Why this is the right architecture (not Option C)

Option C (per-widget React Context) was considered and rejected because it scales O(N) with widget count — every future widget needing per-host customization would need its own Context type and Provider wrap. Option D is one factory + one typed options interface for ALL per-host customization. When a future widget needs `paneEventBus` or `agentClient` or `contextProvider`, those become new entries in `LegalWorkspaceSectionRegistryOptions` — additively, without architectural restructuring. Full evaluation in `notes/option-d-registry-as-composition.md` §2.

## Standalone behavior preserved (FR-25 / NFR-10)

Standalone LegalWorkspace's `App.tsx` mounts `<WorkspaceGrid>` directly, not through `<LegalWorkspaceApp>`. `WorkspaceGrid`'s `sections` prop defaults to the imported `SECTION_REGISTRY` (= `createLegalWorkspaceSectionRegistry()` with no options), so standalone behavior is byte-identical to today's literal const. Verified by code path inspection.

## R6 coordination

R6 PR #395 (merged into master before this PR via #394) made ZERO commits to the files this PR touches. No conflict resolution required. Verified via `git -C r6-worktree log --oneline origin/master..HEAD -- <files>`.

## Test plan

- [x] All existing R2 tests pass (5 suites / 26 tests preserved + 3 new)
- [x] No new TypeScript errors
- [x] Grep verification confirms band-aid removal
- [ ] CI green (will verify after push)
- [ ] After merge: 060 BFF deploy + 061 code-page redeploy from master with both #396 + this PR in (standalone LegalWorkspace bundle unchanged; SpaarkeAi bundle uses Option D path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)