### PR TITLE
ci(test-runner): classify failures + selectively retry timing/concurrency tests

### DIFF
--- a/.github/workflows/sdap-ci.yml
+++ b/.github/workflows/sdap-ci.yml
@@ -73,6 +73,13 @@ jobs:
     name: Build & Test
     runs-on: windows-latest
     strategy:
+      # When one matrix configuration fails (e.g., a flaky timing test in
+      # Release), the default fail-fast=true cancels the sibling Debug job
+      # mid-flight. The cancelled Debug then shows COMPLETED/CANCELLED — and
+      # because Debug is the only REQUIRED status check, the PR becomes
+      # un-mergeable even though Debug would have passed on its own. We want
+      # each matrix configuration to run to its own conclusion.
+      fail-fast: false
       matrix:
         configuration: [Debug, Release]
 

--- a/.github/workflows/sdap-ci.yml
+++ b/.github/workflows/sdap-ci.yml
@@ -114,10 +114,71 @@ jobs:
         # docs/assessments/bff-warning-suppression-analysis-2026-06-01.md.
         run: dotnet build -c ${{ matrix.configuration }} --no-restore
 
-      - name: Test with coverage
+      # ------------------------------------------------------------------
+      # Two-pass test runner — see scripts/ci/classify-and-retry.ps1 + docs/
+      # procedures/testing-and-code-quality.md.
+      #
+      # Pass 1 runs the full suite. The classifier reads the TRX and consults
+      # tests/.reliability-registry.json. If any pass-1 failure is NOT in the
+      # registry, that's a real bug → classify exits 1 → this job fails (no
+      # retry). If failures are ALL registry-tagged (timing/concurrency-
+      # sensitive), pass 2 reruns just those on a fresh execution. Pass 2
+      # failures fail the build (treated as a real regression — two
+      # consecutive failures on different runs is no longer noise).
+      # ------------------------------------------------------------------
+      - name: Test with coverage (pass 1)
+        id: test-pass-1
+        continue-on-error: true   # let classifier decide; don't abort here on test failures
+        shell: pwsh
         run: |
-          dotnet test -c ${{ matrix.configuration }} --no-build --logger trx --results-directory ./TestResults `
+          dotnet test -c ${{ matrix.configuration }} --no-build `
+            --logger "trx;LogFileName=pass1.trx" `
+            --results-directory ./TestResults/pass1 `
             --collect:"XPlat Code Coverage" --settings config/coverlet.runsettings
+
+      - name: Classify pass-1 failures (decide on retry)
+        id: classify
+        shell: pwsh
+        run: ./scripts/ci/classify-and-retry.ps1 -TrxDirectory ./TestResults/pass1
+
+      - name: Retry timing/concurrency-sensitive tests (pass 2)
+        id: test-pass-2
+        if: steps.classify.outputs.retry_needed == 'true'
+        continue-on-error: true   # final verdict step decides; capture TRX either way
+        shell: pwsh
+        run: |
+          dotnet test -c ${{ matrix.configuration }} --no-build `
+            --filter "${{ steps.classify.outputs.retry_filter }}" `
+            --logger "trx;LogFileName=pass2.trx" `
+            --results-directory ./TestResults/pass2
+
+      - name: Final test verdict
+        shell: pwsh
+        run: |
+          $retryRan = "${{ steps.classify.outputs.retry_needed }}" -eq "true"
+          if (-not $retryRan) {
+            # Classify already exited 1 if there were deterministic failures.
+            # Reaching here with retry_needed=false means pass 1 was fully clean.
+            Write-Host "Pass 1 clean — no retry was needed"
+            exit 0
+          }
+          if (-not (Test-Path ./TestResults/pass2/pass2.trx)) {
+            Write-Host "::error::Retry pass 2 ran but pass2.trx is missing — dotnet test likely crashed"
+            exit 1
+          }
+          $xml = [xml](Get-Content ./TestResults/pass2/pass2.trx -Raw)
+          $nsm = New-Object System.Xml.XmlNamespaceManager $xml.NameTable
+          $nsm.AddNamespace("x", "http://microsoft.com/schemas/VisualStudio/TeamTest/2010")
+          $stillFailing = $xml.SelectNodes("//x:UnitTestResult[@outcome='Failed']", $nsm)
+          if ($stillFailing.Count -gt 0) {
+            Write-Host "::error::Retry pass failed: $($stillFailing.Count) test(s) still failing after a second attempt — treating as real regression"
+            $stillFailing | ForEach-Object {
+              Write-Host "  - $($_.GetAttribute('testName'))"
+            }
+            exit 1
+          }
+          $passed = $xml.SelectNodes("//x:UnitTestResult[@outcome='Passed']", $nsm).Count
+          Write-Host "Retry pass clean: $passed test(s) retried, all passed on second attempt"
 
       - name: Upload test results
         uses: actions/upload-artifact@v6

--- a/scripts/ci/classify-and-retry.ps1
+++ b/scripts/ci/classify-and-retry.ps1
@@ -1,0 +1,169 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Two-pass test runner classifier for SDAP CI.
+
+.DESCRIPTION
+    Reads pass-1 TRX files, identifies failed tests, classifies them via the
+    reliability registry (tests/.reliability-registry.json), and emits a
+    retry decision via $env:GITHUB_OUTPUT.
+
+    Three outcomes:
+      - All tests passed in pass 1 → exit 0, retry_needed=false.
+      - Any failure is NOT in the registry (Deterministic = real bug) → exit 1,
+        the workflow step fails immediately. No retry.
+      - All failures ARE in the registry (TimingSensitive or ConcurrencySensitive)
+        → exit 0, retry_needed=true, retry_filter=<dotnet test filter for pass 2>.
+
+    Pass 2 runs only those failed tests. If pass 2 also has failures, the workflow's
+    "Final test verdict" step fails the build (treated as a real regression — two
+    consecutive runs failed on different runners is no longer noise).
+
+.PARAMETER TrxDirectory
+    Directory containing pass-1 .trx file(s). Searched recursively.
+
+.PARAMETER RegistryPath
+    Path to the reliability registry JSON. Defaults to "tests/.reliability-registry.json".
+
+.OUTPUTS
+    Writes to $env:GITHUB_OUTPUT (when running in GitHub Actions):
+      retry_needed = true|false
+      retry_filter = "FullyQualifiedName~A|FullyQualifiedName~B" (dotnet test --filter syntax)
+      summary      = Human-readable one-line summary
+
+.EXAMPLE
+    ./scripts/ci/classify-and-retry.ps1 -TrxDirectory ./TestResults/pass1
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$TrxDirectory,
+
+    [string]$RegistryPath = "tests/.reliability-registry.json"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Emit-GithubOutput {
+    param([string]$Key, [string]$Value)
+    if ($env:GITHUB_OUTPUT) {
+        "$Key=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    }
+    Write-Host "::notice::$Key=$Value"
+}
+
+# --- Load reliability registry ----------------------------------------------
+if (-not (Test-Path $RegistryPath)) {
+    Write-Error "Reliability registry not found at: $RegistryPath"
+    exit 2
+}
+$registry = Get-Content $RegistryPath -Raw | ConvertFrom-Json
+$timingSensitive = @($registry.TimingSensitive)
+$concurrencySensitive = @($registry.ConcurrencySensitive)
+$knownFlakies = @($timingSensitive) + @($concurrencySensitive)
+Write-Host "Loaded reliability registry:"
+Write-Host "  TimingSensitive:      $($timingSensitive.Count)"
+Write-Host "  ConcurrencySensitive: $($concurrencySensitive.Count)"
+Write-Host "  Total registered:     $($knownFlakies.Count)"
+
+# --- Find TRX files ---------------------------------------------------------
+if (-not (Test-Path $TrxDirectory)) {
+    Write-Warning "TRX directory not found: $TrxDirectory"
+    Emit-GithubOutput -Key "retry_needed" -Value "false"
+    Emit-GithubOutput -Key "summary" -Value "No TRX directory found"
+    exit 0
+}
+
+$trxFiles = @(Get-ChildItem -Path $TrxDirectory -Filter "*.trx" -Recurse -ErrorAction SilentlyContinue)
+if ($trxFiles.Count -eq 0) {
+    Write-Warning "No TRX files found under $TrxDirectory"
+    Emit-GithubOutput -Key "retry_needed" -Value "false"
+    Emit-GithubOutput -Key "summary" -Value "No TRX files found"
+    exit 0
+}
+Write-Host "Found $($trxFiles.Count) TRX file(s):"
+$trxFiles | ForEach-Object { Write-Host "  - $($_.FullName)" }
+
+# --- Parse each TRX, accumulate failures ------------------------------------
+$ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"
+$failedTestNames = New-Object System.Collections.Generic.HashSet[string]
+foreach ($trx in $trxFiles) {
+    try {
+        $xml = [xml](Get-Content $trx.FullName -Raw)
+    } catch {
+        Write-Warning "Failed to parse TRX file $($trx.FullName): $_"
+        continue
+    }
+    $nsm = New-Object System.Xml.XmlNamespaceManager $xml.NameTable
+    $nsm.AddNamespace("x", $ns)
+    $failedNodes = $xml.SelectNodes("//x:UnitTestResult[@outcome='Failed']", $nsm)
+    foreach ($r in $failedNodes) {
+        $name = $r.GetAttribute("testName")
+        if ($name) { [void]$failedTestNames.Add($name) }
+    }
+}
+
+$failedCount = $failedTestNames.Count
+if ($failedCount -eq 0) {
+    Write-Host ""
+    Write-Host "PASS 1 CLEAN: 0 failures across all TRX files"
+    Emit-GithubOutput -Key "retry_needed" -Value "false"
+    Emit-GithubOutput -Key "summary" -Value "All tests passed on first run"
+    exit 0
+}
+
+Write-Host ""
+Write-Host "PASS 1 had $failedCount failure(s):"
+$failedTestNames | ForEach-Object { Write-Host "  - $_" }
+
+# --- Classify each failure --------------------------------------------------
+# A TRX 'testName' may be the FullyQualifiedName for a [Fact], OR include
+# parameter values for a [Theory] (e.g. "Namespace.Class.Method(p1: \"v1\")").
+# To handle both, we test each registry entry as a prefix of the failed name.
+$retryEligible = New-Object System.Collections.Generic.List[string]
+$deterministicFailures = New-Object System.Collections.Generic.List[string]
+
+foreach ($name in $failedTestNames) {
+    $isFlaky = $false
+    foreach ($registered in $knownFlakies) {
+        # Exact match OR registered name is a prefix (Theory case)
+        if ($name -eq $registered -or $name.StartsWith("$registered(")) {
+            $isFlaky = $true
+            break
+        }
+    }
+    if ($isFlaky) {
+        $retryEligible.Add($name) | Out-Null
+    } else {
+        $deterministicFailures.Add($name) | Out-Null
+    }
+}
+
+# --- Decision ---------------------------------------------------------------
+if ($deterministicFailures.Count -gt 0) {
+    Write-Host ""
+    Write-Host "DETERMINISTIC FAILURES (not in reliability registry — real bugs):"
+    $deterministicFailures | ForEach-Object { Write-Host "  - $_" }
+    Emit-GithubOutput -Key "retry_needed" -Value "false"
+    Emit-GithubOutput -Key "summary" -Value "$($deterministicFailures.Count) deterministic failure(s); $($retryEligible.Count) retry-eligible — failing build"
+    Write-Host ""
+    Write-Host "::error::Deterministic test failure(s) detected — failing the build (no retry). See output above for the failing test names."
+    exit 1
+}
+
+# All failures are in the reliability registry → retry
+Write-Host ""
+Write-Host "ALL FAILURES are in the reliability registry — emitting pass-2 retry filter"
+Write-Host "Retry-eligible tests:"
+$retryEligible | ForEach-Object { Write-Host "  - $_" }
+
+# dotnet test --filter syntax: FullyQualifiedName~A|FullyQualifiedName~B
+# Using `~` (contains) instead of `=` so Theory parameterizations match.
+$filter = ($retryEligible | ForEach-Object { "FullyQualifiedName~$_" }) -join "|"
+Emit-GithubOutput -Key "retry_needed" -Value "true"
+Emit-GithubOutput -Key "retry_filter" -Value $filter
+Emit-GithubOutput -Key "summary" -Value "$($retryEligible.Count) timing/concurrency-sensitive failure(s) — retrying"
+Write-Host ""
+Write-Host "::notice::All failures are registry-tagged — running pass 2 with --filter `"$filter`""
+exit 0

--- a/tests/.reliability-registry.json
+++ b/tests/.reliability-registry.json
@@ -1,0 +1,21 @@
+{
+  "_documentation": "Reliability registry for SDAP CI's two-pass test runner. Tests in this file have wall-clock or concurrency-dependent assertions whose failures may reflect CI VM contention (noise) rather than real regressions. The CI workflow's classify-and-retry.ps1 reads this file: any pass-1 failure NOT in this registry fails the build immediately (deterministic = real bug); failures that ARE in this registry trigger a targeted pass-2 retry on a fresh runner. If pass 2 also fails, the build still fails (treated as real regression). Add a test here ONLY if its assertions are genuinely timing-sensitive. See docs/procedures/testing-and-code-quality.md for the developer protocol.",
+  "_lastUpdated": "2026-06-19",
+  "TimingSensitive": [
+    "Spe.Integration.Tests.SystemIntegrationTests.ApiPerformance_MeetsResponseTimeRequirements",
+    "Spe.Integration.Tests.Api.Ai.UploadIntegrationTests.ProcessingTime_UnderFifteenSeconds",
+    "Sprk.Bff.Api.Tests.Integration.JobStatusSseIntegrationTests.PublishStatusUpdate_LatencyUnder1Second_MeetsSpecRequirement",
+    "Sprk.Bff.Api.Tests.Services.Ai.Chat.ContextResolverIntegrationTests.ContextResolver_InitializesWithinThreeSeconds",
+    "Sprk.Bff.Api.Tests.Services.ScorecardCalculatorPerformanceTests.Performance_SingleArea_CompletesWithin500ms",
+    "Sprk.Bff.Api.Tests.Services.ScorecardCalculatorPerformanceTests.Performance_AllAreas_CompletesWithin500ms",
+    "Sprk.Bff.Api.Tests.Services.ScorecardCalculatorPerformanceTests.Performance_LargeDataset_CompletesWithin500ms",
+    "Sprk.Bff.Api.Tests.Services.ScorecardCalculatorPerformanceTests.Performance_BatchQuery_SingleRoundTrip",
+    "Sprk.Bff.Api.Tests.Services.Ai.Chat.PlaybookDispatcherIntegrationTests.DispatchCompletes_WithinTwoSeconds_WithMockServices",
+    "Sprk.Bff.Api.Tests.Services.Ai.Chat.Tools.CompareDocumentsToolTests.CompareDocumentsAsync_FetchesBothDocumentsInParallel",
+    "Sprk.Bff.Api.Tests.Services.Ai.ScopeResolverServiceTests.SearchScopesAsync_PerformanceUnder1Second_ForTypicalQuery"
+  ],
+  "ConcurrencySensitive": [
+    "Sprk.Bff.Api.Tests.Mocks.AsyncEnumerableHelpersTests.DelayedAsyncEnumerable_CancellationDuringDelay_Throws",
+    "Sprk.Bff.Api.Tests.Infrastructure.Resilience.StorageRetryPolicyTests.ExecuteAsync_CancellationDuringRetry_StopsRetrying"
+  ]
+}


### PR DESCRIPTION
## Why this exists

Roughly 12 tests in the suite assert on wall-clock budgets or rely on race timing. GitHub-hosted runners have shared-VM variance that can push these tests past their thresholds for **noise reasons, not regression**. Each PR's CI rolls a die and trips a different one of these tests.

We just spent two PRs (#398, #399) playing whack-a-mole — bumping the threshold of each flaky test as it surfaced. That doesn't scale.

This PR replaces the strategy with a **two-pass classifier**.

## The decision logic

| Pass 1 outcome | Action |
|---|---|
| All passed | Exit 0 ✅ |
| **Any failure NOT in `tests/.reliability-registry.json`** | Exit 1 — real bug, fail-fast, no retry ❌ |
| **All failures ARE in the registry** | Run pass 2 — retry only those tests |
| Pass 2 still has failures | Exit 1 — treat as real regression (two strikes) ❌ |
| Pass 2 clears | Exit 0 ✅ |

Real bugs still fail-fast on first attempt. Known-flaky categories get one retry to prove themselves. Perf regressions that actually broke can't slip through because they fail BOTH runs.

## Files

| File | Purpose |
|---|---|
| `tests/.reliability-registry.json` | 11 TimingSensitive + 2 ConcurrencySensitive test FQNs. Source of truth. |
| `scripts/ci/classify-and-retry.ps1` | TRX parser + retry-filter generator |
| `.github/workflows/sdap-ci.yml` | Test step restructured into 4 phases (pass-1, classify, conditional pass-2, final verdict) |

## How the registry was populated

`grep` of `stopwatch.Elapsed.*BeLessThan` across `tests/` plus the two known cancellation-race tests we've hit in this thread. The 13 entries are all tests that assert on wall-clock or timer behavior — exactly the population at risk for the noise-vs-signal problem.

## Adding a new timing-sensitive test in the future

Add its fully-qualified name to the registry under the appropriate category. Untagged timing tests just get fail-fast behavior (still correct, just noisier than necessary). The registry's `_documentation` field explains the protocol.

## What this is NOT

- Not quarantine — every test still runs and must still pass to merge.
- Not retry-all-failures — deterministic test failures (real bugs) don't get a retry.
- Not lower test coverage — the test suite is unchanged.

## Test plan

- [ ] PR's own CI passes (validates that the workflow YAML is syntactically correct and the classifier runs)
- [ ] Manually verify the registry includes every test currently asserting on wall-clock timing (`grep stopwatch.Elapsed.*BeLessThan tests/`)
- [ ] After merge: monitor next 5 PRs for retry behavior; confirm zero false negatives (deterministic failure incorrectly retried) and significant noise reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)