### PR TITLE
feat(daily-update-r2.2): Daily Briefing UX hotfix bundle (TL;DR format + per-item due dates + AddToTodo improvements)

### DIFF
--- a/projects/spaarke-daily-update-service-r2/current-task.md
+++ b/projects/spaarke-daily-update-service-r2/current-task.md
@@ -1,7 +1,7 @@
 # Current Task State
 
-> **Auto-updated by task-execute and context-handoff skills**
-> **Last Updated**: 2026-06-18 (Option D mid-flight)
+> **Last Updated**: 2026-06-20 (R2.2 hotfix starting)
+> **Recovery**: Read "Quick Recovery" section first
 > **Protocol**: [Context Recovery](../../docs/procedures/context-recovery.md)
 
 ---
@@ -10,41 +10,44 @@
 
 | Field | Value |
 |-------|-------|
-| **Task** | Option D — replace module-mutation slot from R2 task 002 with registry-as-composition factory |
-| **Step** | 8 of 12 — design + Phase 7b POMLs done; implementing the 5-file refactor + 3 tests now |
-| **Status** | in-progress |
-| **Next Action** | Execute refactor on 6 source files per `notes/option-d-registry-as-composition.md` §3; add 3 unit tests; commit + push to PR #396 |
-| **Rigor Level** | FULL — touches LegalWorkspaceApp + SpaarkeAi/main.tsx + WorkspaceGrid + sectionRegistry; high-impact architectural change |
-| **Branch** | `work/spaarke-daily-update-service-r2` |
-| **Active PR** | [#396](https://github.com/spaarke-dev/spaarke/pull/396) — auto-merge armed; will re-fire when CI re-runs after Option D push |
+| **Task** | R2.2 hotfix — Daily Briefing UX improvements bundle (3 items) |
+| **Step** | Starting (no commits yet on R2.2 branch) |
+| **Status** | not-started |
+| **Next Action** | Item 1: TL;DR prompt change in [`DailyBriefingEndpoints.cs`](../../src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs#L398-L460) — convert 5-7 sentences format to 2-3 sentences + key takeaways bullets |
+| **Branch** | `work/spaarke-daily-update-service-r2.2` (forked from `origin/master` @ `3d5c58e4b`) |
+| **PR** | Not yet created — draft PR after first commit (per push-to-github convention) |
+| **Predecessors** | R2 (PR #397, merged) + R2.1 hotfix (PR #400, merged) — both shipped + redeployed to spaarkedev1 |
+| **Successor** | R3 `spaarke-platform-foundations-r3` (PR #404 design.md merged; tasks generation in progress in separate worktree) |
 
-### Files Modified Already This Session (Option D)
+### Scope (3 items)
 
-- `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md` — Created — design rationale + alternatives + cookbook + speculative-design discipline
-- `projects/spaarke-daily-update-service-r2/tasks/070-pattern-doc-workspace-section-registry-composition.poml` — Created
-- `projects/spaarke-daily-update-service-r2/tasks/071-update-architecture-docs-for-registry-composition.poml` — Created
-- `projects/spaarke-daily-update-service-r2/tasks/072-adr-workspace-section-registry-composition.poml` — Created
-- `projects/spaarke-daily-update-service-r2/current-task.md` — Modified (this file)
+| # | Item | Effort | Files |
+|---|---|---|---|
+| 1 | TL;DR as 2-3 sentences + key takeaways bullets (was 5-7 sentences) | ~1h | `src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs` (prompt change L398-460) |
+| 2 | Due date rendered per item in `NarrativeBullet` | ~1h | `src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx` |
+| 3 | `AddToTodo` sets sensible default due date + shows confirmation toast | ~2h | `src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useInlineTodoCreate.ts` + UI toast wiring |
 
-### Pending implementation changes (next 6 files + tests)
+### Out of scope for R2.2 (deferred to R3)
 
-| File | Change |
-|---|---|
-| `src/solutions/LegalWorkspace/src/sectionRegistry.ts` | Add `createLegalWorkspaceSectionRegistry(options)` factory + `LegalWorkspaceSectionRegistryOptions` interface; `SECTION_REGISTRY = createLegalWorkspaceSectionRegistry()`; extract dev-guards into `runRegistryDevGuards(registry)` helper |
-| `src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts` | REMOVE `_globalNotificationLoader`, `setLegalWorkspaceDailyBriefingNotificationLoader`, `lateBoundNotificationLoader`; `dailyBriefingRegistration = createLegalWorkspaceDailyBriefingRegistration()` (no loader) |
-| `src/solutions/LegalWorkspace/src/index.ts` | REMOVE setter re-export; ADD factory + options + SECTION_REGISTRY + SectionRegistration type re-exports |
-| `src/solutions/LegalWorkspace/src/LegalWorkspaceApp.tsx` | Add `sections?: readonly SectionRegistration[]` to `ILegalWorkspaceAppProps`; pass to `WorkspaceGrid` |
-| `src/solutions/LegalWorkspace/src/components/Shell/WorkspaceGrid.tsx` | Accept `sections` prop (default → imported SECTION_REGISTRY); replace direct usage |
-| `src/solutions/SpaarkeAi/src/main.tsx` | REMOVE setter import + call; build `customSections = createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext: loadSpaarkeAiNotificationContext } })`; define `SpaarkeAiWorkspaceRenderer = (props) => <LegalWorkspaceApp {...props} sections={customSections} />`; register via existing `setDefaultWorkspaceRenderer(SpaarkeAiWorkspaceRenderer)` |
-| **Tests** | 3 new tests: no-options equivalence; loader threading; legacy setter API removed |
+- ❌ FetchXML OR interim unblock for `notification-new-documents` / `notification-new-emails` playbooks — **decided 2026-06-20 to wait for R3's `MembershipResolverService`** rather than do throwaway work
+- ❌ `??` Handlebars helper fix (R3 Part 3 H1 — `Spaarke.Scheduling` + platform-level)
+- ❌ Unrendered `{{` runtime warning (R3 Part 3 H1)
+
+### Files Modified This Session
+
+(none yet — starting fresh on R2.2)
 
 ### Critical Context
 
-PR #396 is OPEN with auto-merge armed. Option D is being ADDED to this PR so the band-aid module-mutation pattern from R2 task 002 (Wave 8) is REPLACED, not layered. After Option D commits land, CI re-runs and auto-merge fires.
+R2.2 is a small UX-only hotfix bundle for the Daily Briefing widget + standalone code page. It ships independently of R3 (the large platform-foundations project) and supersedes nothing — the 3 items are real UX gaps surfaced during R2 round-2 UAT (2026-06-19) that don't require platform-level work to fix.
 
-R6 PR #395 is open in parallel with ZERO file-level overlap (verified via `git -C r6-worktree log --oneline origin/master..HEAD -- <files>`). Either PR can merge first; both will apply cleanly.
+All 3 items affect both the SpaarkeAi-embedded widget AND the standalone Daily Briefing code page (`sprk_dailyupdate`) since R2 + R2.1 unified them via Pattern D (`@spaarke/daily-briefing-components`). A single set of changes deploys to both surfaces.
 
-3 Phase 7b documentation alignment tasks (070/071/072) are CREATED but NOT EXECUTED in this PR — they're queued for post-merge execution so the docs review can be holistic and not block the implementation merge.
+### Deployment notes
+
+R2.2 changes affect:
+- **BFF** (item 1): redeploy via `bff-deploy` skill or auto-promotion
+- **Both code pages** (items 2 + 3): rebuild + redeploy `sprk_dailyupdate` (Daily Briefing) + `sprk_spaarkeai` (SpaarkeAi workspace) since both consume `@spaarke/daily-briefing-components`
 
 ---
 
@@ -52,165 +55,56 @@ R6 PR #395 is open in parallel with ZERO file-level overlap (verified via `git -
 
 | Field | Value |
 |-------|-------|
-| **Task ID** | Option D (no POML — emerged from PR #396 architectural review) |
-| **Design rationale** | `notes/option-d-registry-as-composition.md` (canonical spec for the refactor) |
-| **Title** | Replace module-mutation slot from R2 task 002 with registry-as-composition factory |
-| **Phase** | P1 (architectural follow-up to task 002) |
-| **Status** | in-progress (design done; implementation next) |
-| **Started** | 2026-06-18 (mid-session, after user code review feedback) |
-| **Rigor Level** | FULL |
+| **Task ID** | R2.2 hotfix bundle (no POML — emerged from R2 round-2 UAT findings 2026-06-19) |
+| **Title** | Daily Briefing UX bundle: TL;DR bullet format + per-item due dates + AddToTodo improvements |
+| **Phase** | Post-R2.1 (PR #400 already merged) |
+| **Status** | not-started |
+| **Started** | 2026-06-20 |
+| **Branch** | `work/spaarke-daily-update-service-r2.2` (forked from `origin/master` @ `3d5c58e4b`) |
+| **Rigor Level** | STANDARD — small UX changes, no architectural impact; quality gates skipped per CLAUDE.md §8 |
 
----
+### Steps
 
-## Progress
+**Item 1 — TL;DR format**
+1. Read current prompt at `DailyBriefingEndpoints.cs:398-460`
+2. Modify prompt to ask for: 2-3 sentence executive summary + key takeaways bullets
+3. Update response parsing (if needed)
+4. Add/update unit test in `Sprk.Bff.Api.Tests`
+5. Commit
 
-### Completed Steps
+**Item 2 — Due dates in NarrativeBullet**
+1. Read `NarrativeBullet.tsx`
+2. Add due-date rendering (data is already in `appnotification.data` payload — `dueDate` field per item)
+3. Style consistent with Fluent v9 + existing card design
+4. Add snapshot test
+5. Commit
 
-- [x] **Step 1**: Diagnose the band-aid pattern (R2 task 002 / Wave 8 Option B module-mutation)
-- [x] **Step 2**: Evaluate alternatives (A: replace registry, B: shipped band-aid, C: React Context, D: registry-as-composition factory)
-- [x] **Step 3**: User authorization for Option D after rejecting C as too narrow for the SpaarkeAi-as-critical-core-surface vision
-- [x] **Step 4**: R6 review (zero file-level overlap confirmed via git diff against branches)
-- [x] **Step 5**: Author comprehensive design rationale in `notes/option-d-registry-as-composition.md`
-- [x] **Step 6**: Create Phase 7b POML tasks 070/071/072 for documentation alignment follow-ups
-- [x] **Step 7**: Update this `current-task.md` with full Option D context
+**Item 3 — AddToTodo improvements**
+1. Read `useInlineTodoCreate.ts:159-279`
+2. Add default due-date setting (proposed: 3 days from now, or use the bullet's own dueDate if available)
+3. Add Fluent v9 toast on success (via `useToastController`)
+4. Add toast on failure (already has error tooltip, but toast is more discoverable)
+5. Update existing test in `ActivityNotesSection.subList.test.tsx` or add new
+6. Commit
 
-### Current Step
+### Step Progress
+- ⏳ Item 1 — not started
+- ⏳ Item 2 — not started
+- ⏳ Item 3 — not started
 
-**Step 8**: Implement the 6-file refactor + 3 unit tests
+### Decisions
 
-**What this step involves**:
-- Refactor `src/solutions/LegalWorkspace/src/sectionRegistry.ts` to expose `createLegalWorkspaceSectionRegistry(options)` factory + `LegalWorkspaceSectionRegistryOptions` interface. Default `SECTION_REGISTRY` becomes `createLegalWorkspaceSectionRegistry()` (no options). Dev-mode duplicate/drift guards extracted into a reusable `runRegistryDevGuards(registry)` helper that runs for every registry built.
-- In `dailyBriefing.registration.ts`: REMOVE `_globalNotificationLoader`, `setLegalWorkspaceDailyBriefingNotificationLoader`, `lateBoundNotificationLoader`. Default `dailyBriefingRegistration` const becomes `createLegalWorkspaceDailyBriefingRegistration()` (no loader → empty contract preserved for standalone consumers).
-- In `LegalWorkspace/src/index.ts`: REMOVE `setLegalWorkspaceDailyBriefingNotificationLoader` re-export. ADD `createLegalWorkspaceSectionRegistry` + `LegalWorkspaceSectionRegistryOptions` + (re-export of) `SECTION_REGISTRY` re-exports.
-- In `LegalWorkspaceApp.tsx`: ADD optional `sections?: readonly SectionRegistration[]` prop to `ILegalWorkspaceAppProps`. Pass through to `WorkspaceGrid`.
-- In `WorkspaceGrid.tsx`: accept `sections` prop (defaults to imported `SECTION_REGISTRY`). Replace direct usage with the prop variable.
-- In `SpaarkeAi/main.tsx`: REPLACE setter import + call with `createLegalWorkspaceSectionRegistry({ dailyBriefing: { loadNotificationContext: loadSpaarkeAiNotificationContext } })`. Define `SpaarkeAiWorkspaceRenderer: WorkspaceRenderer = (props) => <LegalWorkspaceApp {...props} sections={customSections} />`. Register via existing `setDefaultWorkspaceRenderer(SpaarkeAiWorkspaceRenderer)`.
-- Add 3 tests (no-options equivalence; loader threading; legacy setter API removed).
-
-### Subsequent Steps
-
-- **Step 9**: Build verify (`tsc --noEmit` on LegalWorkspace + new package + SpaarkeAi surface gate)
-- **Step 10**: Test verify (`npm test` in `Spaarke.DailyBriefing.Components` — 5 suites / 26 tests must still pass; new tests bring total to 5 suites / 29 tests)
-- **Step 11**: Update TASK-INDEX.md noting Option D as Wave 11 (post-Wave-10/task-024); commit
-- **Step 12**: Push to `work/spaarke-daily-update-service-r2`; auto-merge re-evaluates when CI re-runs
-
-### Decisions Made
-
-- **2026-06-18 (Option D session)**: Use Option D (registry-as-composition factory) instead of Option C (per-widget React Context). Reason: SpaarkeAi is a critical core surface that must support N widgets + two-way Assistant⇄Workspace⇄Context flows; Option C scales linearly with widget count, Option D scales O(1). Who: user (explicit authorization).
-- **2026-06-18**: NO speculative options added to `LegalWorkspaceSectionRegistryOptions` (no `paneEventBus`/`agentClient`/`contextProvider` until first real consumer). Reason: per CLAUDE.md "Don't add features beyond what the task requires"; the interface is extensible additively when concrete needs arrive. Who: design rationale §5.
-- **2026-06-18**: Documentation alignment (pattern doc + architecture docs + ADR) deferred to 3 separate Phase 7b POML tasks (070/071/072) executed post-merge. Reason: keep the implementation PR focused on the refactor; review the documentation holistically without it gating the merge. Who: user request ("include task(s) to review and update related documentation").
-- **2026-06-18**: NO changes to `@spaarke/ui-components` public API (e.g., NOT adding `sections` to `WorkspaceRendererProps`). Reason: SpaarkeAi can register a custom RENDERER (a wrapper function over `LegalWorkspaceApp`) via the existing `setDefaultWorkspaceRenderer` slot, which already accepts arbitrary renderers. This preserves the shared-lib boundary. Who: design rationale §3.6.
-- **2026-06-18 (R6 coordination)**: Proceed with Option D without coordinating with R6 team. Reason: R6 PR #395 makes ZERO commits to the files Option D touches; R6's Pillar 9 operates on a sibling `WorkspaceWidgetRegistry` at the AI-widgets layer, not `SECTION_REGISTRY` at the LegalWorkspace layer. Who: design rationale §6 + Explore-agent review.
-
----
-
-## Next Action
-
-**Next Step**: Step 8 — execute the 6-file implementation refactor + 3 unit tests
-
-**Pre-conditions**:
-- Design rationale documented ✓
-- Phase 7b doc-alignment POMLs created ✓
-- User authorization received ✓
-- R6 zero-overlap confirmed ✓
-- current-task.md updated (this file) ✓
-
-**Key Context**:
-- `notes/option-d-registry-as-composition.md` §3 has the exact target file shapes — implement to those shapes
-- The implementation MUST preserve `SECTION_REGISTRY` as a top-level export (consumer compatibility) — it just becomes a default-options factory call instead of a literal const
-- The legacy setter API (`setLegalWorkspaceDailyBriefingNotificationLoader`) MUST be REMOVED, not deprecated — the whole point is eliminating the band-aid
-- After implementation, all 5 Jest 30 suites + 26 tests from R2 must continue to pass (the new tests bring total to ~29)
-- After commit + push to `work/spaarke-daily-update-service-r2`, auto-merge on PR #396 re-fires when CI re-runs
-
-**Expected Output**:
-- 6 source files modified per notes/option-d-registry-as-composition.md §3
-- 3 new unit tests added
-- BFF build still green (no impact — only TypeScript files touched)
-- Jest suites still green
-- 1 commit pushed to PR #396
-
----
-
-## Blockers
-
-**Status**: None
-
----
-
-## Session Notes
-
-### Current Session
-
-- Started: 2026-06-18 (continuation from R2 31/36 ship state)
-- Focus: Option D architectural refactor (replaces R2 task 002 band-aid)
-
-### Key Learnings
-
-- The user's code-review eye caught the module-mutation band-aid before merge. The orchestration agent's framing ("Option B works, file as debt later") was too narrow. The right answer at architectural-review time is "fix it now if the cost is small relative to the strategic blast radius."
-- The pattern (one factory + typed options interface) is the right primitive for N widgets even when only 1 widget needs it today. Adding the pattern doesn't speculatively design future widgets; it just makes adding them cheap when they arrive.
-- `notes/option-d-registry-as-composition.md` is the persistent record. Future maintainers don't have to re-derive the alternatives evaluation.
-- **Speculative-design discipline**: do NOT add `paneEventBus`/`agentClient`/`contextProvider` to `LegalWorkspaceSectionRegistryOptions` today. Add them when the first concrete consumer needs them. The interface is extensible additively.
+- **2026-06-20**: Skip FetchXML interim unblock (item 4 from original scope). Reason: R3's `MembershipResolverService` supersedes it; ~3-4h of throwaway work for ≤3 weeks of broken "My Documents" channel doesn't pencil out.
+- **2026-06-20**: Branch named `work/spaarke-daily-update-service-r2.2` (versioned, distinguishes from merged R2.1 hotfix branch).
 
 ### Handoff Notes
 
-If this session is interrupted before Option D implementation completes:
-
-1. Read `notes/option-d-registry-as-composition.md` §3 for the exact target file shapes — those are the canonical implementation plan
-2. Read this `current-task.md` "Pending implementation changes" list for the 6 files to modify
-3. Read `notes/task-002-blocker.md` for the original architectural analysis that led here
-4. Read the existing `src/solutions/LegalWorkspace/src/sections/dailyBriefing/dailyBriefing.registration.ts` to see Option B's current code (the band-aid being removed)
-5. Read `src/solutions/SpaarkeAi/src/main.tsx` lines 60-75 + 229-241 to see Option B's setter call (being removed)
-6. After implementing: run `npm test` in `src/client/shared/Spaarke.DailyBriefing.Components/` (existing 5 suites / 26 tests should still pass; new tests bring total to ~29)
-7. Commit + push to `work/spaarke-daily-update-service-r2`; auto-merge on PR #396 will re-evaluate when CI runs
+If session ends mid-flight, the next session can resume by:
+1. Reading this current-task.md Quick Recovery section
+2. Running `git status` to see what's modified
+3. Checking the most recent commit message to know which Item was last touched
+4. Resuming the next un-checked step in the Steps section above
 
 ---
 
-## Quick Reference
-
-### Project Context
-
-- **Project**: `spaarke-daily-update-service-r2`
-- **Project CLAUDE.md**: [`CLAUDE.md`](./CLAUDE.md)
-- **Task Index**: [`tasks/TASK-INDEX.md`](./tasks/TASK-INDEX.md)
-- **Active PR**: [#396](https://github.com/spaarke-dev/spaarke/pull/396)
-- **Companion design rationale**: [`notes/option-d-registry-as-composition.md`](./notes/option-d-registry-as-composition.md)
-- **Phase 7b POMLs (post-merge follow-ups)**: tasks 070 (pattern), 071 (architecture docs), 072 (ADR-033)
-
-### Applicable ADRs (Option D specifically)
-
-- **ADR-006** — UI Surface Architecture (Pattern D dual-use baseline; new ADR-033 will reference)
-- **ADR-012** — Shared Component Library (per-widget factory pattern Option D builds on; new ADR-033 will reference)
-- **ADR-022** — React 19 (the prop-drilling vs context decision; Option D prefers props at this layer)
-- **ADR-026** — Code Page Build Standard (no changes; the shrunk standalone host shell still works)
-
-(See `CLAUDE.md` "Applicable ADRs" for the full R2 ADR table; Option D adds ADR-033 as a follow-up via task 072.)
-
-### Knowledge Files Loaded
-
-- `projects/spaarke-daily-update-service-r2/notes/option-d-registry-as-composition.md` — comprehensive design
-- `projects/spaarke-daily-update-service-r2/notes/task-002-blocker.md` — original architectural analysis
-- R6 worktree at `C:/code_files/spaarke-wt-spaarke-ai-platform-unification-r6` — reviewed for overlap
-- The 6 source files listed under "Pending implementation changes" — read in main session before implementation
-
----
-
-## Recovery Instructions
-
-**To recover context after compaction or new session:**
-
-1. **Quick Recovery**: Read the "Quick Recovery" section above (< 30 seconds)
-2. **If more context needed**: Read Active Task and Progress sections
-3. **Load design rationale**: `notes/option-d-registry-as-composition.md` §3 (target file shapes) is the canonical implementation plan
-4. **Knowledge**: the 6 implementation files are listed under "Pending implementation changes" — read them before editing
-5. **Resume**: From the "Next Action" section
-
-**Commands**:
-- `/project-continue` — Full project context reload + master sync
-- `/context-handoff` — Save current state before compaction
-- "where was I?" — Quick context recovery
-
-**For full protocol**: See [docs/procedures/context-recovery.md](../../docs/procedures/context-recovery.md)
-
----
-
-*This file is the primary source of truth for active work state. Keep it updated.*
+*Updated 2026-06-20 — R2.2 starting.*

--- a/projects/spaarke-daily-update-service/notes/playbooks/notification-tasks-due-soon.json
+++ b/projects/spaarke-daily-update-service/notes/playbooks/notification-tasks-due-soon.json
@@ -109,7 +109,8 @@
           "actionUrl": "/main.aspx?pagetype=entityrecord&etn=task&id={{item.activityid}}",
           "recipientId": "{{run.userId}}",
           "regardingId": "{{item.activityid}}",
-          "regardingType": "task"
+          "regardingType": "task",
+          "dueDate": "{{item.scheduledend}}"
         }
       }
     }

--- a/projects/spaarke-daily-update-service/notes/playbooks/notification-tasks-overdue.json
+++ b/projects/spaarke-daily-update-service/notes/playbooks/notification-tasks-overdue.json
@@ -98,7 +98,8 @@
           "actionUrl": "/main.aspx?pagetype=entityrecord&etn=task&id={{item.activityid}}",
           "recipientId": "{{run.userId}}",
           "regardingId": "{{item.activityid}}",
-          "regardingType": "task"
+          "regardingType": "task",
+          "dueDate": "{{item.scheduledend}}"
         }
       }
     }

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx
@@ -35,6 +35,7 @@ import {
   useId,
   Toast,
   ToastTitle,
+  ToastBody,
 } from '@fluentui/react-components';
 import { DigestHeader } from './DigestHeader';
 import { EmptyState } from './EmptyState';
@@ -228,28 +229,61 @@ export const DailyBriefingApp: React.FC<DailyBriefingAppProps> = ({ params: _par
   // Handlers
   // ---------------------------------------------------------------------------
 
-  /** Add a notification item to To Do and show a toast. */
+  /**
+   * Add a notification item to To Do and show a confirmation toast.
+   * R2.2 Item 3: shows the To Do title in the toast and surfaces a failure
+   * toast when createTodo throws (existing tooltip-only error path was too
+   * easy to miss).
+   */
   const handleAddToTodo = React.useCallback(
     async (itemIds: string[]) => {
       for (const ch of channels) {
         if (ch.status !== 'success') continue;
         for (const item of ch.group.items) {
           if (itemIds.includes(item.id)) {
-            await createTodo(item);
-            dispatchToast(
-              <Toast>
-                <ToastTitle>Added to To Do</ToastTitle>
-              </Toast>,
-              { intent: 'success', timeout: 3000 }
-            );
-            // Also mark notification as read
-            markAsRead?.(item.id);
+            try {
+              await createTodo(item);
+              // useInlineTodoCreate swallows exceptions and surfaces them via
+              // its getError() — check that path too so the user sees a toast
+              // even when the underlying createRecord call failed.
+              const err = getTodoError(item.id);
+              if (err) {
+                dispatchToast(
+                  <Toast>
+                    <ToastTitle>Could not add to To Do</ToastTitle>
+                    <ToastBody>{err}</ToastBody>
+                  </Toast>,
+                  { intent: 'error', timeout: 5000 }
+                );
+              } else {
+                dispatchToast(
+                  <Toast>
+                    <ToastTitle>Added to To Do</ToastTitle>
+                    <ToastBody>{item.title}</ToastBody>
+                  </Toast>,
+                  { intent: 'success', timeout: 3000 }
+                );
+                // Mark notification as read only on success
+                markAsRead?.(item.id);
+              }
+            } catch (e) {
+              // Defensive: createTodo isn't supposed to throw (it catches
+              // internally), but if a future change re-throws we still want
+              // the user to see a toast.
+              dispatchToast(
+                <Toast>
+                  <ToastTitle>Could not add to To Do</ToastTitle>
+                  <ToastBody>{e instanceof Error ? e.message : String(e)}</ToastBody>
+                </Toast>,
+                { intent: 'error', timeout: 5000 }
+              );
+            }
             return;
           }
         }
       }
     },
-    [channels, createTodo, dispatchToast, markAsRead]
+    [channels, createTodo, getTodoError, dispatchToast, markAsRead]
   );
 
   /** Dismiss notification items by marking them as read. */

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
@@ -35,6 +35,7 @@ import { makeStyles, tokens, Text, Button, Tooltip, Spinner } from '@fluentui/re
 import { DismissRegular } from '@fluentui/react-icons';
 import { MicrosoftToDoIcon } from '@spaarke/ui-components';
 import type { NotificationItem } from '../types/notifications';
+import { formatDueDate } from '../utils/formatDueDate';
 import { SubRow } from './SubRow';
 
 // ---------------------------------------------------------------------------
@@ -71,6 +72,15 @@ const useStyles = makeStyles({
     ':hover': {
       textDecorationLine: 'underline',
     },
+  },
+  dueDateRow: {
+    color: tokens.colorNeutralForeground2,
+    lineHeight: tokens.lineHeightBase200,
+    marginTop: tokens.spacingVerticalXXS,
+  },
+  dueDateOverdue: {
+    color: tokens.colorPaletteRedForeground1,
+    fontWeight: tokens.fontWeightSemibold,
   },
   actions: {
     display: 'flex',
@@ -184,6 +194,16 @@ export const NarrativeBullet: React.FC<NarrativeBulletProps> = ({
   // consumers), the sub-list is suppressed.
   const showSubList = itemIds.length > 1 && Array.isArray(items) && items.length > 0;
 
+  // R2.2: per-item due-date hint for SINGLE-item bullets. Aggregated bullets
+  // delegate to SubRow (which renders each item's due date in its own row).
+  // Showing a single due-date on an aggregated bullet would misrepresent
+  // multi-item due dates.
+  const singleItemDueDate =
+    !showSubList && Array.isArray(items) && items.length === 1
+      ? formatDueDate(items[0].dueDate)
+      : null;
+  const isSingleItemOverdue = singleItemDueDate?.startsWith('Overdue') ?? false;
+
   const handleLinkClick = () => {
     if (!primaryEntityType || !primaryEntityId) return;
     const xrm =
@@ -242,6 +262,15 @@ export const NarrativeBullet: React.FC<NarrativeBulletProps> = ({
             }}
           >
             {primaryEntityName} &#8599;
+          </Text>
+        )}
+        {/* R2.2: single-item due-date hint (task notifications only — others have item.dueDate=null). */}
+        {singleItemDueDate && (
+          <Text
+            size={200}
+            className={`${styles.dueDateRow} ${isSingleItemOverdue ? styles.dueDateOverdue : ''}`.trim()}
+          >
+            {singleItemDueDate}
           </Text>
         )}
         {/* FR-11: per-item sub-list for aggregated bullets (itemIds.length > 1). */}

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
@@ -199,9 +199,7 @@ export const NarrativeBullet: React.FC<NarrativeBulletProps> = ({
   // Showing a single due-date on an aggregated bullet would misrepresent
   // multi-item due dates.
   const singleItemDueDate =
-    !showSubList && Array.isArray(items) && items.length === 1
-      ? formatDueDate(items[0].dueDate)
-      : null;
+    !showSubList && Array.isArray(items) && items.length === 1 ? formatDueDate(items[0].dueDate) : null;
   const isSingleItemOverdue = singleItemDueDate?.startsWith('Overdue') ?? false;
 
   const handleLinkClick = () => {

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/SubRow.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/SubRow.tsx
@@ -115,9 +115,7 @@ export const SubRow: React.FC<SubRowProps> = ({ item, onAddToTodoItem, onDismiss
       </div>
       {/* R2.2: per-item due date hint (only when item.dueDate is set, i.e. task notifications). */}
       {dueDateLabel && (
-        <span className={`${styles.dueDate} ${isOverdue ? styles.dueDateOverdue : ''}`.trim()}>
-          {dueDateLabel}
-        </span>
+        <span className={`${styles.dueDate} ${isOverdue ? styles.dueDateOverdue : ''}`.trim()}>{dueDateLabel}</span>
       )}
       {/* Slots B + C: per-item actions (FR-13/FR-14, tasks 022/023). */}
       <div className={styles.actions}>

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/SubRow.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/SubRow.tsx
@@ -26,6 +26,7 @@
 import * as React from 'react';
 import { makeStyles, tokens } from '@fluentui/react-components';
 import type { NotificationItem } from '../types/notifications';
+import { formatDueDate } from '../utils/formatDueDate';
 import { SubRowLink } from './SubRowLink';
 import { SubRowTodo } from './SubRowTodo';
 import { SubRowDismiss } from './SubRowDismiss';
@@ -60,6 +61,18 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
   },
+  dueDate: {
+    flexShrink: 0,
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    lineHeight: tokens.lineHeightBase200,
+    paddingLeft: tokens.spacingHorizontalXS,
+    paddingRight: tokens.spacingHorizontalXS,
+  },
+  dueDateOverdue: {
+    color: tokens.colorPaletteRedForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
   actions: {
     display: 'flex',
     alignItems: 'center',
@@ -87,6 +100,8 @@ export interface SubRowProps {
 
 export const SubRow: React.FC<SubRowProps> = ({ item, onAddToTodoItem, onDismissItem }) => {
   const styles = useStyles();
+  const dueDateLabel = formatDueDate(item.dueDate);
+  const isOverdue = dueDateLabel?.startsWith('Overdue') ?? false;
 
   return (
     <div className={styles.root}>
@@ -98,6 +113,12 @@ export const SubRow: React.FC<SubRowProps> = ({ item, onAddToTodoItem, onDismiss
       <div className={styles.linkSlot}>
         <SubRowLink item={item} />
       </div>
+      {/* R2.2: per-item due date hint (only when item.dueDate is set, i.e. task notifications). */}
+      {dueDateLabel && (
+        <span className={`${styles.dueDate} ${isOverdue ? styles.dueDateOverdue : ''}`.trim()}>
+          {dueDateLabel}
+        </span>
+      )}
       {/* Slots B + C: per-item actions (FR-13/FR-14, tasks 022/023). */}
       <div className={styles.actions}>
         <SubRowTodo item={item} onAddToTodo={onAddToTodoItem} />

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/TldrSection.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/TldrSection.tsx
@@ -49,7 +49,17 @@ const useStyles = makeStyles({
     color: tokens.colorNeutralForeground1,
     lineHeight: tokens.lineHeightBase400,
     display: 'block',
-    marginBottom: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalM,
+  },
+  takeawaysList: {
+    color: tokens.colorNeutralForeground1,
+    lineHeight: tokens.lineHeightBase300,
+    marginTop: '0',
+    marginBottom: tokens.spacingVerticalM,
+    paddingLeft: tokens.spacingHorizontalL,
+  },
+  takeawayItem: {
+    marginBottom: tokens.spacingVerticalXS,
   },
   topAction: {
     display: 'block',
@@ -89,8 +99,14 @@ const useStyles = makeStyles({
 // ---------------------------------------------------------------------------
 
 export interface TldrSectionProps {
+  /**
+   * Structured TL;DR — R2.2 replaced the prior single `briefing` blob with a
+   * 2-3 sentence summary + 3-5 key-takeaway bullets + a top-action sentence so
+   * the user can scan the briefing at a glance instead of reading a paragraph.
+   */
   tldr: {
-    briefing: string;
+    summary: string;
+    keyTakeaways: string[];
     topAction: string;
     categoryCount: number;
     priorityItemCount: number;
@@ -203,9 +219,20 @@ export const TldrSection: React.FC<TldrSectionProps> = ({
       <Badge className={styles.aiBadge} appearance="tint" color="brand" size="small">
         AI Insight
       </Badge>
-      <Text size={300} className={styles.briefingText}>
-        {tldr.briefing}
-      </Text>
+      {tldr.summary && (
+        <Text size={300} className={styles.briefingText}>
+          {tldr.summary}
+        </Text>
+      )}
+      {tldr.keyTakeaways.length > 0 && (
+        <ul className={styles.takeawaysList} aria-label="Key takeaways">
+          {tldr.keyTakeaways.map((takeaway, idx) => (
+            <li key={idx} className={styles.takeawayItem}>
+              <Text size={300}>{takeaway}</Text>
+            </li>
+          ))}
+        </ul>
+      )}
       {tldr.topAction && (
         <Text size={300} weight="semibold" className={styles.topAction}>
           {tldr.topAction}

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useInlineTodoCreate.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useInlineTodoCreate.ts
@@ -77,6 +77,33 @@ const STATECODE_ACTIVE = 0;
 /** sprk_todo statuscode: 1 = Open (statecode 0). */
 const STATUSCODE_OPEN = 1;
 
+/**
+ * R2.2 Item 3 — Default due-date strategy for new To Dos created from
+ * Daily Briefing notifications:
+ *   1. If the source notification carries `item.dueDate` (task notifications
+ *      from the R2.2 plumbing change), use it verbatim — preserves the actual
+ *      task due date so the To Do inherits the original deadline.
+ *   2. Otherwise default to **+3 calendar days from now, end of day (17:00 local)**
+ *      — gives the user a reasonable working window without being too aggressive.
+ *      Notifications without a real due date (documents, emails, events) get
+ *      this default; the user can edit later in the To Do app.
+ */
+const DEFAULT_DUE_OFFSET_DAYS = 3;
+const DEFAULT_DUE_HOUR_LOCAL = 17;
+
+export function computeDueDate(item: NotificationItem, now: Date = new Date()): string {
+  if (item.dueDate) {
+    const parsed = new Date(item.dueDate);
+    if (!isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  const fallback = new Date(now);
+  fallback.setDate(fallback.getDate() + DEFAULT_DUE_OFFSET_DAYS);
+  fallback.setHours(DEFAULT_DUE_HOUR_LOCAL, 0, 0, 0);
+  return fallback.toISOString();
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -182,6 +209,11 @@ export function useInlineTodoCreate(webApi: IWebApi | null): UseInlineTodoCreate
           statecode: STATECODE_ACTIVE,
           statuscode: STATUSCODE_OPEN,
           sprk_priorityscore: mapPriorityToScore(item.priority),
+          // R2.2 Item 3 — auto-default sprk_duedate so the new To Do is
+          // immediately actionable. Uses item.dueDate when supplied by the
+          // playbook (task notifications), else falls back to +3 calendar days
+          // at end-of-day local. See computeDueDate() above.
+          sprk_duedate: computeDueDate(item),
         };
 
         if (item.body) {

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/services/briefingService.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/services/briefingService.ts
@@ -102,9 +102,15 @@ export interface NarrateResponse {
 }
 
 export interface TldrResult {
-  briefing: string;
+  /** 2-3 sentence executive summary (R2.2 replaces the prior single `briefing` blob). */
+  summary: string;
+  /** 3-5 short key-takeaway bullet strings (no leading "- "). */
+  keyTakeaways: string[];
+  /** ONE-sentence top action for today. */
   topAction: string;
+  /** Count of notification categories that fed the summary. */
   categoryCount: number;
+  /** Count of priority items that fed the summary. */
   priorityItemCount: number;
 }
 

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/services/notificationService.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/services/notificationService.ts
@@ -69,6 +69,8 @@ function parseNotificationData(raw: unknown): {
   regardingId: string;
   isAiGenerated: boolean;
   aiConfidence?: number;
+  /** R2.2: ISO-8601 due date from customData.dueDate (set by task playbooks). */
+  dueDate: string | null;
 } | null {
   if (!raw || typeof raw !== 'string') return null;
 
@@ -89,6 +91,7 @@ function parseNotificationData(raw: unknown): {
       regardingId: (customData['regardingId'] as string) ?? (parsed['regardingId'] as string) ?? '',
       isAiGenerated: (customData['isAiGenerated'] as boolean) ?? false,
       aiConfidence: typeof customData['aiConfidence'] === 'number' ? (customData['aiConfidence'] as number) : undefined,
+      dueDate: (customData['dueDate'] as string) ?? null,
     };
   } catch {
     console.warn('[DailyBriefing] Failed to parse notification data JSON');
@@ -121,6 +124,7 @@ function toNotificationItem(entity: WebApiEntity): NotificationItem | null {
     isAiGenerated: customData?.isAiGenerated ?? false,
     aiConfidence: customData?.aiConfidence,
     createdOn: (entity['createdon'] as string) ?? new Date().toISOString(),
+    dueDate: customData?.dueDate ?? null,
   };
 }
 

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/types/notifications.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/types/notifications.ts
@@ -216,6 +216,14 @@ export interface NotificationItem {
   aiConfidence?: number;
   /** ISO timestamp when the notification was created */
   createdOn: string;
+  /**
+   * Optional ISO-8601 due date from notification customData.dueDate (R2.2).
+   * Set by task playbooks (notification-tasks-overdue, notification-tasks-due-soon)
+   * via the BFF CreateNotificationNodeExecutor's DueDate field. Null when the
+   * source channel has no due-date concept (documents, emails, work-assignments,
+   * matter-activity, events).
+   */
+  dueDate: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/utils/formatDueDate.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/utils/formatDueDate.ts
@@ -1,0 +1,42 @@
+/**
+ * formatDueDate — render an ISO-8601 due-date string as a short relative phrase.
+ *
+ * R2.2: per-item due-date rendering for task notifications. Output is meant
+ * for the inline due-date hint shown in NarrativeBullet (single-item) and
+ * SubRow (aggregated per-item). Format favours quick scanning over precision —
+ * "Due tomorrow" / "Overdue by 3d" rather than the raw "2026-06-22T17:00:00Z".
+ *
+ * Buckets:
+ *   - Past:           "Overdue by Nd"  (or "Overdue" when N = 0 but past)
+ *   - Today:          "Due today"
+ *   - Tomorrow:       "Due tomorrow"
+ *   - Future ≤ 7d:    "Due in Nd"
+ *   - Future > 7d:    "Due Mon DD"     (locale-aware short date)
+ *
+ * Returns null for null / unparseable input — callers should skip rendering
+ * the due-date hint entirely in that case.
+ */
+export function formatDueDate(isoTimestamp: string | null | undefined, now: Date = new Date()): string | null {
+  if (!isoTimestamp) return null;
+
+  const due = new Date(isoTimestamp);
+  if (isNaN(due.getTime())) return null;
+
+  // Compare on day boundaries (local time) — a task due "today at 4pm" should
+  // still read "Due today" even at 5pm, not "Overdue by 0d".
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const dueDay = startOfDay(due).getTime();
+  const todayDay = startOfDay(now).getTime();
+  const diffDays = Math.round((dueDay - todayDay) / 86_400_000);
+
+  if (diffDays < 0) {
+    const days = Math.abs(diffDays);
+    return days === 0 ? 'Overdue' : `Overdue by ${days}d`;
+  }
+  if (diffDays === 0) return 'Due today';
+  if (diffDays === 1) return 'Due tomorrow';
+  if (diffDays <= 7) return `Due in ${diffDays}d`;
+
+  // > 7 days out: short locale date (e.g. "Due Jun 28")
+  return `Due ${due.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
+}

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/utils/index.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/utils/index.ts
@@ -7,3 +7,4 @@
  */
 
 export { TOASTER_ID } from './toastUtils';
+export { formatDueDate } from './formatDueDate';

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/ActivityNotesSection.subList.test.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/ActivityNotesSection.subList.test.tsx
@@ -40,6 +40,7 @@ function makeItem(overrides: Partial<NotificationItem>): NotificationItem {
     isRead: false,
     isAiGenerated: false,
     createdOn: new Date().toISOString(),
+    dueDate: null,
     ...overrides,
   } as NotificationItem;
 }

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/DailyBriefingApp.smoke.test.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/DailyBriefingApp.smoke.test.tsx
@@ -137,8 +137,11 @@ describe('DailyBriefingApp (smoke)', () => {
         new Response(
           JSON.stringify({
             tldr: {
-              highlights: ['You have 1 overdue motion.'],
-              confidence: 0.9,
+              summary: 'You have 1 overdue motion that needs immediate review.',
+              keyTakeaways: ['Acme Matter motion to dismiss is overdue.'],
+              topAction: 'Review the Acme Matter motion to dismiss.',
+              categoryCount: 1,
+              priorityItemCount: 1,
             },
             channelNarratives: [
               {

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/DailyBriefingApp.smoke.test.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/DailyBriefingApp.smoke.test.tsx
@@ -83,6 +83,7 @@ const fakeChannels: ChannelFetchResult[] = [
           isRead: false,
           isAiGenerated: false,
           createdOn: new Date().toISOString(),
+          dueDate: null,
         },
       ],
       unreadCount: 1,

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/NarrativeBullet.test.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/NarrativeBullet.test.tsx
@@ -56,6 +56,7 @@ function makeItem(overrides: Partial<NotificationItem> = {}): NotificationItem {
     isRead: false,
     isAiGenerated: false,
     createdOn: new Date().toISOString(),
+    dueDate: null,
     ...overrides,
   };
 }

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/__mocks__/spaarke-auth.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/__mocks__/spaarke-auth.ts
@@ -15,7 +15,7 @@ export const authenticatedFetch: jest.Mock = jest.fn(() =>
   Promise.resolve(
     new Response(
       JSON.stringify({
-        tldr: { highlights: [], confidence: 0 },
+        tldr: { summary: '', keyTakeaways: [], topAction: '', categoryCount: 0, priorityItemCount: 0 },
         channelNarratives: [],
         generatedAtUtc: new Date().toISOString(),
       }),

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/formatDueDate.test.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/formatDueDate.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for formatDueDate (R2.2 Item 2).
+ *
+ * Verifies bucket selection (overdue / today / tomorrow / future-week /
+ * future-month) and null handling. Fixed `now` is used so tests are
+ * deterministic regardless of when they run.
+ */
+
+import { formatDueDate } from '../src/utils/formatDueDate';
+
+const NOW = new Date('2026-06-20T14:00:00Z');
+
+describe('formatDueDate', () => {
+  it('returns null for null input', () => {
+    expect(formatDueDate(null, NOW)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(formatDueDate(undefined, NOW)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(formatDueDate('', NOW)).toBeNull();
+  });
+
+  it('returns null for unparseable date', () => {
+    expect(formatDueDate('not-a-date', NOW)).toBeNull();
+  });
+
+  it('returns "Overdue by Nd" for past dates beyond today', () => {
+    // 3 days before NOW
+    expect(formatDueDate('2026-06-17T12:00:00Z', NOW)).toBe('Overdue by 3d');
+  });
+
+  it('returns "Due today" for the same calendar day', () => {
+    // Same day as NOW, different time of day
+    expect(formatDueDate('2026-06-20T08:00:00Z', NOW)).toBe('Due today');
+    expect(formatDueDate('2026-06-20T20:00:00Z', NOW)).toBe('Due today');
+  });
+
+  it('returns "Due tomorrow" for the next calendar day', () => {
+    expect(formatDueDate('2026-06-21T10:00:00Z', NOW)).toBe('Due tomorrow');
+  });
+
+  it('returns "Due in Nd" for 2-7 days out', () => {
+    expect(formatDueDate('2026-06-22T10:00:00Z', NOW)).toBe('Due in 2d');
+    expect(formatDueDate('2026-06-27T10:00:00Z', NOW)).toBe('Due in 7d');
+  });
+
+  it('returns short locale date for >7 days out', () => {
+    // 14 days out — should be "Due {locale-formatted Mon DD}"
+    const result = formatDueDate('2026-07-04T10:00:00Z', NOW);
+    expect(result).toMatch(/^Due /);
+    expect(result).not.toMatch(/Overdue|today|tomorrow|in \d/);
+  });
+});

--- a/src/client/shared/Spaarke.DailyBriefing.Components/test/useInlineTodoCreate.computeDueDate.test.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/test/useInlineTodoCreate.computeDueDate.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for computeDueDate (R2.2 Item 3).
+ *
+ * Verifies the default due-date strategy used when adding a notification to
+ * To Do: prefer the item's own dueDate when present, else fall back to
+ * +3 calendar days at 17:00 local.
+ */
+
+import { computeDueDate } from '../src/hooks/useInlineTodoCreate';
+import type { NotificationItem } from '../src/types/notifications';
+
+function makeItem(dueDate: string | null): NotificationItem {
+  return {
+    id: 'n-test',
+    title: 'Test todo',
+    body: '',
+    category: 'tasks-overdue',
+    priority: 'normal',
+    actionUrl: '',
+    regardingName: 'Acme',
+    regardingEntityType: 'sprk_matter',
+    regardingId: '00000000-0000-0000-0000-000000000001',
+    isRead: false,
+    isAiGenerated: false,
+    createdOn: new Date().toISOString(),
+    dueDate,
+  };
+}
+
+describe('computeDueDate', () => {
+  const NOW = new Date('2026-06-20T14:00:00Z');
+
+  it('uses the item dueDate verbatim when present and parseable', () => {
+    const item = makeItem('2026-06-25T17:00:00Z');
+    expect(computeDueDate(item, NOW)).toBe('2026-06-25T17:00:00.000Z');
+  });
+
+  it('falls back to +3 days at 17:00 local when item.dueDate is null', () => {
+    const item = makeItem(null);
+    const result = computeDueDate(item, NOW);
+    const resultDate = new Date(result);
+    const expected = new Date(NOW);
+    expected.setDate(expected.getDate() + 3);
+    expected.setHours(17, 0, 0, 0);
+    // Match to the second (avoid millisecond drift between expected/actual)
+    expect(Math.abs(resultDate.getTime() - expected.getTime())).toBeLessThan(1000);
+  });
+
+  it('falls back to +3 days when item.dueDate is empty string', () => {
+    const item = makeItem('');
+    const result = computeDueDate(item, NOW);
+    expect(result).not.toBe('');
+    expect(new Date(result).getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it('falls back to +3 days when item.dueDate is unparseable', () => {
+    const item = makeItem('not-a-date');
+    const result = computeDueDate(item, NOW);
+    expect(result).not.toBe('not-a-date');
+    expect(new Date(result).getTime()).toBeGreaterThan(NOW.getTime());
+  });
+});

--- a/src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs
+++ b/src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs
@@ -220,7 +220,8 @@ public static class DailyBriefingEndpoints
             {
                 Tldr = new TldrResult
                 {
-                    Briefing = string.Empty,
+                    Summary = string.Empty,
+                    KeyTakeaways = [],
                     TopAction = string.Empty,
                     CategoryCount = 0,
                     PriorityItemCount = 0
@@ -300,7 +301,11 @@ public static class DailyBriefingEndpoints
     }
 
     /// <summary>
-    /// Generate the TL;DR briefing (5-7 sentences) with top action identification.
+    /// Generate the TL;DR briefing as a structured response (2-3 sentence summary,
+    /// 3-5 key-takeaway bullets, top action). R2.2: switched from free-form prose
+    /// to a JSON-structured response so the client renders a scannable shape.
+    /// Falls back to populating just <see cref="TldrResult.Summary"/> if JSON parsing
+    /// fails (graceful degradation — user sees a paragraph, not an error).
     /// </summary>
     private static async Task<TldrResult> GetTldrAsync(
         DailyBriefingNarrateRequest request,
@@ -310,33 +315,80 @@ public static class DailyBriefingEndpoints
     {
         var prompt = BuildNarrateTldrPrompt(request);
 
-        var briefingText = await briefingAi.GenerateNarrativeAsync(
+        var responseText = await briefingAi.GenerateNarrativeAsync(
             prompt,
             maxOutputTokens: 500,
             cancellationToken: cancellationToken);
 
-        // Extract top action from the briefing text (last sentence starting with "Your most important action today is...")
-        var trimmed = briefingText.Trim();
-        var topAction = "";
-        var sentences = trimmed.Split(new[] { ". " }, StringSplitOptions.RemoveEmptyEntries);
-        foreach (var sentence in sentences)
-        {
-            if (sentence.TrimStart().StartsWith("Your most important action today is", StringComparison.OrdinalIgnoreCase))
-            {
-                topAction = sentence.TrimStart();
-                if (!topAction.EndsWith('.'))
-                    topAction += ".";
-                break;
-            }
-        }
+        var parsed = ParseTldrResponse(responseText, logger);
 
-        return new TldrResult
+        return parsed with
         {
-            Briefing = trimmed,
-            TopAction = topAction,
             CategoryCount = request.Categories.Length,
             PriorityItemCount = request.PriorityItems.Length
         };
+    }
+
+    /// <summary>
+    /// Parse the AI TL;DR response (expected JSON: { summary, keyTakeaways[], topAction }).
+    /// Strips markdown code fences. Falls back to using the raw text as Summary with empty
+    /// KeyTakeaways and TopAction if parsing fails — graceful degradation per R2.2.
+    /// Internal for unit-test access (mirrors BuildChannelNarrationPrompt convention).
+    /// </summary>
+    internal static TldrResult ParseTldrResponse(string responseText, ILogger logger)
+    {
+        var json = responseText.Trim();
+
+        // Strip markdown code fences if present (mirrors ParseChannelBullets convention)
+        if (json.StartsWith("```"))
+        {
+            var firstNewline = json.IndexOf('\n');
+            if (firstNewline > 0)
+                json = json[(firstNewline + 1)..];
+            if (json.EndsWith("```"))
+                json = json[..^3];
+            json = json.Trim();
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<TldrJsonPayload>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            if (parsed is null)
+            {
+                logger.LogWarning("TL;DR JSON parse returned null. Falling back to raw text as Summary.");
+                return new TldrResult { Summary = responseText.Trim() };
+            }
+
+            return new TldrResult
+            {
+                Summary = parsed.Summary ?? "",
+                KeyTakeaways = parsed.KeyTakeaways ?? [],
+                TopAction = parsed.TopAction ?? ""
+            };
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to parse TL;DR JSON. Falling back to raw text as Summary. Response={Response}",
+                json);
+            return new TldrResult { Summary = responseText.Trim() };
+        }
+    }
+
+    /// <summary>
+    /// Internal DTO matching the JSON shape requested in <see cref="BuildNarrateTldrPrompt"/>.
+    /// Kept private to the endpoint — public callers receive <see cref="TldrResult"/>.
+    /// </summary>
+    private sealed class TldrJsonPayload
+    {
+        public string? Summary { get; set; }
+        public string[]? KeyTakeaways { get; set; }
+        public string? TopAction { get; set; }
     }
 
     /// <summary>
@@ -393,17 +445,23 @@ public static class DailyBriefingEndpoints
 
     /// <summary>
     /// Build the TL;DR prompt for narrate endpoint.
-    /// Instructs the model to produce a 5-7 sentence briefing ending with the most important action.
+    /// R2.2: requests a JSON response shape — `summary` (2-3 sentences), `keyTakeaways`
+    /// (3-5 short bullets), and `topAction` (one action sentence) — so the client can
+    /// render an at-a-glance scannable summary instead of a paragraph block.
     /// </summary>
     internal static string BuildNarrateTldrPrompt(DailyBriefingNarrateRequest request)
     {
         var sb = new StringBuilder();
         sb.AppendLine("You are a concise executive assistant writing a daily briefing for a legal professional.");
-        sb.AppendLine("Summarize the user's daily notifications into a prioritized briefing of 5-7 sentences.");
+        sb.AppendLine("Summarize the user's daily notifications into a structured briefing with THREE parts:");
+        sb.AppendLine("  1. summary: 2-3 sentence executive summary focused on what requires immediate attention");
+        sb.AppendLine("  2. keyTakeaways: 3-5 short bullet strings (each <120 chars, no leading '-' or '*')");
+        sb.AppendLine("  3. topAction: ONE sentence naming the single most important action for today (begin with the action verb, e.g. 'Review the Acme Corp engagement letter (2 days overdue)')");
+        sb.AppendLine();
         sb.AppendLine("IMPORTANT: Reference specific names, titles, matters, and entities from the data below. Do NOT write vague summaries like 'you have one overdue task'. Instead write 'The Acme Corp engagement letter review is 2 days overdue'.");
-        sb.AppendLine("Focus on what requires immediate attention first, then provide context on volume and trends.");
-        sb.AppendLine("Do NOT use bullet points. Write in natural prose.");
-        sb.AppendLine("End with a sentence identifying the single most important action for today, starting with 'Your most important action today is...'");
+        sb.AppendLine();
+        sb.AppendLine("Return ONLY a JSON object (no markdown, no code fences) with this exact shape:");
+        sb.AppendLine("  { \"summary\": \"...\", \"keyTakeaways\": [\"...\", \"...\"], \"topAction\": \"...\" }");
         sb.AppendLine();
         sb.AppendLine("=== Notification Data ===");
 
@@ -455,7 +513,7 @@ public static class DailyBriefingEndpoints
         }
 
         sb.AppendLine();
-        sb.AppendLine("Write a 5-7 sentence briefing referencing specific names and entities:");
+        sb.AppendLine("Return the JSON object now (no markdown, no code fences, no surrounding text):");
 
         return sb.ToString();
     }
@@ -800,7 +858,7 @@ public record ChannelItemDto
 /// </summary>
 public record DailyBriefingNarrateResponse
 {
-    /// <summary>TL;DR executive summary (5-7 sentences).</summary>
+    /// <summary>TL;DR executive summary (2-3 sentences + 3-5 key-takeaway bullets + top action).</summary>
     [JsonPropertyName("tldr")]
     public TldrResult Tldr { get; init; } = new();
 
@@ -814,15 +872,22 @@ public record DailyBriefingNarrateResponse
 }
 
 /// <summary>
-/// TL;DR executive summary with top action identification.
+/// TL;DR executive summary with key takeaways and top action identification.
+/// R2.2: switched from a single 5-7 sentence narrative to a structured shape —
+/// a 2-3 sentence executive summary + 3-5 key-takeaway bullets — so the client
+/// can render an at-a-glance scannable summary instead of a paragraph block.
 /// </summary>
 public record TldrResult
 {
-    /// <summary>AI-generated 5-7 sentence prioritized briefing narrative.</summary>
-    [JsonPropertyName("briefing")]
-    public string Briefing { get; init; } = "";
+    /// <summary>AI-generated 2-3 sentence executive summary.</summary>
+    [JsonPropertyName("summary")]
+    public string Summary { get; init; } = "";
 
-    /// <summary>The single most important action for today, extracted from the briefing.</summary>
+    /// <summary>AI-generated 3-5 short key-takeaway bullet strings (no leading "- ").</summary>
+    [JsonPropertyName("keyTakeaways")]
+    public string[] KeyTakeaways { get; init; } = [];
+
+    /// <summary>The single most important action for today.</summary>
     [JsonPropertyName("topAction")]
     public string TopAction { get; init; } = "";
 

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
@@ -157,6 +157,9 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
             var actionUrl = config.ActionUrl is not null
                 ? _templateEngine.Render(config.ActionUrl, templateContext)
                 : null;
+            var dueDate = config.DueDate is not null
+                ? _templateEngine.Render(config.DueDate, templateContext)
+                : null;
 
             // Resolve recipient
             var recipientId = ResolveRecipientId(config, templateContext);
@@ -229,6 +232,7 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
                 title, body, category, config.Priority ?? DefaultPriority,
                 config.ToastType ?? DefaultToastType,
                 actionUrl, recipientId.Value, regardingId, regardingType,
+                dueDate,
                 context);
 
             // Create the notification via Dataverse Web API
@@ -334,6 +338,7 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
             var body = _templateEngine.Render(itemConfig.Body!, itemContext);
             var category = itemConfig.Category is not null ? _templateEngine.Render(itemConfig.Category, itemContext) : null;
             var actionUrl = itemConfig.ActionUrl is not null ? _templateEngine.Render(itemConfig.ActionUrl, itemContext) : null;
+            var dueDate = itemConfig.DueDate is not null ? _templateEngine.Render(itemConfig.DueDate, itemContext) : null;
 
             var recipientId = ResolveRecipientId(itemConfig, itemContext);
             if (recipientId is null)
@@ -364,7 +369,8 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
             var payload = BuildNotificationPayload(
                 title, body, category, itemConfig.Priority ?? DefaultPriority,
                 itemConfig.ToastType ?? DefaultToastType,
-                actionUrl, recipientId.Value, regardingId, regardingType, context);
+                actionUrl, recipientId.Value, regardingId, regardingType,
+                dueDate, context);
             await CreateAppNotificationAsync(payload, cancellationToken);
             created++;
         }
@@ -477,6 +483,7 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
         Guid recipientId,
         Guid? regardingId,
         string? regardingType,
+        string? dueDate,
         NodeExecutionContext context)
     {
         var payload = new Dictionary<string, object?>
@@ -497,11 +504,20 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
 
         // FR-18 (P3): build appnotification.data payload.
         // - customData.actionUrl is populated regardless of toasttype (Daily Briefing UI consumer).
+        // - customData.dueDate is populated when provided (R2.2 — Daily Briefing per-item due-date UX).
         // - data.actions[] is populated ONLY when actionUrl is present AND toasttype != Hidden
         //   (so MDA native bell icon shows a clickable "Open" button).
-        if (!string.IsNullOrWhiteSpace(actionUrl))
+        // R2.2: data is built whenever actionUrl OR dueDate is present (was: only actionUrl).
+        var hasActionUrl = !string.IsNullOrWhiteSpace(actionUrl);
+        var hasDueDate = !string.IsNullOrWhiteSpace(dueDate);
+        if (hasActionUrl || hasDueDate)
         {
-            var isVisibleToast = toastType != ToastTypeHidden;
+            // Build customData as a dictionary so we conditionally include only the populated fields.
+            var customData = new Dictionary<string, object?>();
+            if (hasActionUrl) customData["actionUrl"] = actionUrl;
+            if (hasDueDate) customData["dueDate"] = dueDate;
+
+            var isVisibleToast = hasActionUrl && toastType != ToastTypeHidden;
             object dataObject = isVisibleToast
                 ? new
                 {
@@ -513,12 +529,9 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
                             data = new { url = actionUrl }
                         }
                     },
-                    customData = new { actionUrl }
+                    customData
                 }
-                : new
-                {
-                    customData = new { actionUrl }
-                };
+                : (object)new { customData };
 
             payload["data"] = JsonSerializer.Serialize(dataObject);
         }
@@ -676,4 +689,12 @@ internal sealed record NotificationNodeConfig
 
     /// <summary>Notification template for each item when IterateItems is true. Supports {{item.fieldName}} variables.</summary>
     public NotificationNodeConfig? ItemNotification { get; init; }
+
+    /// <summary>
+    /// Optional ISO-8601 due-date string written into <c>appnotification.data.customData.dueDate</c>
+    /// when present. Used by Daily Briefing consumers to render per-item due dates (R2.2).
+    /// Supports template variables (e.g. <c>"{{item.scheduledend}}"</c>). Playbooks that don't
+    /// emit a due date can omit this field — consumers render no due-date row when missing.
+    /// </summary>
+    public string? DueDate { get; init; }
 }

--- a/tests/unit/Sprk.Bff.Api.Tests/Api/Ai/DailyBriefingEndpointsTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Api/Ai/DailyBriefingEndpointsTests.cs
@@ -88,11 +88,13 @@ public sealed class DailyBriefingEndpointsTests
         var result = await InvokeHandleNarrateAsync(request, briefingAi.Object, context);
 
         // Assert — 200 with empty narrative response
+        // R2.2: TldrResult shape changed — Briefing replaced by Summary + KeyTakeaways[].
         result.Should().BeOfType<Ok<DailyBriefingNarrateResponse>>();
         var ok = (Ok<DailyBriefingNarrateResponse>)result;
         ok.Value.Should().NotBeNull();
         ok.Value!.Tldr.Should().NotBeNull();
-        ok.Value.Tldr.Briefing.Should().BeEmpty();
+        ok.Value.Tldr.Summary.Should().BeEmpty();
+        ok.Value.Tldr.KeyTakeaways.Should().BeEmpty();
         ok.Value.Tldr.TopAction.Should().BeEmpty();
         ok.Value.Tldr.CategoryCount.Should().Be(0);
         ok.Value.Tldr.PriorityItemCount.Should().Be(0);
@@ -327,6 +329,100 @@ public sealed class DailyBriefingEndpointsTests
         validated[0].PrimaryEntityId.Should().Be(suppliedId);
         validated[0].PrimaryEntityName.Should().Be("Acme Corp");
         logger.WarningCount.Should().Be(0);
+    }
+
+    // ── Tests: R2.2 — structured TL;DR prompt + ParseTldrResponse ─────────────────
+    //
+    // R2.2 hotfix switched TL;DR from a single 5-7 sentence narrative to a
+    // structured response (summary + keyTakeaways[] + topAction) so the client
+    // can render a scannable shape. These tests cover the new prompt + parser.
+
+    [Fact]
+    public void BuildNarrateTldrPrompt_Requests_Json_Structured_Response()
+    {
+        // Arrange — minimal request (prompt content is invariant to data shape)
+        var request = new DailyBriefingNarrateRequest
+        {
+            Categories = [],
+            PriorityItems = [],
+            TotalNotificationCount = 0,
+            Channels = []
+        };
+
+        // Act
+        var prompt = DailyBriefingEndpoints.BuildNarrateTldrPrompt(request);
+
+        // Assert — prompt must request the JSON shape, NOT a 5-7 sentence narrative.
+        prompt.Should().Contain("summary");
+        prompt.Should().Contain("keyTakeaways");
+        prompt.Should().Contain("topAction");
+        prompt.Should().Contain("JSON");
+        prompt.Should().NotContain("5-7 sentence", because: "R2.2 replaced free-form narrative with structured JSON");
+        prompt.Should().NotContain("Do NOT use bullet points", because: "bullets are now requested");
+    }
+
+    [Fact]
+    public void ParseTldrResponse_Parses_Valid_Json_Successfully()
+    {
+        // Arrange — well-formed JSON matching the prompt contract
+        var json = """
+            {
+              "summary": "Three urgent matters need attention today.",
+              "keyTakeaways": ["Acme contract overdue", "Bravo brief due tomorrow", "Charlie meeting at 3pm"],
+              "topAction": "Review the Acme engagement letter (2 days overdue)."
+            }
+            """;
+        var logger = NullLogger.Instance;
+
+        // Act
+        var result = DailyBriefingEndpoints.ParseTldrResponse(json, logger);
+
+        // Assert
+        result.Summary.Should().Be("Three urgent matters need attention today.");
+        result.KeyTakeaways.Should().HaveCount(3);
+        result.KeyTakeaways[0].Should().Be("Acme contract overdue");
+        result.TopAction.Should().Be("Review the Acme engagement letter (2 days overdue).");
+    }
+
+    [Fact]
+    public void ParseTldrResponse_Strips_Markdown_Code_Fences()
+    {
+        // Arrange — LLM sometimes wraps JSON in ```json fences despite "no markdown" instruction
+        var fencedJson = """
+            ```json
+            {
+              "summary": "Test summary.",
+              "keyTakeaways": ["one"],
+              "topAction": "Do the thing."
+            }
+            ```
+            """;
+        var logger = NullLogger.Instance;
+
+        // Act
+        var result = DailyBriefingEndpoints.ParseTldrResponse(fencedJson, logger);
+
+        // Assert — fences stripped, JSON parsed (mirrors ParseChannelBullets convention).
+        result.Summary.Should().Be("Test summary.");
+        result.KeyTakeaways.Should().ContainSingle().Which.Should().Be("one");
+        result.TopAction.Should().Be("Do the thing.");
+    }
+
+    [Fact]
+    public void ParseTldrResponse_Falls_Back_To_Raw_Summary_On_Invalid_Json()
+    {
+        // Arrange — LLM returns a paragraph instead of JSON (failure mode)
+        var nonJsonResponse = "Three urgent matters need attention today. Review the Acme letter first.";
+        var logger = new CapturingTestLogger();
+
+        // Act
+        var result = DailyBriefingEndpoints.ParseTldrResponse(nonJsonResponse, logger);
+
+        // Assert — graceful degradation: raw text becomes Summary, bullets + topAction empty.
+        result.Summary.Should().Be(nonJsonResponse);
+        result.KeyTakeaways.Should().BeEmpty();
+        result.TopAction.Should().BeEmpty();
+        logger.WarningCount.Should().Be(1, because: "fallback path logs a structured warning");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Status

**🚧 DRAFT — work in progress**

R2.2 hotfix bundle. 3 small UX improvements to the Daily Briefing widget + standalone code page (both surfaces consume the shared \`@spaarke/daily-briefing-components\` package post-R2.1).

## Scope (3 items)

- [ ] **Item 1** — TL;DR formatted as 2-3 sentences + key takeaways bullets (was 5-7 sentences). BFF prompt change in \`DailyBriefingEndpoints.cs:398-460\`.
- [ ] **Item 2** — Due date rendered per item in \`NarrativeBullet\` (data already in \`appnotification.data\` payload).
- [ ] **Item 3** — \`AddToTodo\` sets sensible default due date + shows confirmation toast (\`useInlineTodoCreate.ts\` + Fluent v9 toast).

## Out of scope (deferred to R3 \`spaarke-platform-foundations-r3\`)

- FetchXML OR interim unblock for broken \`notification-new-documents\` / \`notification-new-emails\` playbooks — R3's \`MembershipResolverService\` supersedes it cleanly, so the ~3-4h of throwaway interim work isn't worth it.
- \`??\` Handlebars helper fix and unrendered \`{{\` runtime warning — both are platform-level (R3 Part 3 H1).

## Predecessors

- R2 (PR #397) — Pattern D hoist + 4 defect fixes — MERGED
- R2.1 hotfix (PR #400) — widget parity + sub-list wiring — MERGED + DEPLOYED

## Surfaces affected

| Surface | Item 1 (TL;DR) | Item 2 (due dates) | Item 3 (AddToTodo) |
|---|---|---|---|
| \`sprk_dailyupdate\` (standalone code page) | ✓ | ✓ | ✓ |
| \`sprk_spaarkeai\` (workspace widget) | ✓ | ✓ | ✓ |

Both consume \`@spaarke/daily-briefing-components\` since R2.1, so one set of changes + one deploy per surface.

## Test plan

- [ ] Item 1: BFF unit test in \`Sprk.Bff.Api.Tests\` verifying new TL;DR prompt produces expected JSON shape
- [ ] Item 2: Snapshot test for \`NarrativeBullet\` with due-date rendered
- [ ] Item 3: Test in \`ActivityNotesSection.subList.test.tsx\` (or new test file) verifying default due date set + toast fired
- [ ] Manual UAT in spaarkedev1 after deploy: confirm all 3 items render correctly in both code page surfaces

## Deployment after merge

- \`bff-deploy\` or auto-promotion for Item 1 (BFF prompt change)
- \`code-page-deploy\` for \`sprk_dailyupdate\` + \`sprk_spaarkeai\` for Items 2 + 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)