### PR TITLE
fix(smart-todo-r4): UAT round 4 — Contact entity correction + 6 UI bugs + CreateTodoWizard

### DIFF
--- a/.claude/patterns/ui/INDEX.md
+++ b/.claude/patterns/ui/INDEX.md
@@ -13,7 +13,7 @@
 | [fluent-v9-portal-gotcha.md](fluent-v9-portal-gotcha.md) | Using Popover / Tooltip / Toast / Dialog / Menu / Combobox dropdown | 2026-05-26 | Current |
 | [fluent-v9-react-version-boundaries.md](fluent-v9-react-version-boundaries.md) | Authoring in Spaarke.UI.Components OR bumping React versions | 2026-05-26 | Current |
 | [fluent-v9-host-visual-fit.md](fluent-v9-host-visual-fit.md) | Surface-by-surface theme-source matrix; "make it look native" inside MDA / Canvas / Code Pages / Office Add-ins | 2026-05-28 | Current |
-| [embedded-widget-sizing.md](embedded-widget-sizing.md) | Building/maintaining ANY workspace widget that mounts DataGrid or other content with wide intrinsic width; box-sizing + min-width:0 chain + ResizeObserver pixel cap | 2026-06-09 | Current |
+| [embedded-widget-sizing.md](embedded-widget-sizing.md) | Building/maintaining ANY workspace widget — WIDTH chain (box-sizing + min-width:0 + ResizeObserver pixel cap) AND HEIGHT chain (WorkspaceLayoutWidget.root height:100% + WorkspaceShell.row flex + widget body display:flex) | 2026-06-22 | Current |
 
 ## Critical Constraint (ADR-021 + ADR-022)
 

--- a/.claude/patterns/ui/embedded-widget-sizing.md
+++ b/.claude/patterns/ui/embedded-widget-sizing.md
@@ -1,24 +1,32 @@
 # Embedded Workspace-Widget Sizing — Boundary, Chain, and Box-Sizing
 
-> **Last Reviewed**: 2026-06-09 (created after iter-2 round 11 fix)
+> **Last Reviewed**: 2026-06-22 (extended with HEIGHT chain after smart-todo-r4 rounds 4-12)
 > **Status**: Current
-> **Severity**: High — getting this wrong causes ~120-150px column overshoot + permanent horizontal scrollbars
+> **Severity**: High — width problems cause ~120-150px column overshoot + horizontal scrollbars; height problems cause widgets to render at content height with large empty section areas below
 
 ## When
 
-ANY workspace widget that renders content whose intrinsic width can exceed
-its container — DataGrid, wide tables, side-by-side cards, image galleries,
-horizontal scrollers — embedded inside SpaarkeAi, LegalWorkspace, or any
-future workspace shell.
+ANY workspace widget embedded inside SpaarkeAi, LegalWorkspace, or any
+future workspace shell — covering both:
+- **WIDTH**: content whose intrinsic width can exceed its container
+  (DataGrid, wide tables, side-by-side cards, image galleries, horizontal scrollers)
+- **HEIGHT**: content that should grow to fill the SectionPanel area
+  (kanban boards, lists, vertical scrollers, embedded grids)
 
 ## Read These Files (in order)
 
+For WIDTH:
 1. [`../../../docs/guides/DATAGRID-CODE-PAGE-HOST-CONTRACT.md`](../../../docs/guides/DATAGRID-CODE-PAGE-HOST-CONTRACT.md) §2 + §9.1
 2. [`../../../docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md`](../../../docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md) §7.1
 3. [`../../../src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/DataverseEntityViewWidget.tsx`](../../../src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/DataverseEntityViewWidget.tsx) — canonical reference impl
 4. [`../../../src/client/shared/Spaarke.UI.Components/src/components/DataGrid/DataGrid.tsx`](../../../src/client/shared/Spaarke.UI.Components/src/components/DataGrid/DataGrid.tsx) — see `columnSizingOptions` useMemo
 
-## Four-Step Contract (every widget host MUST satisfy)
+For HEIGHT:
+1. [`../../../docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md`](../../../docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md) §7.2 — full chain contract + diagnostic script
+2. [`../../../src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx`](../../../src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx) — canonical fill-the-section pattern (`height: 100%` root + `flex: 1` scroll content)
+3. [`../../../src/client/shared/Spaarke.Events.Components/src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx`](../../../src/client/shared/Spaarke.Events.Components/src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx) — Pattern D reference (`height: 100%` root + `flex: 1 1 auto, minHeight: 0` grid container)
+
+## WIDTH — Four-Step Contract (every widget host MUST satisfy)
 
 1. **Host Code Page's `index.html` MUST have `*, *::before, *::after { box-sizing: border-box }`.** Without it, every grid cell renders `+24px` wider than its declared width (12+12 padding adds to content-box). Audit before adding a widget:
    ```bash
@@ -31,13 +39,57 @@ future workspace shell.
 
 4. **If your widget mounts `<DataGrid>`, the rest is framework-internal** — already handled by the DataGrid component: Fluent `min-width: fit-content` override, 2-pass column math, per-cell padding reserve, full `min-width: 0` chain.
 
+## HEIGHT — Three-Rule Contract (every widget author MUST satisfy)
+
+The full height chain runs from viewport → 3-pane shell → WorkspacePane → tab content → **WorkspaceLayoutWidget.root** → LegalWorkspaceApp → WorkspaceShell.shell → **WorkspaceShell.row** → SectionPanel.card → SectionPanel.content → **YOUR WIDGET ROOT → inner wrappers → scrollable body**. Three of those links are author-controlled and break silently if any one of them is wrong.
+
+1. **`WorkspaceLayoutWidget.root` MUST set `height: 100%`** (not just `flex: 1`). Its parent (a tab content wrapper) is `display: block`, which IGNORES flex on children. Already fixed in source — don't remove it.
+
+2. **`WorkspaceShell.row` MUST set `flex: 1 1 0 + minHeight: 0 + alignItems: stretch`.** This makes the grid row claim the shell's vertical space AND stretch SectionPanel grid cells to fill row height. Already fixed in source — don't remove it.
+
+3. **YOUR widget's intermediate wrappers MUST all be `display: flex` (or `grid`).** A `div` defaults to `display: block`. A child with `flex: 1 1 auto` inside a `display: block` parent has its flex IGNORED → child falls back to content height. The most common failure: a "body" or "content" wrapper with `flex: 1 1 auto, overflowY: auto` but MISSING `display: flex` — children can't claim the body's height.
+
+```typescript
+// ✅ CORRECT — every wrapper in the chain is flex
+const useStyles = makeStyles({
+  root: {
+    display: 'flex', flexDirection: 'column',
+    height: '100%',       // anchor to parent's supplied height (block-parent-safe)
+    overflow: 'hidden',
+  },
+  body: {
+    display: 'flex',      // ← CRITICAL — without this, child flex props don't work
+    flexDirection: 'column',
+    flex: '1 1 auto', minHeight: 0, overflowY: 'auto',
+  },
+  scrollableContent: {
+    flex: '1 1 auto',     // claims body's height
+    minHeight: 0,
+  },
+});
+
+// ❌ THE TRAP — body div is implicitly display:block, children's flex is IGNORED
+const broken = {
+  body: { flex: '1 1 auto', minHeight: 0, overflowY: 'auto' /* MISSING display: flex */ },
+};
+```
+
+In `workspaceConfig.tsx`, EVERY section MUST supply its own card height (SectionPanel.card has no `height: 100%` by default):
+```typescript
+{ id: "...", style: { height: "calc(100vh - 200px)", minHeight: "560px" }, renderContent: ... }
+```
+
 ## Constraints
 
 - **No `width: 100%` without `min-width: 0`.** Flex items still refuse to shrink below intrinsic content width.
+- **No `flex: 1 1 0` on a child of `display: block`.** Flex is IGNORED in block parents — use `height: 100%` instead.
 - **No CSS class without `!important`** to override Fluent v9 inline styles. Inline beats class in specificity unless `!important` is on the class.
-- **No assumption about pane width.** Operator can resize panes; widget must constrain regardless.
+- **No assumption about pane width OR height.** Operator can resize panes; widget must constrain itself regardless.
+- **No `minHeight: 400px` (or any pixel floor) on the scrollable body to "guarantee" rendering.** Pixel floors mask broken chains — fix the chain instead; use `minHeight: 0` so the flex chain can supply natural height.
 
 ## Failure Modes Catalog
+
+### Width failures
 
 | Symptom | Cause | Fix |
 |---|---|---|
@@ -46,13 +98,24 @@ future workspace shell.
 | Table scrollWidth > container clientWidth, rendered ≈ declared widths | DataGrid column math regression | File a bug; do not work around at widget level |
 | Widget renders fine in standalone Code Page but overflows when embedded | Missing the §7.1.1.3 ResizeObserver pixel-cap wrapper | Copy DataverseEntityViewWidget's pattern verbatim |
 
-## Diagnostic Script
+### Height failures
 
-Switch DevTools Console to the Code Page iframe, then paste from
-[`DATAGRID-CODE-PAGE-HOST-CONTRACT.md` §9.1.6](../../../docs/guides/DATAGRID-CODE-PAGE-HOST-CONTRACT.md#916-diagnostic-script).
+| Symptom | Cause | Fix |
+|---|---|---|
+| Widget renders at ~600px regardless of SectionPanel size | `WorkspaceLayoutWidget.root` missing `height: 100%` (block parent ignores its flex) | Already fixed in source. If reintroduced, restore. |
+| Widget root fills correctly but section grid row stays at content height | `WorkspaceShell.row` missing `flex: 1 1 0 + alignItems: stretch` | Already fixed in source. If reintroduced, restore. |
+| Card fills SectionPanel but YOUR widget's inner area caps at ~400px (your min-height floor) | A wrapper div between widget root and scrollable body is missing `display: flex` | Add `display: flex, flexDirection: column` to that wrapper |
+| Other widgets (DailyBriefing, Calendar) fill correctly but yours doesn't | Your widget's intermediate wrappers don't follow Rule 3 above | Run the §7.2.4 diagnostic script to find the first `display: block` parent breaking the chain |
+
+## Diagnostic Scripts
+
+For WIDTH: switch DevTools Console to the Code Page iframe, paste from [`DATAGRID-CODE-PAGE-HOST-CONTRACT.md` §9.1.6](../../../docs/guides/DATAGRID-CODE-PAGE-HOST-CONTRACT.md#916-diagnostic-script).
+
+For HEIGHT: paste from [`BUILD-A-NEW-WORKSPACE-WIDGET.md` §7.2.4](../../../docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md) — walks UP from your widget to viewport and shows every element's display/flex/height so you can spot the chain break.
 
 ## See Also
 
 - [`fluent-v9-host-visual-fit.md`](./fluent-v9-host-visual-fit.md) — theme + visual fit per surface (orthogonal concern)
 - [`fluent-v9-component-authoring.md`](./fluent-v9-component-authoring.md) — Fluent v9 component-level rules
-- iter-2 rounds 6-11 commit chain in `feature/ai-spaarke-ai-workspace-UI-r1` — the 11-round saga that surfaced this knowledge
+- iter-2 rounds 6-11 commit chain in `feature/ai-spaarke-ai-workspace-UI-r1` — 11-round saga that surfaced the WIDTH knowledge
+- smart-todo-r4 UAT rounds 4-12 commit chain (June 2026) on `work/smart-todo-r4-uat4-fixes` — 9-round saga that surfaced the HEIGHT knowledge; PR #406

--- a/docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md
+++ b/docs/guides/BUILD-A-NEW-WORKSPACE-WIDGET.md
@@ -650,6 +650,184 @@ The output tells you:
 
 ---
 
+## 7.2 Sizing & layout — the HEIGHT chain (NEW 2026-06-22, smart-todo-r4 round 12)
+
+If your widget's body should grow to fill the SectionPanel area (kanban,
+list, grid, anything that benefits from vertical space) — and you see it
+capping at content height even though the surrounding section has more
+room — the height chain has a break somewhere between the workspace tab
+content and your widget's innermost flex child.
+
+This was the root cause of a 7-round debug cycle on the SmartTodo widget
+(smart-todo-r4 UAT 4 → 12, June 2026). The widget kept rendering at
+~600px (or its minHeight floor) even when the section panel was 900+ px
+tall. Working widgets in the same pane (Daily Briefing, Calendar) fill
+correctly because they follow the contract below.
+
+### 7.2.1 The three-rule contract
+
+The full height chain is:
+
+```
+viewport
+  → SpaarkeAi 3-pane shell                  (✓ established, don't touch)
+  → WorkspacePane / tab content              (✓ established, don't touch)
+  → WorkspaceLayoutWidget.root               ★ Rule 1
+  → LegalWorkspaceApp root                   (✓ already height:100%)
+  → WorkspaceShell.shell                     (✓ flex 1 1 auto)
+  → WorkspaceShell.row                       ★ Rule 2
+  → SectionPanel.card                        (height supplied via `style: { height: ... }`)
+  → SectionPanel.content                     (✓ flex 1 1 auto)
+  → YOUR WIDGET ROOT                         ★ Rule 3 (your responsibility)
+  → ...inner widget wrappers...              ★ Rule 3 (your responsibility)
+  → your scrollable body / kanban / list
+```
+
+**Rule 1 — Block-parent crossing**: `WorkspaceLayoutWidget.root` is mounted
+inside a `display: block` tab-content wrapper. A block parent **ignores
+flex** on children. Without explicit `height: 100%`, the widget root
+shrinks to content height (~600px) regardless of how tall the parent is.
+
+This is already fixed in `WorkspaceLayoutWidget.tsx` styles (`height:
+'100%'` + `flex: 1`). Don't remove it.
+
+**Rule 2 — Grid row must claim shell height**: `WorkspaceShell.row`
+(`display: grid`) needs `flex: 1 1 0, minHeight: 0, alignItems: stretch`
+to claim its flex shell parent's vertical space AND stretch SectionPanel
+cards to fill the row.
+
+This is already fixed in `WorkspaceShell.styles.ts`. Don't remove it.
+
+**Rule 3 — YOUR widget's internal wrappers must all be `display: flex`** (or
+`grid`), not the div default of `block`. Every level between your widget
+root and your scrollable body must propagate height via flex.
+
+```typescript
+// ✅ CORRECT — every wrapper in the chain is flex
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',          // anchor to parent's supplied height
+    overflow: 'hidden',
+  },
+  body: {
+    display: 'flex',         // ← CRITICAL: without this, child flex props don't work
+    flexDirection: 'column',
+    flex: '1 1 auto',
+    minHeight: 0,
+    overflowY: 'auto',
+  },
+  kanbanContainer: {
+    flex: '1 1 auto',        // claims body's height
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+});
+
+// ❌ THE TRAP — the body div is implicitly display:block, so the kanbanContainer
+// child's `flex: 1 1 auto` is IGNORED. Kanban falls back to content height.
+const broken = makeStyles({
+  body: {
+    flex: '1 1 auto',
+    minHeight: 0,
+    overflowY: 'auto',
+    // MISSING: display: 'flex'  ← caused the smart-todo-r4 round 4-12 cycle
+  },
+});
+```
+
+### 7.2.2 Working reference widgets (clone this layout)
+
+If in doubt, copy the proven pattern from these widgets — they fill
+correctly with NO height-cap workarounds:
+
+- **`DailyBriefingApp`** — `src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx` —
+  `container: { display: flex, flexDirection: column, height: '100%' }` +
+  `scrollContent: { flex: 1 }`. Note `height: 100%` instead of `flex: 1` on
+  the root anchors against the block-parent-crossing problem.
+- **`CalendarWorkspaceWidget`** — `src/client/shared/Spaarke.Events.Components/src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx` —
+  `root: { display: flex, flexDirection: column, height: '100%' }` +
+  `gridContainer: { flex: '1 1 auto', minHeight: 0 }`. Canonical Pattern D
+  reference.
+
+### 7.2.3 Per-section height supply (workspaceConfig)
+
+`SectionPanel.card` does NOT have `height: 100%` by default (a structural
+fix attempt in round 7 collapsed the workspace because the chain above
+the shell wasn't yet repaired). Each section must supply its own height
+via inline style:
+
+```typescript
+// In src/solutions/LegalWorkspace/src/workspaceConfig.tsx
+{
+  id: "your-widget",
+  type: "content",
+  title: "Your Widget",
+  style: { height: "calc(100vh - 200px)", minHeight: "560px" },  // ← required
+  renderContent: () => <YourWidget />,
+}
+```
+
+The `calc(100vh - 200px)` accounts for the SpaarkeAi shell chrome
+(headers + tab strip ≈ 200px). Adjust if your shell is taller. The
+`minHeight: 560px` is a defensive floor for very short viewports.
+
+### 7.2.4 Diagnostic script when something looks wrong
+
+Open DevTools console on the SpaarkeAi page with your widget visible
+and paste:
+
+```javascript
+(function dumpHeightChain() {
+  var start = document.querySelector('[role="region"][aria-label*="your-widget-name"]') ||
+              document.querySelector('main');
+  var el = start, depth = 0;
+  while (el && depth < 25) {
+    var cs = getComputedStyle(el);
+    var rect = el.getBoundingClientRect();
+    var cls = (typeof el.className === 'string'
+      ? '.' + el.className.split(/\s+/)[0] : '');
+    console.log('  '.repeat(depth) + el.tagName.toLowerCase() + cls +
+      ' | h=' + Math.round(rect.height) + 'px' +
+      ' | display=' + cs.display +
+      ' | flex=' + cs.flex);
+    el = el.parentElement; depth++;
+  }
+})();
+```
+
+The output walks UP from your widget to viewport. Look for:
+- The first `display: block` parent that has more height than its child
+  → that's where flex children are being ignored.
+- Any `flex: 1 1 0` or `flex: 1 1 auto` element NOT growing to fill its
+  parent → that level needs `height: 100%` instead, OR its parent isn't
+  a flex container.
+
+For a worked-through example see `projects/smart-todo-r4/notes/` — the
+UAT rounds 4-12 debugging artifacts (kept as a reference for the height
+chain investigation methodology).
+
+### 7.2.5 Anti-patterns specific to height sizing
+
+- ❌ **Using `flex: 1 1 0` on a child of `display: block`.** Flex
+  properties only work in flex parents. `display: block` ignores them
+  and child sizes to content. Either make the parent `display: flex` or
+  use `height: 100%` on the child.
+- ❌ **Forgetting `display: flex` on intermediate wrappers.** A div with
+  `flex: 1 1 auto, overflowY: auto` looks like a flex item but its
+  CHILDREN can't use flex (because the div itself is block). Add
+  `display: flex, flexDirection: column` to make it a flex container.
+- ❌ **Setting `minHeight: 400px` (or any pixel floor) on the scrollable
+  body to "guarantee" it renders.** That's masking a broken chain. Fix
+  the chain; use `minHeight: 0` so the chain can supply natural height.
+- ❌ **Inventing a per-widget height fallback like `height: 'calc(100vh
+  - 200px)'`** ON the widget itself rather than on the section config.
+  Sections own height; widgets fill what they're given.
+
+---
+
 ## 8. Anti-patterns
 
 - **❌ Do not invent a third wrapper.** The two wrappers (Dashboard + Direct) are intentionally retained per OC-R4-06 (model doc §2.3). If you find yourself wanting a third — "but my widget is sort-of-composable" or "but my widget needs Dataverse persistence too" — re-read the model doc. Dual-use (§4 here) is almost always the right answer.

--- a/projects/smart-todo-r4/current-task.md
+++ b/projects/smart-todo-r4/current-task.md
@@ -1,6 +1,6 @@
 # Current Task State — smart-todo-r4
 
-> **Last Updated**: 2026-06-18 (Wave D ✅ deployed; Wave E queued — 3 new widget/app parity tasks 102/103/104 per UAT round 2)
+> **Last Updated**: 2026-06-20 22:30Z (PR #403 merged to master — UAT iteration complete + Contact lookup migration code on master)
 > **Recovery**: Read "Quick Recovery" section first
 
 ---
@@ -9,16 +9,76 @@
 
 | Field | Value |
 |-------|-------|
-| **Project** | smart-todo-r4 — 7 workstreams (A-G), 34 tasks total (31 baseline + 3 Wave D widget-parity adds) |
-| **Status** | **31 of 34 tasks ✅** (91% by count; all implementation waves + widget parity complete) |
-| **PR #377** | ✅ MERGED to master as squash `eed39e40a` (Phases 0 + 1 + Wave 2a + followups; 13 tasks) |
-| **PR #384** | ✅ MERGED to master 2026-06-11 (Waves A + B + C; 14 tasks) |
-| **Wave D** | ✅ COMPLETE on branch (NOT yet on master): 099 widget chrome + Pattern D, 101 useKanbanColumns hoist, 100 openTodo launch + BroadcastChannel refetch. 4 commits on branch (`c50690be8` planning + `6074d42b9` 099 + `afb6ac6cc` 101 + `f593292c2` 100). Closes UAT issues 1-6 from 2026-06-18 screenshot. |
-| **Worktree branch** | `work/smart-todo-r4-wave2` — synced to master tip `3d02a3d38` (post-PR-394 Wave E merge); R4-105 closeout local |
-| **Active task** | **R4-092 deploy** (in-progress) — Wave D + Wave E both deployed to spaarkedev1; awaiting user UAT round 3 sign-off |
-| **Working tree** | R4-105 POML + TASK-INDEX changes pending commit (this commit) |
-| **Next Action** | **User UAT round 3 options**: (a) test on the deployed spaarkedev1 bits (Ctrl+F5 first); OR (b) use the NEW prototype harness at `c:/code_files/spaarke-prototype/projects/smart-todo-r4-uat/` (`npm run dev` → localhost:5173, sub-second HMR on widget source edits — no deploy needed for visual iteration). After UAT sign-off: flip R4-092 + R4-093 to ✅, proceed to R4-098 wrap-up + final PR-close. |
-| **PR strategy** | Wave D (PR #391 `e4e91a3ec`); CI hardening (PR #392 + #393); Wave E (PR #394 `3d02a3d38` merged 2026-06-18T21:03:49Z). Prototype harness on `feature/uat-harness-framework` in spaarke-prototype repo — separate PR there when ready to land. R4-098 wrap-up + project-close still HELD until final UAT acceptance per durable user instruction. |
+| **Project** | smart-todo-r4 — 7 workstreams; PR-merge phase post-UAT iteration |
+| **Status** | All implementation + 2 days of UAT iteration ✅ **MERGED TO MASTER** (commit `845521aaf` via PR #403 squash, 2026-06-20T22:22:27Z) |
+| **PR #403** | ✅ MERGED 2026-06-20 — 19 commits squash-merged covering: contact-lookup migration, chrome uniformity (title row above toolbar, 3-field quick-add, Filter slide), color-coded count pills, collapsible columns (both orientations), columnOrders cross-device persistence, modal-launch harness wiring, prototype-framework skills, Header.tsx production regression fix |
+| **Worktree branch** | `work/smart-todo-r4-wave2` was DELETED after merge. Worktree is now on `master` @ `845521aaf` |
+| **Active task** | **R4-092 deploy** still in-progress — code is on master but NOT YET DEPLOYED to spaarkedev1 |
+| **Working tree** | 2 unrelated researcher subagent memory files modified (`.claude/agent-memory/researcher/*`) — non-source, safe to ignore |
+| **Next Action** | **Master-deploy to spaarkedev1**: `/master-deploy` (or invoke `master-deploy` skill). PREREQ to verify before deploy: (1) `sprk_todo.sprk_assignedto` is migrated to sprk_contact Contact lookup on spaarkedev1 (user confirmed migration done); (2) at least one `sprk_contact` record exists with `sprk_systemuser` populated for test users (otherwise useCurrentContactId returns null → empty kanban). After deploy: UAT round 4 on deployed bits; flip R4-092 + R4-093 to ✅; proceed to R4-098 project wrap-up. |
+| **Critical schema dependency** | New code REQUIRES `sprk_todo.sprk_assignedto` = lookup to `sprk_contact` (NOT systemuser). Filter resolves current user → sprk_contact via `useCurrentContactId` hook. Without the schema migration + at least one sprk_contact row per user, the widget + Code Page will show empty for that user. |
+
+### What landed in PR #403 (highlights)
+
+| Area | Change |
+|---|---|
+| **Schema migration** | `sprk_todo.sprk_assignedto` migrated systemuser → sprk_contact; `useCurrentContactId` hook in `@spaarke/smart-todo-components`; widget + Code Page + queryHelpers + DataverseService all rewired; bind format `/sprk_contacts(...)` |
+| **Chrome uniformity** | Title row above toolbar (both surfaces); 3-field quick-add (name + due + assigned + Add icon); Filter slide UX (replaces search-as-icon expand row); list view removed from Code Page |
+| **Kanban improvements** | Tomorrow → yellow accent + dark text on pill (WCAG); color-coded count pills (red/yellow/green); KanbanBoard width:100% + alignSelf:stretch; widget kanbanContainer flex 1 1 0 + flexible min-height `max(400px, 60vh)`; collapsible columns in BOTH orientations (single-container pattern + `alignSelf:flex-start` for horizontal-collapsed); orientation toggle single-source-of-truth (was stuck on Code Page); widget defaults to horizontal |
+| **Persistence** | `columnOrders` field on `ITodoKanbanPreferences` (cross-device JSON pref); `useKanbanColumns` `initialColumnOrders` + `onColumnOrdersChange`; SmartToDo wired to persist via `updatePreferences` |
+| **Production regression fix** | `SmartTodoApp/components/Header/Header.tsx` import (`../../icons/MicrosoftToDoIcon` → `@spaarke/ui-components`) — slipped past master-deploy webpack resolution, caught by harness |
+| **Tooling** | 3 new skills: `prototype-harness-setup`, `prototype-harness-extend`, `prototype-experiment-init` |
+| **Architecture note** | `projects/smart-todo-r4/notes/ownership-filter-alignment-2026-06-19.md` |
+| **Prototype harness companion commits** | spaarke-prototype repo: `_infra/seed/factories/sprk_contact.ts` + sprk_todo seed updated to use contact GUID + localStorage persistence simulator + widget→modal harness wiring + worked-example guide + Mode 1/2 pcfContext mock + Code Page mount alias |
+
+### Files Modified Since 2026-06-18 Restart (this session work)
+
+**Production (now on master):**
+- `src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx` + `.styles.ts` — three-field quick-add, Filter slide, title row, collapse wiring, contact-id integration, Add icon
+- `src/client/shared/Spaarke.SmartTodo.Components/src/hooks/useKanbanColumns.ts` — columnOrders plumbing, Tomorrow yellow accent + dark countTextColor
+- `src/client/shared/Spaarke.SmartTodo.Components/src/hooks/useCurrentContactId.ts` (NEW) — systemuser → sprk_contact resolver
+- `src/client/shared/Spaarke.SmartTodo.Components/src/components/SmartTodoKanban/SmartTodoKanban.tsx` — collapse + columnOrders forwarding
+- `src/client/shared/Spaarke.UI.Components/src/components/Kanban/KanbanBoard.tsx` + `types.ts` — width:100% + alignSelf:stretch, count pill, single-container collapsed
+- `src/solutions/SmartTodo/src/SmartTodoApp.tsx` — orientation prop down, contact resolution, list view + ViewToggle removed
+- `src/solutions/SmartTodo/src/components/SmartToDo.tsx` — orientation override prop, columnOrders wiring, three-field event payload
+- `src/solutions/SmartTodo/src/components/Header/Header.tsx` + `.styles.ts` — title row, three-field quick-add, Filter slide, contact defaults
+- `src/solutions/SmartTodo/src/services/queryHelpers.ts` + `DataverseService.ts` + `hooks/useTodoItems.ts` — contactId param rename
+- `src/solutions/SmartTodo/src/hooks/useUserPreferences.ts` — columnOrders field
+- `.claude/skills/prototype-harness-setup/SKILL.md` (NEW)
+- `.claude/skills/prototype-harness-extend/SKILL.md` (NEW)
+- `.claude/skills/prototype-experiment-init/SKILL.md` (NEW)
+- `.claude/skills/INDEX.md` — added new skills
+- `projects/smart-todo-r4/notes/ownership-filter-alignment-2026-06-19.md` (NEW)
+
+**Harness (spaarke-prototype repo, `feature/uat-harness-framework` branch):**
+- `_infra/mocks/xrm.ts` — OData lookup normalization, @odata.bind handling, localStorage persistence, server-side defaults on create
+- `_infra/mocks/pcfContext.ts` (NEW) — PCF ComponentFramework.Context mock
+- `_infra/mocks/auth.ts` — auth mocks
+- `_infra/mocks/index.ts` — InstallMocks aggregate + persistKey + PCF exports
+- `_infra/seed/factories/sprk_todo.ts` — sprk_assignedto now contact GUID, more fields
+- `_infra/seed/factories/sprk_contact.ts` (NEW) — Person table seed for contact resolution
+- `_infra/seed/presets/smart-todo-default.ts` — seeds both entities
+- `_infra/vite.shared-libs.ts` — @spaarke/smart-todo-app alias for Code Page mount
+- `projects/smart-todo-r4-uat/src/App.tsx` — tab switcher (Widget + Code Page), CreateTodoWizard mount, widget→modal launch wiring
+- `projects/smart-todo-r4-uat/src/main.tsx` — persistKey enabled
+- `docs/PROTOTYPE-UI-SYSTEM-GUIDE.md` — Mode 1/2 + worked example + interactive UI + seed data + PCF + Coverage&limits sections
+- `docs/SKILLS-TO-BUILD.md` — design doc for the 3 prototype skills (now built)
+
+### Decisions Made This Session
+
+| Decision | Why |
+|---|---|
+| **Squash merge** for PR #403 | User's choice — single commit on master vs preserving 19 individual commits |
+| **`useCurrentContactId` hook** (new shared peer) over inline resolution in each surface | Single source-of-truth for systemuser → sprk_contact mapping; both widget + Code Page consume the same hook |
+| **Dual-field display vs polymorphic vs name+systemuser** for Assigned To | User chose to migrate `sprk_assignedto` straight to sprk_contact lookup (removed old, created new); polymorphic was rejected (FetchXML can't filter); name-only rejected (loses lookup semantics) |
+| **In-memory contactId state + visible name display** for quick-add | UI shows resolved contact NAME (not raw GUID); bind payload uses GUID; user can leave Assigned To empty (placeholder shows) → bind defaults to current user's contact |
+| **Default contactId placeholder over auto-fill** | UAT feedback: field hint should show "Assigned to" — pre-filling with contact name hides the placeholder. Internal contactId tracking still defaults assignment to current user when field is empty. |
+| **`flex: 1 1 0` + `max(400px, 60vh)` min-height** on widget kanbanContainer | UAT discovery: nested Griffel `min-height: 0` collapsed the kanban to invisible; flexible floor prevents collapse while still growing in larger hosts. User noted "this needs to be flexible." |
+| **`alignSelf: flex-start` for horizontal-collapsed columns** | Lets collapsed columns shrink to header-height while sibling expanded columns still stretch to board height. Replaces prior 40px vertical-rl rail (which user found visually disjoint). |
+| **Single-container collapsed pattern** (no separate `<div>` for collapsed) | Same element renders in both states; only the Droppable card-list area is conditional. Solves the "vertical-mode collapsed hides header + takes giant height" bug. |
+| **Orientation passed as prop SmartTodoApp → SmartToDo** (not via internal hook instance) | Two `useUserPreferences` instances had independent state — toggle persisted but didn't reach SmartToDo's KanbanBoard. Prop down = single source of truth. |
+| **localStorage persistence in harness mock** | Production has Dataverse persistence; harness re-seeded on every refresh, making pin moves appear lost. localStorage simulates production behavior. |
+| **Modal-launch via URL params + key remount in harness** | Mirrors production's `useLaunchContext` flow exactly. SmartTodoApp's useLaunchContext re-reads URL on mount; key bump forces remount. |
 
 ### 🆕 UAT-iteration harness (R4-105)
 

--- a/projects/smart-todo-r4/tasks/092-deploy-all-affected-solutions.poml
+++ b/projects/smart-todo-r4/tasks/092-deploy-all-affected-solutions.poml
@@ -179,5 +179,119 @@ Dataverse server timestamps confirm both writes landed within the past 5 minutes
 ### Status (unchanged)
 
 `in-progress` until user UAT round 3 confirms widget/app parity per the 11 UAT items in `notes/e-widget-app-parity-audit-2026-06-18.md`. R4-098 wrap-up + final PR-close stay HELD.
+
+---
+
+## Deploy session 2026-06-20 (Wave 2 UAT post-merge)
+
+Post-PR #403 (`feat(smart-todo-r4): UAT 2026-06-19/20 — Contact lookup migration + chrome uniformity + persistence + skills`) squash-merged to master at `845521aaf` (2026-06-20T22:22:27Z). This deploy supersedes the Wave E deploy (2026-06-18) for the same 2 surfaces — they now carry the Wave 2 UAT delta (contact-lookup ownership migration, Code Page chrome uniformity, cross-device columnOrders persistence, collapsible columns in both orientations, color-coded count pills, Filter slide UX, three-field quick-add, widget→modal launch).
+
+### Surfaces deployed (2)
+
+| Surface | Web Resource | Bundle | Carries (Wave 2 UAT delta) |
+|---|---|---|---|
+| SmartTodo Code Page | `sprk_smarttodo` | 1714 KB (was 1709 KB pre-Wave-2-UAT) | Header three-field quick-add, Filter slide, title row, useCurrentContactId resolution, useUserPreferences.columnOrders, orientation prop down-flow, queryHelpers contact-filter, services/DataverseService contactId param |
+| SpaarkeAi (embeds LW shell with widget) | `sprk_spaarkeai` | 3848 KB (was 3766 KB pre-Wave-2-UAT) | Spaarke.SmartTodo.Components widget (Filter slide, 3-field quick-add, useCurrentContactId, persistence, MicrosoftToDoIcon, Add20Regular); Spaarke.UI.Components Kanban (collapse in both orientations, countTextColor, board flex stretch, conditional Droppable) |
+
+### Surfaces NOT redeployed (intentional)
+
+- **CreateTodoWizard** (`sprk_createtodowizard`) — PR #403 did NOT modify it. No-op skip.
+- **RegardingResolver PCF v1.1.0**, **`sprk_todo_dirty_check.js`**, **BFF API**, **Matter VisualHost web resources** — all untouched in PR #403 (same as prior waves).
+
+### Pre-deploy verification
+
+- This worktree (`c:/code_files/spaarke-wt-smart-todo-r4`) on master tip `845521aaf` (PR #403 squash-merge SHA)
+- SpaarkeAi: required `npm install --legacy-peer-deps --no-audit --no-fund` to pull a new transitive `@spaarke/daily-briefing-components` peer dep that landed via master between Wave E and now
+- Vite cache cleared before SpaarkeAi build (per code-page-deploy skill mandate); SmartTodo built via existing `Deploy-SmartTodo.ps1` (build embedded in script)
+- Build outputs verified to contain PR #403 strings (columnOrders, countTextColor) post-minification
+- Both Vite builds green: SmartTodo 1.71 MB / 475 KB gzip in 12.48s; SpaarkeAi 3.85 MB / 1.07 MB gzip in 13.21s
+- DATAVERSE_URL = https://spaarkedev1.crm.dynamics.com; az auth valid (ralph.schroeder@spaarke.com)
+
+### Deploy results — both ✅
+
+- SmartTodo: "Publishing customizations... Published"; deploy via `Deploy-SmartTodo.ps1` (combined build + deploy)
+- SpaarkeAi: "Publishing customizations... Published"; deploy via `Deploy-SpaarkeAi.ps1` (manual build first; script verifies + uploads)
+
+### Schema dependency (pre-UAT verification on spaarkedev1)
+
+Per `useCurrentContactId` introduction in PR #403, the following MUST be true on spaarkedev1 before UAT round 4 can pass golden-path tests:
+
+1. `sprk_todo.sprk_assignedto` is a Contact lookup (not systemuser) — user confirmed migration done
+2. At least one `sprk_contact` record exists with `sprk_systemuser` populated for the test user (`ralph.schroeder@spaarke.com`) — otherwise the widget's empty-state shows and no kanban renders
+
+### Acceptance criteria status (cumulative)
+
+- [x] All affected solutions deployed to spaarkedev1 (3 unique surfaces across Wave D + E + 2-UAT; SmartTodo + SpaarkeAi redeployed this session)
+- [x] sprk_todoflag: 0 functional hits in source (R4-094 grep gate 2026-06-12, unchanged)
+- [ ] Golden-path smoke test — DELEGATED to user UAT round 4 (Wave 2 UAT)
+- [ ] PR description — Wave 2 UAT landed via PR #403; this notes block records the deploy
+
+### Status (unchanged)
+
+`in-progress` until user UAT round 4 confirms the 11 Wave 2 UAT items. R4-098 wrap-up + final PR-close stay HELD.
+
+---
+
+## Deploy session 2026-06-21 (UAT round 4 hotfix)
+
+User UAT round 4 surfaced 6 issues against the 2026-06-20 deploy. Root causes identified live (no separate audit task — this notes block records both diagnosis + fix):
+
+### Bugs found in UAT round 4
+
+| # | Symptom | Root cause |
+|---|---|---|
+| 1 | Widget orientation default wrong | Both surfaces defaulted to `'horizontal'`. User intent: WIDGET default = vertical (stacked rows), Code Page default = horizontal (columns). |
+| 2 | Widget collapse doesn't shrink column width | `KanbanBoard` only set `alignSelf: flex-start` for collapsed horizontal — cross-axis only. Base `column` flex `1 1 0` still claimed equal width. |
+| 3 | Clicking Open in widget opened BOTH Code Page modal AND record modal (stack) | LW shim's `handleOpenTodo` always navigated to `sprk_smarttodo` Code Page with `?action=openTodo&todoId=<guid>`. The Code Page then auto-mounted the record modal — net result two stacked dialogs. |
+| 4 | Future column hidden at narrow widget width | `KanbanBoard.board` style had `overflow: hidden`. When 3 columns + gap exceeded available width (even with `flex 1 1 0 / minWidth 0`), rightmost column got clipped invisibly. |
+| 5 | Code Page kanban showed "All caught up" — 0 records | `useCurrentContactId` queried `sprk_contact` entity with `sprk_contactid` / `sprk_name` fields. **None of those exist**. The actual schema uses the OOB `contact` entity (extended with custom `sprk_systemuser` lookup) — fields are `contactid` / `fullname`. Hook returned null → `useTodoItems` filtered by null contactId → 0 records. |
+| 5a (security regression) | Widget showed all 14 active sprk_todos system-wide | `buildSmartTodoQuery` fell back to `activeClause` only when contactId was null. This was a data-isolation breach: anyone whose contact didn't resolve saw everyone's todos. |
+| 6 | Assigned To field was a plain Input, not connected to a lookup | Designed as a plain Input pending real picker. Same fix scope as #5. |
+
+### Honest process gap
+
+The UAT mock-data harness (spaarke-prototype) seeded a `sprk_contact` row with `sprk_contactid` / `sprk_name` fields, masking the entity-name bug entirely. Prototype tests against mocks should NOT be considered UAT for query-shape correctness — only a real-Dataverse smoke test catches entity-existence and field-name errors. **Future R-cycles MUST add a "real Dataverse smoke" deploy step before merge** (filing as `[[r4-process-gap-2026-06-21]]` candidate in lessons-learned).
+
+### Files changed in fix wave
+
+| File | Change |
+|---|---|
+| `src/client/shared/Spaarke.SmartTodo.Components/src/hooks/useCurrentContactId.ts` | Entity `sprk_contact` → `contact`; fields `sprk_contactid` → `contactid`, `sprk_name` → `fullname`; docblock rewritten |
+| `src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx` | (1) `@odata.bind` set `sprk_contacts` → `contacts`; (2) `buildSmartTodoQuery` now returns zero-row filter (not activeClause-only) when contextClause empty — security fix #5a; (3) orientation default `'horizontal'` → `'vertical'`; (4) added typeahead state + debounced contact search effect + select handler; (5) replaced plain Input with typeahead wrapper + Listbox dropdown |
+| `src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts` | Added `assignedToWrap` / `assignedToResults` / `assignedToResultItem` / `assignedToResultsHint` styles for typeahead dropdown |
+| `src/client/shared/Spaarke.UI.Components/src/components/Kanban/KanbanBoard.tsx` | (1) `board.overflow` `hidden` → `overflowX: auto, overflowY: hidden` — fix #4; (2) collapsed-horizontal inline style now adds `flex: '0 0 auto'` alongside `alignSelf: 'flex-start'` so column shrinks both axes — fix #2 |
+| `src/solutions/SmartTodo/src/components/SmartToDo.tsx` | `@odata.bind` set `sprk_contacts` → `contacts` in three-field quick-add handler |
+| `src/solutions/SmartTodo/src/components/Header/Header.tsx` | (1) `handleQuickAddAssignedToChange` clears contactId on edit; (2) added typeahead state + debounced contact search effect + select handler; (3) replaced plain Input with typeahead wrapper + Listbox dropdown |
+| `src/solutions/SmartTodo/src/components/Header/Header.styles.ts` | Added typeahead styles mirroring widget |
+| `src/solutions/LegalWorkspace/src/sections/todo.registration.ts` | `handleOpenTodo` rewritten: with `todoId` → `Xrm.Navigation.openForm({entityName:'sprk_todo', entityId})` directly (no Code Page hop); without `todoId` → keep Code Page nav for "open the full app" — fix #3 |
+
+### Bugs NOT fixed (out of UAT scope, tracked for next cycle)
+
+_(none remaining — see CreateTodoWizard sub-deploy below)_
+
+### Surfaces deployed (3)
+
+| Surface | Web Resource | Bundle | Carries |
+|---|---|---|---|
+| SmartTodo Code Page | `sprk_smarttodo` | 1719 KB (was 1714 KB pre-fix) | All Code Page-side fixes for #1/#5/#6 |
+| SpaarkeAi (embeds LW shell with widget) | `sprk_spaarkeai` | 3851 KB (was 3848 KB pre-fix) | All widget-side fixes for #1/#2/#3/#4/#5/#5a/#6 |
+| CreateTodoWizard Code Page | `sprk_createtodowizard` | 1617 KB | Wizard `@odata.bind` switched from `/systemusers(...)` to `/contacts(...)`; Assignee LookupField now searches OOB `contact` entity via `searchContactsAsLookup`; placeholder updated to "Search contacts..."; nav-prop discovery now matches `ReferencedEntity === 'contact'`. Without this redeploy, ANY new To Do created via the `+` wizard would FAIL with a Dataverse type-mismatch error. |
+
+### Pre-deploy verification
+
+- This worktree (`c:/code_files/spaarke-wt-smart-todo-r4`) on master tip `845521aaf` + uncommitted UAT-round-4 fixes
+- Vite cache cleared before SpaarkeAi build
+- Both Vite builds green: SmartTodo 1.76 MB / 476 KB gzip in 14.07s; SpaarkeAi 3.94 MB / 1.08 MB gzip in 14.86s
+- Schema verified via MCP `describe('tables/sprk_todo')`: `sprk_assignedto LOOKUP (GUID) ( Related table : contact)` ✓
+- User contact verified via MCP: `contactid=2e419a4f-010d-f111-8342-7ced8d1dc988, fullname="Ralph Schroeder", sprk_systemuser=1d02f31c-1872-f011-b4cb-7c1e52671ad0` ✓
+
+### Deploy results — both ✅
+
+- SmartTodo: "Publishing customizations... Published"
+- SpaarkeAi: "Publishing customizations... Published"
+
+### Status
+
+`in-progress` — fixes deployed but NOT user-verified. User to retest the 6 UAT items against new bundles. R4-098 wrap-up + final PR-close stay HELD until UAT signoff.
   </notes>
 </task>

--- a/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/WorkspaceLayoutWidget.tsx
+++ b/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/WorkspaceLayoutWidget.tsx
@@ -89,6 +89,13 @@ const useStyles = makeStyles({
   root: {
     flex: 1,
     minHeight: 0,
+    // UAT 2026-06-22 round 11: ADDED `height: 100%`. Console diagnostics
+    // confirmed this element's parent (a workspace tab content wrapper) is
+    // `display: block`, so the `flex: 1` here is ignored. Without
+    // `height: 100%` the widget root shrinks to content height (~600px)
+    // even when the parent has 900+ available pixels — capping the entire
+    // SectionPanel chain below.
+    height: '100%',
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden',

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/hooks/useCurrentContactId.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/hooks/useCurrentContactId.ts
@@ -1,16 +1,22 @@
 /**
- * useCurrentContactId — Resolve the current systemuser's sprk_contact GUID.
+ * useCurrentContactId — Resolve the current systemuser's OOB contact GUID.
  *
- * UAT 2026-06-19: `sprk_todo.sprk_assignedto` was migrated from a systemuser
- * lookup to a `sprk_contact` (custom Person table) lookup. The "Assigned to Me"
- * filter therefore needs the CONTACT GUID corresponding to the current user,
- * not their systemuser GUID.
+ * UAT 2026-06-20: `sprk_todo.sprk_assignedto` was migrated from a systemuser
+ * lookup to the OOB `contact` (Person) table. The OOB `contact` entity has
+ * been extended with a custom `sprk_systemuser` lookup pointing back to
+ * systemuser (relationship `sprk_SystemUser_SystemUser_Contact`). The
+ * "Assigned to Me" filter therefore needs the CONTACT GUID corresponding to
+ * the current user, not their systemuser GUID.
+ *
+ * IMPORTANT: This queries the OOB `contact` entity (NOT a custom `sprk_contact`
+ * entity — there is no such custom table). Fields used:
+ *   - `contactid` (PK)
+ *   - `fullname` (display name)
+ *   - `_sprk_systemuser_value` (OData filter form of `sprk_systemuser` lookup)
  *
  * Resolution flow (one query at mount):
- *   1. Query `sprk_contact` where `_sprk_systemuser_value eq <systemUserId>`
- *      (the sprk_contact table has a sprk_systemuser lookup pointing back
- *      to systemuser — relationship sprk_SystemUser_SystemUser_Contact).
- *   2. If exactly one match → return that contact's `sprk_contactid`.
+ *   1. Query `contact` where `_sprk_systemuser_value eq <systemUserId>`.
+ *   2. If exactly one match → return that contact's `contactid`.
  *   3. If zero matches → return null (user has no associated contact;
  *      surfaces should fall back to "no records" rather than filter by an
  *      invalid GUID).
@@ -23,7 +29,7 @@
  * when contactId resolves.
  *
  * @see sprk_todo.sprk_assignedto (Contact lookup) — the field this resolves for
- * @see sprk_contact.sprk_systemuser (SystemUser lookup) — the reverse relationship
+ * @see contact.sprk_systemuser (SystemUser lookup) — the reverse relationship
  */
 
 import * as React from 'react';
@@ -36,10 +42,10 @@ export interface IUseCurrentContactIdOptions {
 }
 
 export interface IUseCurrentContactIdResult {
-  /** The resolved sprk_contact GUID, or null when not found / still loading. */
+  /** The resolved contact GUID, or null when not found / still loading. */
   contactId: string | null;
-  /** UAT 2026-06-19 — the resolved contact's display name, for UI display (so
-   *  the user sees "Jane Doe" not a raw GUID). Null when not resolved. */
+  /** UAT 2026-06-20 — the resolved contact's display name (`fullname`), for UI
+   *  display so the user sees "Jane Doe" not a raw GUID. Null when not resolved. */
   contactName: string | null;
   /** True while the resolve query is in flight. */
   isLoading: boolean;
@@ -60,36 +66,38 @@ export function useCurrentContactId(options: IUseCurrentContactIdOptions): IUseC
     let cancelled = false;
     setIsLoading(true);
 
-    // Select sprk_name too so the UI can display the contact name in
-    // place of the raw GUID (e.g., quick-add "Assigned To" field).
-    const query = `?$select=sprk_contactid,sprk_name&$filter=_sprk_systemuser_value eq ${userId}&$top=2`;
+    // OOB `contact` entity. The relevant fields:
+    //   - `contactid` (PK)
+    //   - `fullname` (display name)
+    //   - `_sprk_systemuser_value` (OData form of the custom `sprk_systemuser` lookup)
+    const query = `?$select=contactid,fullname&$filter=_sprk_systemuser_value eq ${userId}&$top=2`;
 
     webApi
-      .retrieveMultipleRecords('sprk_contact', query)
+      .retrieveMultipleRecords('contact', query)
       .then(result => {
         if (cancelled) return;
-        const entities = (result.entities ?? []) as Array<{ sprk_contactid?: string; sprk_name?: string }>;
+        const entities = (result.entities ?? []) as Array<{ contactid?: string; fullname?: string }>;
         if (entities.length === 0) {
           // eslint-disable-next-line no-console
           console.warn(
-            `[useCurrentContactId] No sprk_contact found for systemuser ${userId}. "Assigned to Me" filter will return empty.`
+            `[useCurrentContactId] No contact found for systemuser ${userId}. "Assigned to Me" filter will return empty.`
           );
           setContactId(null);
           setContactName(null);
         } else {
           if (entities.length > 1) {
             // eslint-disable-next-line no-console
-            console.warn(`[useCurrentContactId] Multiple sprk_contact records for systemuser ${userId}; using first.`);
+            console.warn(`[useCurrentContactId] Multiple contact records for systemuser ${userId}; using first.`);
           }
-          setContactId(entities[0].sprk_contactid ?? null);
-          setContactName(entities[0].sprk_name ?? null);
+          setContactId(entities[0].contactid ?? null);
+          setContactName(entities[0].fullname ?? null);
         }
         setIsLoading(false);
       })
       .catch((err: Error) => {
         if (cancelled) return;
         // eslint-disable-next-line no-console
-        console.warn('[useCurrentContactId] sprk_contact resolve failed:', err);
+        console.warn('[useCurrentContactId] contact resolve failed:', err);
         setContactId(null);
         setContactName(null);
         setIsLoading(false);

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/hooks/useKanbanColumns.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/hooks/useKanbanColumns.ts
@@ -117,11 +117,37 @@ function computeTodoScore(todo: IKanbanTodoLike): number {
 // no-mutation render path that doesn't need stateful overrides).
 // ---------------------------------------------------------------------------
 
-/** Determine which column an unpinned item belongs to based on its To Do Score. */
-function assignColumnByScore(todo: IKanbanTodoLike, todayThreshold: number, tomorrowThreshold: number): TodoColumn {
-  const score = computeTodoScore(todo);
-  if (score >= todayThreshold) return 'Today';
-  if (score >= tomorrowThreshold) return 'Tomorrow';
+/**
+ * UAT 2026-06-21 — bucket by DUE DATE, not score.
+ *
+ * The column names (Today / Tomorrow / Future) are date concepts; the
+ * previous score-based bucketing produced confusing UX where high-priority
+ * items with far-out due dates landed in "Today" while low-priority items
+ * due today landed in "Future". Per user UAT round 5, bucketing now uses
+ * sprk_duedate directly:
+ *   - Today    = due today OR overdue (no due date counts as Future)
+ *   - Tomorrow = due tomorrow
+ *   - Future   = due day-after-tomorrow or later, OR no due date set
+ *
+ * Score is still computed (see `computeTodoScore`) and used as the within-
+ * column sort key — high-score items surface to the top of their bucket.
+ *
+ * Threshold args are kept on the function signature for back-compat with
+ * existing call sites but are no longer consulted. Plan to remove in a
+ * follow-up cleanup task once all callers update.
+ */
+function assignColumnByDate(todo: IKanbanTodoLike): TodoColumn {
+  const due = parseDueDate(todo.sprk_duedate);
+  if (!due) return 'Future';
+  // Compare day boundaries in LOCAL time so "today" matches the user's
+  // calendar, not UTC.
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const dueDay = new Date(due.getFullYear(), due.getMonth(), due.getDate());
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const diffDays = Math.round((dueDay.getTime() - today.getTime()) / msPerDay);
+  if (diffDays <= 0) return 'Today'; // due today OR overdue
+  if (diffDays === 1) return 'Tomorrow';
   return 'Future';
 }
 
@@ -146,9 +172,9 @@ function pinnedColumnAsNumber(value: number | string | null | undefined): number
 function resolveColumn(todo: IKanbanTodoLike, todayThreshold: number, tomorrowThreshold: number): TodoColumn {
   const pinnedChoice = pinnedColumnAsNumber(todo.sprk_todocolumn);
   if (todo.sprk_todopinned && pinnedChoice != null) {
-    return CHOICE_TO_COLUMN[pinnedChoice] ?? assignColumnByScore(todo, todayThreshold, tomorrowThreshold);
+    return CHOICE_TO_COLUMN[pinnedChoice] ?? assignColumnByDate(todo);
   }
-  return assignColumnByScore(todo, todayThreshold, tomorrowThreshold);
+  return assignColumnByDate(todo);
 }
 
 /**
@@ -192,7 +218,8 @@ export function bucketTodoItems<T extends IKanbanTodoLike>(
     {
       id: 'Today',
       title: 'Today',
-      subtitle: `Score ≥ ${todayThreshold}`,
+      // UAT 2026-06-21 — date-based bucketing; subtitle reflects new meaning
+      subtitle: 'Due today or overdue',
       items: today,
       accentColor: tokens.colorPaletteRedBorder2,
       tintColor: tokens.colorPaletteRedBackground1,
@@ -200,7 +227,7 @@ export function bucketTodoItems<T extends IKanbanTodoLike>(
     {
       id: 'Tomorrow',
       title: 'Tomorrow',
-      subtitle: `Score ${tomorrowThreshold}–${todayThreshold - 1}`,
+      subtitle: 'Due tomorrow',
       items: tomorrow,
       // 2026-06-19 UAT: yellow accent (not orange/red) per user feedback —
       // matches the yellow tint background; cards inherit this for left-border.
@@ -213,7 +240,7 @@ export function bucketTodoItems<T extends IKanbanTodoLike>(
     {
       id: 'Future',
       title: 'Future',
-      subtitle: `Score < ${tomorrowThreshold}`,
+      subtitle: 'Due later or undated',
       items: future,
       accentColor: tokens.colorPaletteGreenBorder2,
       tintColor: tokens.colorPaletteGreenBackground1,
@@ -464,7 +491,7 @@ export function useKanbanColumns<T extends IKanbanTodoLike>(
     for (const item of effectiveItems) {
       if (item.sprk_todopinned) continue;
 
-      const computedColumn = assignColumnByScore(item, todayThreshold, tomorrowThreshold);
+      const computedColumn = assignColumnByDate(item);
       const computedChoice = COLUMN_TO_CHOICE[computedColumn];
       const currentChoice = pinnedColumnAsNumber(item.sprk_todocolumn);
 

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
@@ -362,13 +362,13 @@ export const useSmartTodoWidgetStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     flex: '1 1 0',
-    // UAT 2026-06-21 round 6: removed the artificial `minHeight: max(400px,
-    // 60vh)` floor that was preventing pure responsive fill. The parent
-    // chain (SectionPanel.card height → SectionPanel.content flex → widget
-    // root height:100% → kanbanContainer flex:1 1 0) now correctly lets the
-    // container size to the section's available space. The 400px floor is
-    // kept only as a hard minimum so the kanban never collapses to nothing.
-    minHeight: '400px',
+    // UAT 2026-06-21 round 7: dropped all floor constraints. With the
+    // SectionPanel.card { height: 100% } + WorkspaceShell.row { flex: 1 1 0
+    // } structural fix in place, the parent chain now reliably delivers
+    // the full workspace pane height to this container. `minHeight: 0` is
+    // required to allow the container to shrink in tight viewports without
+    // pushing the toolbar / title row above it offscreen.
+    minHeight: 0,
     minWidth: 0,
   },
 

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
@@ -319,6 +319,15 @@ export const useSmartTodoWidgetStyles = makeStyles({
 
   /** Scrollable body — owns internal scroll for the cards list. */
   body: {
+    // UAT 2026-06-22 round 11: ADDED `display: flex, flexDirection: column`.
+    // Without these, this div is `display: block` (the div default), and its
+    // child (the kanbanContainer with `flex: 1 1 auto`) cannot use flex to
+    // claim height — falling back to content height = the kanban's 400px
+    // min-height floor. Console diagnostics confirmed this is the ONE break
+    // in the height chain that was capping the widget at ~400px even when
+    // the SectionPanel had 900+ available pixels.
+    display: 'flex',
+    flexDirection: 'column',
     flex: '1 1 auto',
     minHeight: 0,
     overflowY: 'auto',

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
@@ -362,15 +362,11 @@ export const useSmartTodoWidgetStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     flex: '1 1 auto',
-    // UAT 2026-06-21 round 8: matching the working pattern from
-    // CalendarWorkspaceWidget (`gridContainer: flex 1 1 auto, minHeight 0`)
-    // and DailyBriefingApp (`scrollContent: flex 1`). `minHeight: 0` is
-    // critical — it lets this flex child shrink BELOW its content's
-    // intrinsic size when the parent has constrained height, instead of
-    // pushing the toolbar above it offscreen. Combined with the section's
-    // `minHeight: auto` (no inline height cap), the kanban now claims the
-    // full SectionPanel content area like Daily Briefing/Calendar do.
-    minHeight: 0,
+    // UAT 2026-06-22 round 9 (REVERT round 8): restoring the defensive
+    // 400px floor so the kanban renders even when the parent section's
+    // calc(100vh-200px) height supplies less than expected. minHeight 0
+    // exposed a collapse bug when the parent chain wasn't reliable.
+    minHeight: '400px',
     minWidth: 0,
   },
 

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
@@ -361,13 +361,16 @@ export const useSmartTodoWidgetStyles = makeStyles({
   kanbanContainer: {
     display: 'flex',
     flexDirection: 'column',
-    flex: '1 1 0',
-    // UAT 2026-06-21 round 7 REVERT: structural fix above was reverted —
-    // restoring the defensive 400px floor so the kanban never collapses
-    // to nothing if the parent chain delivers 0. The per-section
-    // `style: { height: 'calc(100vh - 200px)' }` in workspaceConfig is
-    // the actual height-supply for now.
-    minHeight: '400px',
+    flex: '1 1 auto',
+    // UAT 2026-06-21 round 8: matching the working pattern from
+    // CalendarWorkspaceWidget (`gridContainer: flex 1 1 auto, minHeight 0`)
+    // and DailyBriefingApp (`scrollContent: flex 1`). `minHeight: 0` is
+    // critical — it lets this flex child shrink BELOW its content's
+    // intrinsic size when the parent has constrained height, instead of
+    // pushing the toolbar above it offscreen. Combined with the section's
+    // `minHeight: auto` (no inline height cap), the kanban now claims the
+    // full SectionPanel content area like Daily Briefing/Calendar do.
+    minHeight: 0,
     minWidth: 0,
   },
 

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
@@ -170,6 +170,74 @@ export const useSmartTodoWidgetStyles = makeStyles({
   },
 
   /**
+   * UAT 2026-06-20 round 4 — Typeahead container for the inline Assigned To
+   * input. Wraps the Input + the floating results dropdown so the dropdown
+   * positions relative to the input.
+   */
+  assignedToWrap: {
+    position: 'relative',
+    flex: '0 1 220px',
+    minWidth: '140px',
+  },
+
+  /** Results dropdown — absolutely positioned just below the Assigned To input. */
+  assignedToResults: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    right: 0,
+    zIndex: 50,
+    marginTop: '2px',
+    maxHeight: '220px',
+    overflowY: 'auto',
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderTopWidth: '1px',
+    borderRightWidth: '1px',
+    borderBottomWidth: '1px',
+    borderLeftWidth: '1px',
+    borderTopStyle: 'solid',
+    borderRightStyle: 'solid',
+    borderBottomStyle: 'solid',
+    borderLeftStyle: 'solid',
+    borderTopColor: tokens.colorNeutralStroke2,
+    borderRightColor: tokens.colorNeutralStroke2,
+    borderBottomColor: tokens.colorNeutralStroke2,
+    borderLeftColor: tokens.colorNeutralStroke2,
+    borderTopLeftRadius: tokens.borderRadiusMedium,
+    borderTopRightRadius: tokens.borderRadiusMedium,
+    borderBottomLeftRadius: tokens.borderRadiusMedium,
+    borderBottomRightRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow8,
+  },
+
+  /** Each search result row in the Assigned To dropdown. */
+  assignedToResultItem: {
+    display: 'block',
+    width: '100%',
+    textAlign: 'left',
+    padding: `${tokens.spacingVerticalXS} ${tokens.spacingHorizontalSNudge}`,
+    backgroundColor: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground1,
+    ':hover': {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+    },
+    ':focus': {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+      outlineStyle: 'none',
+    },
+  },
+
+  /** Empty / no-results / loading state inside the Assigned To dropdown. */
+  assignedToResultsHint: {
+    padding: `${tokens.spacingVerticalXS} ${tokens.spacingHorizontalSNudge}`,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+
+  /**
    * UAT 2026-06-19 — Inline filter SearchBox shown in the right toolbar
    * cluster when Filter is active. Takes the horizontal space that the
    * action buttons (Open/Refresh/Orient) normally occupy.

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
@@ -362,7 +362,13 @@ export const useSmartTodoWidgetStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     flex: '1 1 0',
-    minHeight: 'max(400px, 60vh)',
+    // UAT 2026-06-21 round 6: removed the artificial `minHeight: max(400px,
+    // 60vh)` floor that was preventing pure responsive fill. The parent
+    // chain (SectionPanel.card height → SectionPanel.content flex → widget
+    // root height:100% → kanbanContainer flex:1 1 0) now correctly lets the
+    // container size to the section's available space. The 400px floor is
+    // kept only as a hard minimum so the kanban never collapses to nothing.
+    minHeight: '400px',
     minWidth: 0,
   },
 

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.styles.ts
@@ -362,13 +362,12 @@ export const useSmartTodoWidgetStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     flex: '1 1 0',
-    // UAT 2026-06-21 round 7: dropped all floor constraints. With the
-    // SectionPanel.card { height: 100% } + WorkspaceShell.row { flex: 1 1 0
-    // } structural fix in place, the parent chain now reliably delivers
-    // the full workspace pane height to this container. `minHeight: 0` is
-    // required to allow the container to shrink in tight viewports without
-    // pushing the toolbar / title row above it offscreen.
-    minHeight: 0,
+    // UAT 2026-06-21 round 7 REVERT: structural fix above was reverted —
+    // restoring the defensive 400px floor so the kanban never collapses
+    // to nothing if the parent chain delivers 0. The per-section
+    // `style: { height: 'calc(100vh - 200px)' }` in workspaceConfig is
+    // the actual height-supply for now.
+    minHeight: '400px',
     minWidth: 0,
   },
 

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
@@ -749,7 +749,14 @@ export const SmartTodoWidget: React.FC<SmartTodoWidgetProps> = ({
     const assignedToContactId =
       quickAddAssignedTo.trim() && quickAddAssignedToContactId ? quickAddAssignedToContactId : contactId || '';
     if (assignedToContactId) {
-      payload['sprk_assignedto@odata.bind'] = `/contacts(${assignedToContactId})`;
+      // UAT 2026-06-22 round 13: bind key MUST be the navigation property
+      // name (PascalCase `sprk_AssignedTo`), not the lookup column logical
+      // name (lowercase `sprk_assignedto`). Dataverse rejects the lowercase
+      // form with: "An undeclared property 'sprk_assignedto' which only has
+      // property annotations in the payload but no property value was
+      // found in the payload." Verified via EntityDefinitions metadata:
+      // ReferencingEntityNavigationPropertyName = "sprk_AssignedTo".
+      payload['sprk_AssignedTo@odata.bind'] = `/contacts(${assignedToContactId})`;
     }
     if (quickAddDueDate) {
       // Date input gives YYYY-MM-DD; treat as end-of-day local.

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
@@ -142,21 +142,27 @@ const SEARCH_DEBOUNCE_MS = 150;
 /**
  * Build the active-todo $select+$filter query targeting `sprk_todo`.
  *
- * Per R4 spec FR-02 + UAT 2026-06-19 assigned-to migration:
+ * Per R4 spec FR-02 + UAT 2026-06-20 assigned-to migration:
  *   - statecode eq 0
  *   - statuscode in (Open, In Progress)
  *   - regarding context filter (when supplied)
  *   - assignee filter (when supplied and no regarding context) —
- *     `_sprk_assignedto_value` is now a CONTACT lookup (was systemuser).
- *     Callers must resolve their systemuser → sprk_contact via
- *     useCurrentContactId hook and pass `contactId` here. Passing a raw
- *     systemuser GUID will produce zero matches.
+ *     `_sprk_assignedto_value` is now an OOB **contact** lookup (was systemuser).
+ *     Callers must resolve their systemuser → contact via useCurrentContactId
+ *     hook and pass `contactId` here. Passing a raw systemuser GUID will
+ *     produce zero matches.
+ *
+ * SECURITY (UAT 2026-06-20): when there is NO regarding context AND NO
+ * contactId (e.g., user has no contact link), returns a query that yields
+ * **zero rows** — NOT a fallback to all active sprk_todos system-wide.
+ * Showing other people's todos to an unauthenticated/unresolved user is a
+ * data-isolation breach. The caller surfaces "no records" instead.
  *
  * Zero `sprk_event` references. Zero `sprk_todoflag` references.
  */
 export function buildSmartTodoQuery(opts: {
   regardingContext?: IRegardingContext | null;
-  /** sprk_contact GUID — the current user's contact, NOT systemuser GUID. */
+  /** Contact GUID — the current user's contact (OOB), NOT systemuser GUID. */
   contactId?: string;
   businessUnitId?: string;
   scope?: 'my' | 'all';
@@ -198,7 +204,12 @@ export function buildSmartTodoQuery(opts: {
     contextClause = `_sprk_assignedto_value eq ${opts.contactId}`;
   }
 
-  const filter = contextClause ? `${contextClause} and ${activeClause}` : activeClause;
+  // SECURITY: if no context clause was built (no regarding AND no contactId),
+  // force a zero-row filter rather than returning all active todos. See the
+  // SECURITY note in buildSmartTodoQuery's docblock.
+  const filter = contextClause
+    ? `${contextClause} and ${activeClause}`
+    : `sprk_todoid eq 00000000-0000-0000-0000-000000000000`;
   const orderby = 'sprk_priorityscore desc,sprk_duedate asc';
 
   return `?$select=${select}&$filter=${encodeURIComponent(filter)}&$orderby=${encodeURIComponent(orderby)}&$top=${top}`;
@@ -359,9 +370,13 @@ export const SmartTodoWidget: React.FC<SmartTodoWidgetProps> = ({
   // multiple workspace contexts and forcing per-context Dataverse round-trips
   // would inflate cold-start time. The Code Page (which is the user's "Smart
   // To Do home") persists orientation via `useUserPreferences` (R4-071) —
-  // that's the canonical persistence point. Default 'horizontal' matches the
-  // Code Page default + the original app behaviour.
-  const [orientation, setOrientation] = React.useState<Orientation>('horizontal');
+  // that's the canonical persistence point.
+  //
+  // UAT 2026-06-20: WIDGET default is 'vertical' (Today on top, Tomorrow in
+  // middle, Future on bottom — stacked rows). This matches the widget's
+  // typical narrow workspace pane. The Code Page default remains
+  // 'horizontal' (columns side-by-side) because it gets full viewport width.
+  const [orientation, setOrientation] = React.useState<Orientation>('vertical');
 
   // SearchBox — local controlled value debounced into `appliedQuery` which
   // drives the in-memory filter.
@@ -420,9 +435,18 @@ export const SmartTodoWidget: React.FC<SmartTodoWidgetProps> = ({
   const { contactId, contactName, isLoading: isContactLoading } = useCurrentContactId({ webApi, userId });
 
   // Track the resolved contact GUID separately from the user-visible name.
-  // Display = name; internal payload = GUID. User can clear the field to
-  // unassign, or in a future iteration we can wire a real lookup picker.
+  // Display = name; internal payload = GUID. Selection comes from the
+  // typeahead dropdown below (UAT 2026-06-20 round 4 — replaced the plain
+  // Input with a search-as-you-type contact picker).
   const [quickAddAssignedToContactId, setQuickAddAssignedToContactId] = React.useState<string>('');
+
+  // UAT 2026-06-20 round 4 — typeahead state for the Assigned To picker.
+  // Search the OOB `contact` entity by fullname; user picks from a small
+  // floating result list. Selection sets BOTH the display name AND the
+  // internal contactId used for the @odata.bind on quick-add submit.
+  const [assignedToResults, setAssignedToResults] = React.useState<Array<{ id: string; name: string }>>([]);
+  const [isSearchingContacts, setIsSearchingContacts] = React.useState<boolean>(false);
+  const [showAssignedToResults, setShowAssignedToResults] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     // Track the contactId internally for the bind, but DON'T pre-fill the
@@ -627,9 +651,82 @@ export const SmartTodoWidget: React.FC<SmartTodoWidgetProps> = ({
   const handleQuickAddAssignedToChange = React.useCallback(
     (_e: React.ChangeEvent<HTMLInputElement>, data: { value: string }) => {
       setQuickAddAssignedTo(data.value);
+      // Typing changes the display string; previous selection's contactId
+      // is no longer valid unless the user picks again or the text exactly
+      // re-matches. Clear it to avoid silently binding the wrong contact.
+      if (data.value.trim() === '') {
+        setQuickAddAssignedToContactId(contactId ?? '');
+      } else {
+        setQuickAddAssignedToContactId('');
+      }
     },
-    []
+    [contactId]
   );
+
+  // UAT 2026-06-20 round 4 — debounced typeahead search of the OOB `contact`
+  // entity. Fires when the user types 2+ chars, queries `contains(fullname,
+  // '<q>')`, and surfaces up to 8 matches in a dropdown. On selection, sets
+  // both the visible name AND the internal contactId.
+  React.useEffect(() => {
+    const q = quickAddAssignedTo.trim();
+    if (q.length < 2 || !webApi.retrieveMultipleRecords) {
+      setAssignedToResults([]);
+      setShowAssignedToResults(false);
+      setIsSearchingContacts(false);
+      return;
+    }
+    // If the current text exactly matches the previously selected name, no
+    // need to re-query (avoids the user's selection getting wiped on focus).
+    if (contactName && q === contactName.trim()) {
+      setShowAssignedToResults(false);
+      return;
+    }
+    let cancelled = false;
+    setIsSearchingContacts(true);
+    const handle = window.setTimeout(() => {
+      // OData single-quote escape (' → '') is required to keep the filter
+      // valid when a user types a name with an apostrophe.
+      const escaped = q.replace(/'/g, "''");
+      const url = `?$select=contactid,fullname&$filter=statecode eq 0 and contains(fullname,'${encodeURIComponent(escaped)}')&$top=8&$orderby=fullname asc`;
+      webApi.retrieveMultipleRecords!('contact', url)
+        .then(result => {
+          if (cancelled) return;
+          const entities = (result.entities ?? []) as Array<{ contactid?: string; fullname?: string }>;
+          const mapped = entities
+            .filter(e => !!e.contactid && !!e.fullname)
+            .map(e => ({ id: e.contactid as string, name: e.fullname as string }));
+          setAssignedToResults(mapped);
+          setShowAssignedToResults(true);
+          setIsSearchingContacts(false);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setAssignedToResults([]);
+          setShowAssignedToResults(false);
+          setIsSearchingContacts(false);
+        });
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [quickAddAssignedTo, webApi, contactName]);
+
+  const handleSelectAssignedTo = React.useCallback((id: string, name: string) => {
+    setQuickAddAssignedTo(name);
+    setQuickAddAssignedToContactId(id);
+    setShowAssignedToResults(false);
+  }, []);
+
+  const handleAssignedToBlur = React.useCallback(() => {
+    // Hide on blur, but defer so a click on a result still registers (click
+    // fires after blur in some browsers).
+    window.setTimeout(() => setShowAssignedToResults(false), 150);
+  }, []);
+
+  const handleAssignedToFocus = React.useCallback(() => {
+    if (assignedToResults.length > 0) setShowAssignedToResults(true);
+  }, [assignedToResults.length]);
 
   const submitQuickAdd = React.useCallback(async () => {
     const title = quickAddTitle.trim();
@@ -642,20 +739,17 @@ export const SmartTodoWidget: React.FC<SmartTodoWidgetProps> = ({
     setIsQuickAdding(true);
     setQuickAddError(null);
 
-    // Build payload from the three-field quick-add. Per UAT 2026-06-19
-    // assigned-to migration, `sprk_assignedto` now targets sprk_contact
-    // (NOT systemuser). Bind format must use `/sprk_contacts(GUID)` and
-    // the GUID must be a sprk_contact ID — for "assigned to me" we use the
-    // resolved contactId from useCurrentContactId. The quickAddAssignedTo
-    // text field can override (when user types a different contact GUID).
+    // Build payload from the three-field quick-add. Per UAT 2026-06-20
+    // assigned-to migration, `sprk_assignedto` targets the OOB `contact`
+    // entity (NOT systemuser, NOT a custom sprk_contact). Bind set name is
+    // `contacts`. For "assigned to me" we use the resolved contactId from
+    // useCurrentContactId. The quickAddAssignedTo picker overrides when the
+    // user selects a different contact.
     const payload: Record<string, unknown> = { sprk_name: title };
-    // Use the internal contactId (not the display name) for the bind. If the
-    // user has cleared the Assigned To name field, fall back to contactId
-    // (still assigns to current user); if they cleared both, leave unassigned.
     const assignedToContactId =
       quickAddAssignedTo.trim() && quickAddAssignedToContactId ? quickAddAssignedToContactId : contactId || '';
     if (assignedToContactId) {
-      payload['sprk_assignedto@odata.bind'] = `/sprk_contacts(${assignedToContactId})`;
+      payload['sprk_assignedto@odata.bind'] = `/contacts(${assignedToContactId})`;
     }
     if (quickAddDueDate) {
       // Date input gives YYYY-MM-DD; treat as end-of-day local.
@@ -841,15 +935,48 @@ export const SmartTodoWidget: React.FC<SmartTodoWidgetProps> = ({
                 aria-label="Due date"
                 className={styles.quickAddDateInput}
               />
-              <Input
-                size="small"
-                value={quickAddAssignedTo}
-                onChange={handleQuickAddAssignedToChange}
-                placeholder="Assigned to"
-                disabled={isQuickAdding}
-                aria-label="Assigned to"
-                className={styles.quickAddAssignedInput}
-              />
+              <div className={styles.assignedToWrap}>
+                <Input
+                  size="small"
+                  value={quickAddAssignedTo}
+                  onChange={handleQuickAddAssignedToChange}
+                  onFocus={handleAssignedToFocus}
+                  onBlur={handleAssignedToBlur}
+                  placeholder="Assigned to"
+                  disabled={isQuickAdding}
+                  aria-label="Assigned to"
+                  aria-autocomplete="list"
+                  aria-expanded={showAssignedToResults}
+                  aria-controls="smart-todo-widget-assignedto-results"
+                  role="combobox"
+                />
+                {showAssignedToResults && (
+                  <div id="smart-todo-widget-assignedto-results" role="listbox" className={styles.assignedToResults}>
+                    {isSearchingContacts && <div className={styles.assignedToResultsHint}>Searching…</div>}
+                    {!isSearchingContacts && assignedToResults.length === 0 && (
+                      <div className={styles.assignedToResultsHint}>No contacts found</div>
+                    )}
+                    {!isSearchingContacts &&
+                      assignedToResults.map(c => (
+                        <button
+                          key={c.id}
+                          type="button"
+                          role="option"
+                          aria-selected={c.id === quickAddAssignedToContactId}
+                          className={styles.assignedToResultItem}
+                          // onMouseDown beats onBlur so the click registers
+                          // before the dropdown closes.
+                          onMouseDown={e => {
+                            e.preventDefault();
+                            handleSelectAssignedTo(c.id, c.name);
+                          }}
+                        >
+                          {c.name}
+                        </button>
+                      ))}
+                  </div>
+                )}
+              </div>
               <Tooltip content="Add to-do (Enter)" relationship="label">
                 <Button
                   appearance="primary"

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/CreateTodoStep.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/CreateTodoStep.tsx
@@ -7,7 +7,8 @@
  *   - Due Date      (optional, sprk_duedate)
  *   - Priority Score (0-100 slider, sprk_priorityscore)
  *   - Effort Score   (0-100 slider, sprk_effortscore)
- *   - Assignee      (optional, systemuser lookup → sprk_assignedto)
+ *   - Assignee      (optional, OOB contact lookup → sprk_assignedto)
+ *                   UAT 2026-06-21: migrated from systemuser to contact
  *   - Notes         (optional, multi-line, sprk_notes)
  *
  * Per smart-todo-decoupling-r3 spec FR-15: This form writes to `sprk_todo`,
@@ -30,7 +31,12 @@ import type { ILookupItem } from '../../types/LookupTypes';
 
 export interface ICreateTodoStepProps {
   dataService: IDataService;
-  /** Search callback for systemuser assignee lookup. */
+  /**
+   * Search callback for the Assignee LookupField. Should return matching
+   * OOB `contact` records (UAT 2026-06-21 — `sprk_assignedto` migrated from
+   * systemuser to contact). Prop name retained for back-compat with the
+   * generic CreateRecordWizard pattern.
+   */
   onSearchUsers: (query: string) => Promise<ILookupItem[]>;
   onValidChange: (isValid: boolean) => void;
   onFormValues: (values: ICreateTodoFormState) => void;
@@ -154,7 +160,7 @@ export const CreateTodoStep: React.FC<ICreateTodoStepProps> = ({
           value={assigneeValue}
           onChange={handleAssigneeChange}
           onSearch={onSearchUsers}
-          placeholder="Search users..."
+          placeholder="Search contacts..."
         />
       </div>
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/TodoWizardDialog.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/TodoWizardDialog.tsx
@@ -174,7 +174,12 @@ const TodoWizardDialog: React.FC<ICreateTodoWizardProps> = ({
         renderContent: _wizardFiles => (
           <CreateTodoStep
             dataService={dataService}
-            onSearchUsers={handleSearchUsers}
+            // UAT 2026-06-21 — sprk_todo.sprk_assignedto migrated to a Contact
+            // lookup. The wizard's Assignee picker now searches the OOB
+            // `contact` entity (not systemuser) so the selected GUID matches
+            // the lookup's target. Prop name kept as `onSearchUsers` for back-
+            // compat with the existing CreateTodoStep signature.
+            onSearchUsers={handleSearchContacts}
             onValidChange={setFormValid}
             onFormValues={setFormValues}
             initialFormValues={formValues}

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/__tests__/todoService.test.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/__tests__/todoService.test.ts
@@ -87,11 +87,11 @@ const NAV_PROPS_RESPONSE = {
       ReferencingEntityNavigationPropertyName: 'sprk_RegardingRecordType',
       ReferencedEntity: 'sprk_recordtype_ref',
     },
-    // Assignee
+    // Assignee — UAT 2026-06-21: migrated from systemuser to OOB contact lookup
     {
       ReferencingAttribute: 'sprk_assignedto',
       ReferencingEntityNavigationPropertyName: 'sprk_AssignedTo',
-      ReferencedEntity: 'systemuser',
+      ReferencedEntity: 'contact',
     },
   ],
 };
@@ -242,13 +242,14 @@ describe('TodoService.createTodo', () => {
 
     await service.createTodo({
       ...FORM_VALUES,
-      assignedToId: 'user-guid-123',
+      assignedToId: 'contact-guid-123',
       assignedToName: 'Jane Doe',
     });
 
     const [, payload] = dataService.createRecord.mock.calls[0] as [string, Record<string, unknown>];
-    // Discovered nav-prop is sprk_AssignedTo
-    expect(payload['sprk_AssignedTo@odata.bind']).toBe('/systemusers(user-guid-123)');
+    // Discovered nav-prop is sprk_AssignedTo; bind targets the OOB contact entity
+    // (UAT 2026-06-21 migration — was /systemusers pre-migration)
+    expect(payload['sprk_AssignedTo@odata.bind']).toBe('/contacts(contact-guid-123)');
   });
 
   // -----------------------------------------------------------------

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/todoService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/todoService.ts
@@ -140,22 +140,26 @@ export class TodoService {
     entity['sprk_priorityscore'] = formValues.priorityScore;
     entity['sprk_effortscore'] = formValues.effortScore;
 
-    // 2. Assignee lookup (sprk_assignedto → systemuser)
+    // 2. Assignee lookup (sprk_assignedto → contact). UAT 2026-06-21:
+    //    sprk_todo.sprk_assignedto was migrated from a systemuser lookup to
+    //    the OOB `contact` (Person) entity. The wizard's Assignee picker
+    //    now feeds a CONTACT GUID via `searchContactsAsLookup`. Bind set
+    //    name is `contacts` (plural of the OOB contact table).
     if (formValues.assignedToId) {
       try {
         const navProps = await _discoverNavProps('sprk_todo');
         const assignedNav = navProps.find(
-          n => n.referencedEntity === 'systemuser' && n.columnName.toLowerCase().includes('assignedto')
+          n => n.referencedEntity === 'contact' && n.columnName.toLowerCase().includes('assignedto')
         );
         if (assignedNav) {
-          entity[`${assignedNav.navPropName}@odata.bind`] = `/systemusers(${formValues.assignedToId})`;
+          entity[`${assignedNav.navPropName}@odata.bind`] = `/contacts(${formValues.assignedToId})`;
         } else {
           // Fallback: use the lookup attribute name directly
-          entity['sprk_assignedto@odata.bind'] = `/systemusers(${formValues.assignedToId})`;
+          entity['sprk_assignedto@odata.bind'] = `/contacts(${formValues.assignedToId})`;
         }
       } catch (err) {
         console.warn('[TodoService] Failed to resolve sprk_assignedto nav-prop, using fallback:', err);
-        entity['sprk_assignedto@odata.bind'] = `/systemusers(${formValues.assignedToId})`;
+        entity['sprk_assignedto@odata.bind'] = `/contacts(${formValues.assignedToId})`;
       }
     }
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/todoService.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/CreateTodoWizard/todoService.ts
@@ -155,11 +155,13 @@ export class TodoService {
           entity[`${assignedNav.navPropName}@odata.bind`] = `/contacts(${formValues.assignedToId})`;
         } else {
           // Fallback: use the lookup attribute name directly
-          entity['sprk_assignedto@odata.bind'] = `/contacts(${formValues.assignedToId})`;
+          // UAT 2026-06-22 round 13: PascalCase nav-prop name required
+          entity['sprk_AssignedTo@odata.bind'] = `/contacts(${formValues.assignedToId})`;
         }
       } catch (err) {
         console.warn('[TodoService] Failed to resolve sprk_assignedto nav-prop, using fallback:', err);
-        entity['sprk_assignedto@odata.bind'] = `/contacts(${formValues.assignedToId})`;
+        // UAT 2026-06-22 round 13: PascalCase nav-prop name required
+        entity['sprk_AssignedTo@odata.bind'] = `/contacts(${formValues.assignedToId})`;
       }
     }
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/Kanban/KanbanBoard.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/Kanban/KanbanBoard.tsx
@@ -44,16 +44,22 @@ const useStyles = makeStyles({
     // guarantee the board fills its container's cross-axis. Without these,
     // some host layouts (Griffel-nested flex chains, SectionPanel) computed
     // the board at half the container width and clipped Tomorrow + Future
-    // columns via `overflow: hidden`. The user's decision (2026-06-19):
-    // horizontal mode = ALWAYS fit all 3 columns to container, no
-    // horizontal scroll. Columns themselves shrink via `flex: 1 1 0 /
-    // minWidth: 0 / overflow: hidden` so cards ellipsis-truncate cleanly
-    // in narrow widgets.
+    // columns via `overflow: hidden`.
+    //
+    // UAT 2026-06-20 round 4: replaced `overflow: hidden` with
+    // `overflowX: auto` + `overflowY: hidden`. In narrow workspace panes the
+    // 3 columns + gap can still exceed available width even with `flex: 1 1
+    // 0 / minWidth: 0` (because card content + padding sets an intrinsic
+    // floor). Without horizontal scroll the rightmost column (Future) was
+    // CLIPPED — invisible to the user. Now: columns still shrink to fit when
+    // possible; when they can't, the user can scroll horizontally to reveal
+    // them. Vertical orientation overrides via `boardVertical`.
     width: '100%',
     alignSelf: 'stretch',
     minHeight: 0,
     minWidth: 0,
-    overflow: 'hidden',
+    overflowX: 'auto',
+    overflowY: 'hidden',
     // FR-29 / NFR-08 — smooth row↔column flip (CSS-only). Honour
     // prefers-reduced-motion by snapping with zero transition.
     transitionProperty: 'gap',
@@ -257,16 +263,22 @@ function KanbanBoardInner<T>(props: IKanbanBoardProps<T>, _ref: React.Ref<HTMLDi
 
           // UAT 2026-06-20 — Single container for both expanded AND collapsed.
           // Same column classname/layout in both states; only the droppable
-          // card list area is conditional. This fixes two issues:
+          // card list area is conditional. This fixes three issues:
           //   1. Vertical mode collapsed: column inherits columnVertical's
           //      `flex: 0 0 auto` so it sizes to its content (just the header
           //      = ~44px), instead of growing via the prior `columnCollapsed`
           //      `flex: 1 1 0` which fell through unstyled in vertical parents.
-          //   2. Horizontal mode collapsed: `alignSelf: flex-start` opts out
-          //      of the cross-axis stretch default so the column height
-          //      collapses to header height. Other expanded siblings still
-          //      stretch to board height normally.
-          const collapsedHorizontalInline = isCollapsed && !isVertical ? { alignSelf: 'flex-start' as const } : {};
+          //   2. Horizontal mode collapsed CROSS-axis: `alignSelf: flex-start`
+          //      opts out of the cross-axis stretch default so the column
+          //      height collapses to header height. Other expanded siblings
+          //      still stretch to board height normally.
+          //   3. Horizontal mode collapsed INLINE-axis (UAT 2026-06-20 round 4):
+          //      override base column `flex: 1 1 0` with `flex: 0 0 auto` so
+          //      the column width shrinks to header content instead of
+          //      equal-sharing with expanded siblings. Result: a thin "tab"
+          //      strip the user can click to re-expand.
+          const collapsedHorizontalInline =
+            isCollapsed && !isVertical ? { alignSelf: 'flex-start' as const, flex: '0 0 auto' as const } : {};
 
           return (
             <div

--- a/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/SectionPanel.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/SectionPanel.tsx
@@ -86,6 +86,18 @@ const useStyles = makeStyles({
     // win. Same fix pattern as in DataGrid root/innerCard/gridScroll +
     // DataverseEntityViewWidget root — this completes the chain.
     minWidth: 0,
+    // smart-todo-r4 UAT round 7 (2026-06-21): make the card actually claim
+    // its parent grid cell's full height by default. Without this, the
+    // card defaults to intrinsic content height — which forces every
+    // embedded widget to either hard-code a per-section
+    // `style: { height: '560px' }` (the legacy workaround) or live with a
+    // ~content-height container that doesn't fill the Workspace pane.
+    //
+    // The fix pairs with WorkspaceShell.row { height: 100%, alignItems:
+    // stretch } so grid rows fill the shell and cards stretch to fill rows.
+    // Existing per-section inline `style: { height: ... }` overrides still
+    // win (inline style trumps class), so this is back-compat safe.
+    height: '100%',
   },
   titleBar: {
     display: 'flex',

--- a/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/SectionPanel.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/SectionPanel.tsx
@@ -86,18 +86,11 @@ const useStyles = makeStyles({
     // win. Same fix pattern as in DataGrid root/innerCard/gridScroll +
     // DataverseEntityViewWidget root — this completes the chain.
     minWidth: 0,
-    // smart-todo-r4 UAT round 7 (2026-06-21): make the card actually claim
-    // its parent grid cell's full height by default. Without this, the
-    // card defaults to intrinsic content height — which forces every
-    // embedded widget to either hard-code a per-section
-    // `style: { height: '560px' }` (the legacy workaround) or live with a
-    // ~content-height container that doesn't fill the Workspace pane.
-    //
-    // The fix pairs with WorkspaceShell.row { height: 100%, alignItems:
-    // stretch } so grid rows fill the shell and cards stretch to fill rows.
-    // Existing per-section inline `style: { height: ... }` overrides still
-    // win (inline style trumps class), so this is back-compat safe.
-    height: '100%',
+    // NOTE: a UAT round 7 attempt to add `height: 100%` here (paired with
+    // WorkspaceShell.row { flex: 1 1 0 }) collapsed the SpaarkeAi embedded
+    // workspace to 40px because the height couldn't resolve up the chain.
+    // Reverted; per-section `style: { height: ... }` remains the supply
+    // mechanism until a deeper layout audit identifies the true break.
   },
   titleBar: {
     display: 'flex',

--- a/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/WorkspaceShell.styles.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/WorkspaceShell.styles.ts
@@ -30,17 +30,25 @@ export const useWorkspaceShellStyles = makeStyles({
    * A grid row within the shell.
    * Column layout is supplied inline via `style.gridTemplateColumns`.
    *
-   * NOTE: a UAT round 7 attempt to add `flex: 1 1 0, alignItems: stretch`
-   * here collapsed the workspace to ~40px (only the tab bar visible) in
-   * the SpaarkeAi embedded context because the parent shell's
-   * `flex: 1 1 auto` couldn't resolve a determinate height through every
-   * layer above. Reverted to default grid behaviour; per-section
-   * `style: { height: ... }` remains the height-supply mechanism until a
-   * deeper layout audit identifies the true break point above the shell.
+   * UAT 2026-06-22 round 12: NOW SAFE to add `flex: 1 1 0, minHeight: 0,
+   * alignItems: stretch`. The round 7 attempt failed because the parent
+   * chain ABOVE the shell didn't have determinate height. Round 11
+   * resolved that by adding `height: 100%` to WorkspaceLayoutWidget.root
+   * (which is the block-parent's child). With the chain now propagating
+   * height, the row's flex sizing can take effect — it claims the shell's
+   * vertical space and stretches the SectionPanel grid cell to row height,
+   * which is the final missing link from console diagnostics:
+   *   1. WorkspaceLayoutWidget.root height:100% (round 11)
+   *   2. WorkspaceShell.row flex:1 1 0 + alignItems:stretch (this fix)
+   *   3. SmartTodoWidget.body display:flex (round 11)
+   * Together they restore the full height chain to the kanban.
    */
   row: {
     display: 'grid',
     gap: tokens.spacingHorizontalL,
+    flex: '1 1 0',
+    minHeight: 0,
+    alignItems: 'stretch',
   },
 });
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/WorkspaceShell.styles.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/WorkspaceShell.styles.ts
@@ -28,11 +28,27 @@ export const useWorkspaceShellStyles = makeStyles({
 
   /**
    * A grid row within the shell.
+   *
    * Column layout is supplied inline via `style.gridTemplateColumns`.
+   *
+   * smart-todo-r4 UAT round 7 (2026-06-21): the row now claims available
+   * vertical space from the flex `shell` via `flex: 1 1 0` (with `minHeight:
+   * 0` so it can shrink in tight viewports). `alignItems: stretch` is the
+   * grid default but expressed explicitly so SectionPanel cards stretch to
+   * the row's height — combined with `SectionPanel.card { height: 100% }`,
+   * this establishes the height contract from viewport → pane → row → card
+   * → widget without per-section inline `style: { height: "560px" }` hacks.
+   *
+   * For multi-row workspaces, all rows share the shell's vertical space
+   * equally (each gets `flex-basis: 0`); to size a row to content instead,
+   * pass `style: { flex: '0 0 auto' }` on the row config.
    */
   row: {
     display: 'grid',
     gap: tokens.spacingHorizontalL,
+    flex: '1 1 0',
+    minHeight: 0,
+    alignItems: 'stretch',
   },
 });
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/WorkspaceShell.styles.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/WorkspaceShell/WorkspaceShell.styles.ts
@@ -28,27 +28,19 @@ export const useWorkspaceShellStyles = makeStyles({
 
   /**
    * A grid row within the shell.
-   *
    * Column layout is supplied inline via `style.gridTemplateColumns`.
    *
-   * smart-todo-r4 UAT round 7 (2026-06-21): the row now claims available
-   * vertical space from the flex `shell` via `flex: 1 1 0` (with `minHeight:
-   * 0` so it can shrink in tight viewports). `alignItems: stretch` is the
-   * grid default but expressed explicitly so SectionPanel cards stretch to
-   * the row's height — combined with `SectionPanel.card { height: 100% }`,
-   * this establishes the height contract from viewport → pane → row → card
-   * → widget without per-section inline `style: { height: "560px" }` hacks.
-   *
-   * For multi-row workspaces, all rows share the shell's vertical space
-   * equally (each gets `flex-basis: 0`); to size a row to content instead,
-   * pass `style: { flex: '0 0 auto' }` on the row config.
+   * NOTE: a UAT round 7 attempt to add `flex: 1 1 0, alignItems: stretch`
+   * here collapsed the workspace to ~40px (only the tab bar visible) in
+   * the SpaarkeAi embedded context because the parent shell's
+   * `flex: 1 1 auto` couldn't resolve a determinate height through every
+   * layer above. Reverted to default grid behaviour; per-section
+   * `style: { height: ... }` remains the height-supply mechanism until a
+   * deeper layout audit identifies the true break point above the shell.
    */
   row: {
     display: 'grid',
     gap: tokens.spacingHorizontalL,
-    flex: '1 1 0',
-    minHeight: 0,
-    alignItems: 'stretch',
   },
 });
 

--- a/src/client/webresources/js/sprk_todo_dirty_check.js
+++ b/src/client/webresources/js/sprk_todo_dirty_check.js
@@ -88,7 +88,7 @@ Spaarke.SmartTodo.DirtyCheck = Spaarke.SmartTodo.DirtyCheck || {};
     // -----------------------------------------------------------------------
 
     /** Version for diagnostic logging. */
-    ns.VERSION = "1.0.0";
+    ns.VERSION = "1.1.0";
 
     /**
      * Message-type discriminators. MUST stay in lockstep with
@@ -97,6 +97,18 @@ Spaarke.SmartTodo.DirtyCheck = Spaarke.SmartTodo.DirtyCheck || {};
      */
     var REQUEST_TYPE = "request-dirty-check";
     var RESULT_TYPE = "dirty-check-result";
+
+    /**
+     * v1.1.0 — outbound message type the iframe posts to the parent when
+     * the OOB form's "Save & Close" (or any Xrm.Page.ui.close call) fires.
+     * Parent dismisses the SmartTodoModal and the iframe is unmounted
+     * BEFORE MDA's default close-and-navigate-parent behaviour runs, so
+     * the parent page (Code Page modal / embedded Code Page / SpaarkeAi)
+     * never gets navigated away.
+     *
+     * MUST stay in lockstep with the consumer in SmartTodoModal.tsx.
+     */
+    var CLOSE_INTENT_TYPE = "sprk_todo_form_close_intent";
 
     /**
      * Inbound-origin allow-list (Spaarke domains only). Patterns:
@@ -124,6 +136,9 @@ Spaarke.SmartTodo.DirtyCheck = Spaarke.SmartTodo.DirtyCheck || {};
      */
     var FORM_CONTEXT_HOLDER = "__sprk_todo_dirty_check_formctx__";
 
+    /** v1.1.0 — sentinel to install the ui.close monkey-patch exactly once. */
+    var CLOSE_PATCH_INSTALLED = "__sprk_todo_close_patch_installed__";
+
     // -----------------------------------------------------------------------
     // OnLoad — register message listener + cache formContext
     // -----------------------------------------------------------------------
@@ -148,6 +163,13 @@ Spaarke.SmartTodo.DirtyCheck = Spaarke.SmartTodo.DirtyCheck || {};
             // Refresh the cached formContext (per-load — new record may differ).
             window[FORM_CONTEXT_HOLDER] = formContext;
 
+            // v1.1.0 — reset the close-post dedup so each record's first
+            // Save & Close posts exactly once (without this the second
+            // record's Save & Close would silently no-op).
+            if (typeof ns._resetClosePost === "function") {
+                ns._resetClosePost();
+            }
+
             // Install the message listener exactly once per iframe lifetime.
             if (!window[LISTENER_INSTALLED]) {
                 window.addEventListener("message", ns._handleMessage, false);
@@ -156,10 +178,91 @@ Spaarke.SmartTodo.DirtyCheck = Spaarke.SmartTodo.DirtyCheck || {};
             } else {
                 console.log("[SmartTodo.DirtyCheck v" + ns.VERSION + "] formContext refreshed for new record");
             }
+
+            // v1.1.0 — install the ui.close monkey-patch exactly once. The
+            // OOB Save & Close ribbon command, and any custom call to
+            // Xrm.Page.ui.close() or formContext.ui.close(), would normally
+            // navigate the iframe's PARENT WINDOW (an MDA behaviour that
+            // assumes the form is the top-level page). Inside our hybrid
+            // modal that parent is the SmartTodo Code Page (or SpaarkeAi
+            // hosting it) and we don't want it navigated.
+            //
+            // Strategy: replace `ui.close` on both `formContext.ui` and the
+            // legacy `Xrm.Page.ui` with a function that posts a close-intent
+            // message to the parent and does nothing else. The parent
+            // listens, dismisses the SmartTodoModal, and the iframe is
+            // unmounted before any further nav could fire.
+            if (!window[CLOSE_PATCH_INSTALLED]) {
+                installCloseInterceptor(formContext);
+                window[CLOSE_PATCH_INSTALLED] = true;
+            }
         } catch (err) {
             console.error("[SmartTodo.DirtyCheck v" + ns.VERSION + "] onLoad error:", err);
         }
     };
+
+    // -----------------------------------------------------------------------
+    // v1.1.0 — Save & Close interceptor
+    // -----------------------------------------------------------------------
+
+    /**
+     * Replaces `formContext.ui.close` AND the legacy `Xrm.Page.ui.close`
+     * with a function that posts a close-intent message to the iframe's
+     * parent window. Both references must be patched because:
+     *   - Custom command-bar commands sometimes use the deprecated
+     *     `Xrm.Page.ui.close()` directly (legacy code paths)
+     *   - Newer command formulas use `formContext.ui.close(executionContext)`
+     *
+     * Defensive: if either reference path is missing (older / sandboxed
+     * MDA), the corresponding patch is silently skipped. The other patch
+     * still applies. If both are missing the user falls back to the
+     * pre-v1.1.0 behaviour (parent navigation) — no worse than before.
+     *
+     * @param {object} formContext - The current form's execution context
+     */
+    function installCloseInterceptor(formContext) {
+        var posted = false;
+        var postCloseIntent = function () {
+            if (posted) return; // dedup — Save & Close fires both paths sometimes
+            posted = true;
+            try {
+                if (window.parent && typeof window.parent.postMessage === "function") {
+                    // Use "*" target origin here because the parent is
+                    // same-origin in production but iframe-loaded forms can
+                    // execute in cross-origin contexts during diagnostics.
+                    // The message body is a fixed sentinel — no user data
+                    // leaks via origin wildcards.
+                    window.parent.postMessage({ type: CLOSE_INTENT_TYPE }, "*");
+                    console.log("[SmartTodo.DirtyCheck v" + ns.VERSION + "] posted " + CLOSE_INTENT_TYPE);
+                }
+            } catch (err) {
+                console.warn("[SmartTodo.DirtyCheck v" + ns.VERSION + "] postCloseIntent failed:", err);
+            }
+        };
+
+        // Reset the dedup flag whenever this form re-loads (new record).
+        ns._resetClosePost = function () { posted = false; };
+
+        // Patch 1: formContext.ui.close
+        try {
+            if (formContext && formContext.ui && typeof formContext.ui.close === "function") {
+                formContext.ui.close = postCloseIntent;
+                console.log("[SmartTodo.DirtyCheck v" + ns.VERSION + "] patched formContext.ui.close");
+            }
+        } catch (err) {
+            console.warn("[SmartTodo.DirtyCheck v" + ns.VERSION + "] formContext.ui.close patch failed:", err);
+        }
+
+        // Patch 2: legacy Xrm.Page.ui.close
+        try {
+            if (typeof Xrm !== "undefined" && Xrm.Page && Xrm.Page.ui && typeof Xrm.Page.ui.close === "function") {
+                Xrm.Page.ui.close = postCloseIntent;
+                console.log("[SmartTodo.DirtyCheck v" + ns.VERSION + "] patched Xrm.Page.ui.close");
+            }
+        } catch (err) {
+            console.warn("[SmartTodo.DirtyCheck v" + ns.VERSION + "] Xrm.Page.ui.close patch failed:", err);
+        }
+    }
 
     // -----------------------------------------------------------------------
     // Message handler — validate, compute dirty, respond

--- a/src/solutions/LegalWorkspace/src/components/SmartToDo/SmartToDo.tsx
+++ b/src/solutions/LegalWorkspace/src/components/SmartToDo/SmartToDo.tsx
@@ -131,11 +131,22 @@ const useStyles = makeStyles({
     flex: "1 1 0",
     minHeight: "400px",
   },
-  /** Borderless, height-flexible root for use inside a tabbed container. */
+  /**
+   * Borderless, height-flexible root for use inside a tabbed container.
+   *
+   * UAT 2026-06-22 round 10: switched from `flex: 1 1 0` to `height: 100%`
+   * to match the working DailyBriefingApp pattern. In a SectionPanel.content
+   * flex container with `flex: 1 1 auto` (basis: auto), a child `flex: 1 1 0`
+   * doesn't reliably claim the parent's full height because the parent's
+   * own basis is the intrinsic size — the chain doesn't propagate height
+   * unless the child explicitly says `height: 100%`. DailyBriefingApp uses
+   * this exact pattern and fills correctly; this brings SmartToDo into
+   * parity.
+   */
   embeddedRoot: {
     display: "flex",
     flexDirection: "column",
-    flex: "1 1 0",
+    height: "100%",
     overflow: "hidden",
     backgroundColor: tokens.colorNeutralBackground1,
   },

--- a/src/solutions/LegalWorkspace/src/components/SmartToDo/SmartToDo.tsx
+++ b/src/solutions/LegalWorkspace/src/components/SmartToDo/SmartToDo.tsx
@@ -131,22 +131,11 @@ const useStyles = makeStyles({
     flex: "1 1 0",
     minHeight: "400px",
   },
-  /**
-   * Borderless, height-flexible root for use inside a tabbed container.
-   *
-   * UAT 2026-06-22 round 10: switched from `flex: 1 1 0` to `height: 100%`
-   * to match the working DailyBriefingApp pattern. In a SectionPanel.content
-   * flex container with `flex: 1 1 auto` (basis: auto), a child `flex: 1 1 0`
-   * doesn't reliably claim the parent's full height because the parent's
-   * own basis is the intrinsic size — the chain doesn't propagate height
-   * unless the child explicitly says `height: 100%`. DailyBriefingApp uses
-   * this exact pattern and fills correctly; this brings SmartToDo into
-   * parity.
-   */
+  /** Borderless, height-flexible root for use inside a tabbed container. */
   embeddedRoot: {
     display: "flex",
     flexDirection: "column",
-    height: "100%",
+    flex: "1 1 0",
     overflow: "hidden",
     backgroundColor: tokens.colorNeutralBackground1,
   },

--- a/src/solutions/LegalWorkspace/src/hooks/useKanbanColumns.ts
+++ b/src/solutions/LegalWorkspace/src/hooks/useKanbanColumns.ts
@@ -79,16 +79,32 @@ export interface IUseKanbanColumnsResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Determine which column an unpinned item belongs to based on its To Do Score.
+ * UAT 2026-06-21 — bucket by DUE DATE, not score (parity fix with shared lib).
+ *
+ * Same rationale as Spaarke.SmartTodo.Components/useKanbanColumns.ts:
+ * column names Today/Tomorrow/Future are date concepts so the bucketing
+ * must follow due date. Threshold args kept for back-compat with callers
+ * but unused.
+ *
+ *   - Today    = due today OR overdue (no due date counts as Future)
+ *   - Tomorrow = due tomorrow
+ *   - Future   = due day-after-tomorrow or later, OR no due date set
  */
 function assignColumnByScore(
   todo: ITodo,
-  todayThreshold: number,
-  tomorrowThreshold: number
+  _todayThreshold: number,
+  _tomorrowThreshold: number
 ): TodoColumn {
-  const { todoScore } = computeTodoScore(todo);
-  if (todoScore >= todayThreshold) return 'Today';
-  if (todoScore >= tomorrowThreshold) return 'Tomorrow';
+  if (!todo.sprk_duedate) return 'Future';
+  const due = new Date(todo.sprk_duedate);
+  if (isNaN(due.getTime())) return 'Future';
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const dueDay = new Date(due.getFullYear(), due.getMonth(), due.getDate());
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const diffDays = Math.round((dueDay.getTime() - today.getTime()) / msPerDay);
+  if (diffDays <= 0) return 'Today';
+  if (diffDays === 1) return 'Tomorrow';
   return 'Future';
 }
 
@@ -129,9 +145,9 @@ function buildColumns(
   }
 
   return [
-    { id: 'Today', title: 'Today', subtitle: `Score \u2265 ${todayThreshold}`, items: today, accentColor: tokens.colorPaletteRedBorder2 },
-    { id: 'Tomorrow', title: 'Tomorrow', subtitle: `Score ${tomorrowThreshold}\u2013${todayThreshold - 1}`, items: tomorrow, accentColor: tokens.colorPaletteDarkOrangeBorder2 },
-    { id: 'Future', title: 'Future', subtitle: `Score < ${tomorrowThreshold}`, items: future, accentColor: tokens.colorPaletteGreenBorder2 },
+    { id: 'Today', title: 'Today', subtitle: 'Due today or overdue', items: today, accentColor: tokens.colorPaletteRedBorder2 },
+    { id: 'Tomorrow', title: 'Tomorrow', subtitle: 'Due tomorrow', items: tomorrow, accentColor: tokens.colorPaletteDarkOrangeBorder2 },
+    { id: 'Future', title: 'Future', subtitle: 'Due later or undated', items: future, accentColor: tokens.colorPaletteGreenBorder2 },
   ];
 }
 

--- a/src/solutions/LegalWorkspace/src/sections/todo.registration.ts
+++ b/src/solutions/LegalWorkspace/src/sections/todo.registration.ts
@@ -127,30 +127,56 @@ const FeedSyncBridgeHost: React.FC<IFeedSyncBridgeHostProps> = ({ ctx }) => {
     [notifyTodoChange, subscribe],
   );
 
-  // UAT 2026-06-20 round 4 — split Open behaviour by selection:
+  // UAT 2026-06-21 round 5 — split Open behaviour by selection AND open as
+  // a true DIALOG (not page-nav):
   //
-  //   - todoId PRESENT → open the OOB To Do record FORM directly via
-  //     `Xrm.Navigation.openForm({ entityName: 'sprk_todo', entityId })`.
-  //     Skips the SmartTodo Code Page hop entirely so the user gets a single
-  //     record modal instead of the prior "Code Page modal → record modal"
-  //     stack (UAT round 4 issue 3). The form gets BPF + business rules +
-  //     ribbon for free — same as opening from any view.
+  //   - todoId PRESENT → open the OOB sprk_todo record FORM as a dialog via
+  //     `Xrm.Navigation.navigateTo({pageType:'entityrecord', ...}, {target:2})`.
+  //     `target: 2` = dialog mode (modal overlay over the current page).
+  //     The current SpaarkeAi page stays mounted underneath, so when the
+  //     dialog closes, the user is back exactly where they were (widget
+  //     context preserved). This fixes UAT round 5 issues #2 (was opening as
+  //     full-page nav via openForm) and #3 (save/close was landing the user
+  //     on SpaarkeAi instead of returning to the widget context).
   //
   //   - todoId ABSENT  → open the SmartTodo Code Page (no launch data) so
   //     `useLaunchContext` returns undefined → app renders its default 3-col
   //     Kanban view (no auto-modal). This preserves "user wants to just open
   //     the full app" without forcing a card selection first.
   //
-  // Falls back to the prior Code-Page-hop path if Xrm.Navigation is somehow
-  // unavailable (defensive — should not happen inside MDA).
+  // Falls back to openForm (page-nav) if Xrm.Navigation.navigateTo is somehow
+  // unavailable — defensive only, should not happen inside MDA.
   const handleOpenTodo = React.useCallback(
     (todoId?: string) => {
       if (todoId) {
-        // Preferred path: open the record form directly. No Code Page stack.
-        // `Xrm` is the model-driven app global; types are loose because the
-        // shared lib doesn't pull in @types/xrm.
-        const xrm = (globalThis as unknown as { Xrm?: { Navigation?: { openForm?: (opts: unknown) => Promise<unknown> } } }).Xrm;
+        // Loose typing — the shared lib doesn't pull in @types/xrm.
+        const xrm = (globalThis as unknown as {
+          Xrm?: {
+            Navigation?: {
+              navigateTo?: (page: unknown, opts?: unknown) => Promise<unknown>;
+              openForm?: (opts: unknown) => Promise<unknown>;
+            };
+          };
+        }).Xrm;
+        if (xrm?.Navigation?.navigateTo) {
+          // target: 2 = dialog. Width/height keep the dialog roomy but inset.
+          void xrm.Navigation.navigateTo(
+            {
+              pageType: "entityrecord",
+              entityName: "sprk_todo",
+              entityId: todoId,
+            },
+            {
+              target: 2,
+              position: 1, // 1 = center
+              width: { value: 80, unit: "%" },
+              height: { value: 80, unit: "%" },
+            },
+          );
+          return;
+        }
         if (xrm?.Navigation?.openForm) {
+          // Defensive — page-nav fallback only.
           void xrm.Navigation.openForm({
             entityName: "sprk_todo",
             entityId: todoId,
@@ -158,7 +184,7 @@ const FeedSyncBridgeHost: React.FC<IFeedSyncBridgeHostProps> = ({ ctx }) => {
           });
           return;
         }
-        // Defensive fallback only — should never run in real MDA.
+        // Last-resort fallback: Code-Page-hop (legacy path).
         const data =
           `${LAUNCH_PARAM_ACTION}=${LAUNCH_ACTION_OPEN_TODO}` +
           `&${LAUNCH_PARAM_TODO_ID}=${encodeURIComponent(todoId)}`;

--- a/src/solutions/LegalWorkspace/src/sections/todo.registration.ts
+++ b/src/solutions/LegalWorkspace/src/sections/todo.registration.ts
@@ -127,30 +127,50 @@ const FeedSyncBridgeHost: React.FC<IFeedSyncBridgeHostProps> = ({ ctx }) => {
     [notifyTodoChange, subscribe],
   );
 
-  // R4 task 100 (W-2) — Open handler now passes the `openTodo` launch
-  // discriminator so the SmartTodo Code Page auto-mounts <SmartTodoModal>
-  // on the clicked record. Pre-R4-100 it used `eventId=<guid>` which the
-  // Code Page ignored (defaulting to Kanban) — UAT issue 4.
+  // UAT 2026-06-20 round 4 — split Open behaviour by selection:
   //
-  // R4 task 103 (E-2, 2026-06-18) — UAT 2 made the widget's Open button
-  // ALWAYS-ENABLED. The `todoId` arg is now OPTIONAL:
-  //   - present → dispatch openTodo launch (existing behaviour, auto-mount modal)
-  //   - absent  → open the SmartTodo Code Page with NO launch data → the
-  //     app's `useLaunchContext` returns undefined → app renders its default
-  //     3-col Kanban view (no auto-modal). This satisfies "user wants to just
-  //     open the app" without forcing a card selection first.
+  //   - todoId PRESENT → open the OOB To Do record FORM directly via
+  //     `Xrm.Navigation.openForm({ entityName: 'sprk_todo', entityId })`.
+  //     Skips the SmartTodo Code Page hop entirely so the user gets a single
+  //     record modal instead of the prior "Code Page modal → record modal"
+  //     stack (UAT round 4 issue 3). The form gets BPF + business rules +
+  //     ribbon for free — same as opening from any view.
   //
-  // Wire format: `action=openTodo&todoId=<guid>` — Dataverse URL-encodes the
-  // entire string as `?data=<envelope>` per the parseDataParams convention
-  // (ADR-026). `useLaunchContext.parseLaunchContextFromSearch` handles BOTH
-  // wire formats so test URLs (raw query) work without an MDA host too.
+  //   - todoId ABSENT  → open the SmartTodo Code Page (no launch data) so
+  //     `useLaunchContext` returns undefined → app renders its default 3-col
+  //     Kanban view (no auto-modal). This preserves "user wants to just open
+  //     the full app" without forcing a card selection first.
+  //
+  // Falls back to the prior Code-Page-hop path if Xrm.Navigation is somehow
+  // unavailable (defensive — should not happen inside MDA).
   const handleOpenTodo = React.useCallback(
     (todoId?: string) => {
-      const data = todoId
-        ? `${LAUNCH_PARAM_ACTION}=${LAUNCH_ACTION_OPEN_TODO}` +
-          `&${LAUNCH_PARAM_TODO_ID}=${encodeURIComponent(todoId)}`
-        : undefined;
-      ctx.onOpenWizard(SMART_TODO_CODE_PAGE_NAME, data, {
+      if (todoId) {
+        // Preferred path: open the record form directly. No Code Page stack.
+        // `Xrm` is the model-driven app global; types are loose because the
+        // shared lib doesn't pull in @types/xrm.
+        const xrm = (globalThis as unknown as { Xrm?: { Navigation?: { openForm?: (opts: unknown) => Promise<unknown> } } }).Xrm;
+        if (xrm?.Navigation?.openForm) {
+          void xrm.Navigation.openForm({
+            entityName: "sprk_todo",
+            entityId: todoId,
+            openInNewWindow: false,
+          });
+          return;
+        }
+        // Defensive fallback only — should never run in real MDA.
+        const data =
+          `${LAUNCH_PARAM_ACTION}=${LAUNCH_ACTION_OPEN_TODO}` +
+          `&${LAUNCH_PARAM_TODO_ID}=${encodeURIComponent(todoId)}`;
+        ctx.onOpenWizard(SMART_TODO_CODE_PAGE_NAME, data, {
+          width: { value: 85, unit: "%" },
+          height: { value: 85, unit: "%" },
+        });
+        return;
+      }
+
+      // No selection → open the full Smart To Do Code Page at its default view.
+      ctx.onOpenWizard(SMART_TODO_CODE_PAGE_NAME, undefined, {
         width: { value: 85, unit: "%" },
         height: { value: 85, unit: "%" },
       });

--- a/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
+++ b/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
@@ -299,12 +299,14 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
       // -----------------------------------------------------------------------
       // My To Do List — SmartToDo
       //
-      // UAT 2026-06-21 round 7 (REVERT): the structural SectionPanel /
-      // WorkspaceShell.row fix collapsed the entire workspace to 40px
-      // because the height chain has an unresolved break above the shell
-      // that the per-section inline height was masking. Restored
-      // `calc(100vh - 200px)` with 560px floor until the deeper audit
-      // lands.
+      // UAT 2026-06-21 round 8: matching the working pattern from
+      // Daily Briefing's workspaceConfig (no `height` cap, just
+      // `minHeight: 'auto'`). The SectionPanel's flex chain delivers the
+      // full pane height down to the widget; the widget's internal
+      // `kanbanContainer { flex 1 1 auto, minHeight 0 }` claims that
+      // height and scrolls internally on overflow. Previous rounds set
+      // `height: 'calc(100vh - 200px)'` here which CAPPED the section
+      // (not just floored it), preventing fill in tall viewports.
       // -----------------------------------------------------------------------
       {
         id: "todo",
@@ -312,7 +314,7 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
         title: "My To Do List",
         badgeCount: p.todoCount,
         toolbar: todoToolbar,
-        style: { height: "calc(100vh - 200px)", minHeight: "560px" },
+        style: { minHeight: "auto" },
         renderContent: () => (
           <SmartToDo
             embedded

--- a/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
+++ b/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
@@ -297,7 +297,13 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
       },
 
       // -----------------------------------------------------------------------
-      // My To Do List — SmartToDo (height: 560px, 50% width)
+      // My To Do List — SmartToDo
+      //
+      // UAT 2026-06-21 round 5 — height was pinned at 560px which capped the
+      // widget regardless of viewport size. Switched to viewport-relative
+      // `calc(100vh - 200px)` so the widget grows to fill the available
+      // vertical space (minus tab chrome + header). Internal scroll inside
+      // the kanban handles overflow when there are many cards.
       // -----------------------------------------------------------------------
       {
         id: "todo",
@@ -305,7 +311,7 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
         title: "My To Do List",
         badgeCount: p.todoCount,
         toolbar: todoToolbar,
-        style: { height: "560px" },
+        style: { height: "calc(100vh - 200px)", minHeight: "560px" },
         renderContent: () => (
           <SmartToDo
             embedded

--- a/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
+++ b/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
@@ -299,11 +299,11 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
       // -----------------------------------------------------------------------
       // My To Do List — SmartToDo
       //
-      // UAT 2026-06-21 round 5 — height was pinned at 560px which capped the
-      // widget regardless of viewport size. Switched to viewport-relative
-      // `calc(100vh - 200px)` so the widget grows to fill the available
-      // vertical space (minus tab chrome + header). Internal scroll inside
-      // the kanban handles overflow when there are many cards.
+      // UAT 2026-06-21 round 7 — removed inline height. The structural fix
+      // in SectionPanel.card { height: 100% } + WorkspaceShell.row { flex: 1
+      // 1 0, alignItems: stretch } now propagates pane height down to the
+      // card automatically. Widgets fill whatever vertical space the
+      // workspace pane offers, no per-section hardcoding needed.
       // -----------------------------------------------------------------------
       {
         id: "todo",
@@ -311,7 +311,6 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
         title: "My To Do List",
         badgeCount: p.todoCount,
         toolbar: todoToolbar,
-        style: { height: "calc(100vh - 200px)", minHeight: "560px" },
         renderContent: () => (
           <SmartToDo
             embedded

--- a/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
+++ b/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
@@ -299,14 +299,13 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
       // -----------------------------------------------------------------------
       // My To Do List — SmartToDo
       //
-      // UAT 2026-06-21 round 8: matching the working pattern from
-      // Daily Briefing's workspaceConfig (no `height` cap, just
-      // `minHeight: 'auto'`). The SectionPanel's flex chain delivers the
-      // full pane height down to the widget; the widget's internal
-      // `kanbanContainer { flex 1 1 auto, minHeight 0 }` claims that
-      // height and scrolls internally on overflow. Previous rounds set
-      // `height: 'calc(100vh - 200px)'` here which CAPPED the section
-      // (not just floored it), preventing fill in tall viewports.
+      // UAT 2026-06-22 round 9 (REVERT round 8): the `minHeight: auto`
+      // change collapsed the widget because LegalWorkspace's parent chain
+      // doesn't deliver flex height through SectionPanel without an
+      // explicit supply. The Explore-agent comparison to DailyBriefing
+      // may be measuring a different layout context. Restoring the
+      // viewport-relative `calc(100vh - 200px)` that worked in rounds 5/6
+      // until a deeper layout audit identifies the structural break.
       // -----------------------------------------------------------------------
       {
         id: "todo",
@@ -314,7 +313,7 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
         title: "My To Do List",
         badgeCount: p.todoCount,
         toolbar: todoToolbar,
-        style: { minHeight: "auto" },
+        style: { height: "calc(100vh - 200px)", minHeight: "560px" },
         renderContent: () => (
           <SmartToDo
             embedded

--- a/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
+++ b/src/solutions/LegalWorkspace/src/workspaceConfig.tsx
@@ -299,11 +299,12 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
       // -----------------------------------------------------------------------
       // My To Do List — SmartToDo
       //
-      // UAT 2026-06-21 round 7 — removed inline height. The structural fix
-      // in SectionPanel.card { height: 100% } + WorkspaceShell.row { flex: 1
-      // 1 0, alignItems: stretch } now propagates pane height down to the
-      // card automatically. Widgets fill whatever vertical space the
-      // workspace pane offers, no per-section hardcoding needed.
+      // UAT 2026-06-21 round 7 (REVERT): the structural SectionPanel /
+      // WorkspaceShell.row fix collapsed the entire workspace to 40px
+      // because the height chain has an unresolved break above the shell
+      // that the per-section inline height was masking. Restored
+      // `calc(100vh - 200px)` with 560px floor until the deeper audit
+      // lands.
       // -----------------------------------------------------------------------
       {
         id: "todo",
@@ -311,6 +312,7 @@ export function buildWorkspaceConfig(p: WorkspaceConfigParams): WorkspaceConfig 
         title: "My To Do List",
         badgeCount: p.todoCount,
         toolbar: todoToolbar,
+        style: { height: "calc(100vh - 200px)", minHeight: "560px" },
         renderContent: () => (
           <SmartToDo
             embedded

--- a/src/solutions/SmartTodo/src/SmartTodoApp.tsx
+++ b/src/solutions/SmartTodo/src/SmartTodoApp.tsx
@@ -135,6 +135,17 @@ function SmartTodoLayout(): React.ReactElement {
     settingsOpenerRef.current?.();
   }, []);
 
+  // UAT 2026-06-21 round 8: capture the inner SmartToDo's refetch so the
+  // Header's Refresh button can actually trigger a re-fetch. The
+  // TodoContext.refetch is a no-op placeholder (see TodoContext.tsx — was
+  // never wired to a real data source); the real data lives in SmartToDo's
+  // internal `useTodoItems` hook. SmartToDo exposes its refetch via
+  // `onRefetchReady`; we capture it in a ref + use it in `handleRefresh`.
+  const innerRefetchRef = React.useRef<(() => void) | null>(null);
+  const handleInnerRefetchReady = React.useCallback((fn: () => void) => {
+    innerRefetchRef.current = fn;
+  }, []);
+
   // ── R4 task 030 — Header state (App-level, per task brief) ───────────────
   //
   // `searchQuery` is owned here so future tasks (031 facets, 033 list view)
@@ -365,9 +376,16 @@ function SmartTodoLayout(): React.ReactElement {
     [actionHandlers],
   );
 
-  // Refresh → re-query todos via the existing context refetch (task 022).
+  // Refresh — UAT 2026-06-21 round 8: route to the inner SmartToDo's real
+  // refetch (captured via onRefetchReady). Fall back to the TodoContext
+  // refetch only if the inner one hasn't reported in yet (defensive — would
+  // never happen in normal mount order).
   const handleRefresh = React.useCallback(() => {
-    refetch();
+    if (innerRefetchRef.current) {
+      innerRefetchRef.current();
+    } else {
+      refetch();
+    }
   }, [refetch]);
 
   // R4-104 (Wave E-3) — The consolidated Header's primary add path is the
@@ -437,6 +455,7 @@ function SmartTodoLayout(): React.ReactElement {
           // that's still anchored inside SmartToDo.
           hideHeader
           onSettingsOpenerReady={handleSettingsOpenerReady}
+          onRefetchReady={handleInnerRefetchReady}
           // UAT 2026-06-19 — single-source-of-truth for orientation.
           // Without this prop, SmartToDo's internal useUserPreferences
           // instance held its own copy that didn't react to Header toggle

--- a/src/solutions/SmartTodo/src/components/Header/Header.styles.ts
+++ b/src/solutions/SmartTodo/src/components/Header/Header.styles.ts
@@ -156,6 +156,71 @@ export const useHeaderStyles = makeStyles({
   },
 
   /**
+   * UAT 2026-06-20 round 4 — typeahead wrapper + dropdown for the Assigned
+   * To field. Mirrors the widget's `assignedToWrap` / `assignedToResults` /
+   * `assignedToResultItem` styles so the two surfaces look identical.
+   */
+  assignedToWrap: {
+    position: 'relative',
+    flex: '0 1 220px',
+    minWidth: '140px',
+  },
+
+  assignedToResults: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    right: 0,
+    zIndex: 50,
+    marginTop: '2px',
+    maxHeight: '220px',
+    overflowY: 'auto',
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderTopWidth: '1px',
+    borderRightWidth: '1px',
+    borderBottomWidth: '1px',
+    borderLeftWidth: '1px',
+    borderTopStyle: 'solid',
+    borderRightStyle: 'solid',
+    borderBottomStyle: 'solid',
+    borderLeftStyle: 'solid',
+    borderTopColor: tokens.colorNeutralStroke2,
+    borderRightColor: tokens.colorNeutralStroke2,
+    borderBottomColor: tokens.colorNeutralStroke2,
+    borderLeftColor: tokens.colorNeutralStroke2,
+    borderTopLeftRadius: tokens.borderRadiusMedium,
+    borderTopRightRadius: tokens.borderRadiusMedium,
+    borderBottomLeftRadius: tokens.borderRadiusMedium,
+    borderBottomRightRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow8,
+  },
+
+  assignedToResultItem: {
+    display: 'block',
+    width: '100%',
+    textAlign: 'left',
+    padding: `${tokens.spacingVerticalXS} ${tokens.spacingHorizontalSNudge}`,
+    backgroundColor: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground1,
+    ':hover': {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+    },
+    ':focus': {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+      outlineStyle: 'none',
+    },
+  },
+
+  assignedToResultsHint: {
+    padding: `${tokens.spacingVerticalXS} ${tokens.spacingHorizontalSNudge}`,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+
+  /**
    * Flex spacer — pushes the right cluster to the trailing edge of the row.
    * `flex: '1 1 0'` (vs auto) means it absorbs leftover space without
    * fighting the QuickAdd for room.

--- a/src/solutions/SmartTodo/src/components/Header/Header.tsx
+++ b/src/solutions/SmartTodo/src/components/Header/Header.tsx
@@ -350,9 +350,88 @@ export const Header: React.FC<HeaderProps> = ({
   const handleQuickAddAssignedToChange = React.useCallback(
     (_e: React.ChangeEvent<HTMLInputElement>, data: { value: string }) => {
       setQuickAddAssignedTo(data.value);
+      // Typing invalidates a previously selected contactId unless the user
+      // re-selects from the typeahead. Empty → fall back to default user.
+      if (data.value.trim() === '') {
+        setQuickAddAssignedToContactId(defaultAssignedToContactId || '');
+      } else {
+        setQuickAddAssignedToContactId('');
+      }
     },
-    [],
+    [defaultAssignedToContactId],
   );
+
+  // UAT 2026-06-20 round 4 — typeahead picker for the Assigned To field.
+  // Mirrors the widget's implementation: debounced search of the OOB
+  // `contact` entity by fullname; user selects from a small popup. Uses
+  // Xrm.WebApi (always available inside the MDA-hosted Code Page).
+  const [assignedToResults, setAssignedToResults] = React.useState<Array<{ id: string; name: string }>>([]);
+  const [isSearchingContacts, setIsSearchingContacts] = React.useState<boolean>(false);
+  const [showAssignedToResults, setShowAssignedToResults] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    const q = quickAddAssignedTo.trim();
+    if (q.length < 2) {
+      setAssignedToResults([]);
+      setShowAssignedToResults(false);
+      setIsSearchingContacts(false);
+      return;
+    }
+    if (defaultAssignedToName && q === defaultAssignedToName.trim()) {
+      setShowAssignedToResults(false);
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const xrmAny = (globalThis as any).Xrm;
+    const webApi = xrmAny?.WebApi;
+    if (!webApi?.retrieveMultipleRecords) {
+      setShowAssignedToResults(false);
+      setIsSearchingContacts(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsSearchingContacts(true);
+    const handle = window.setTimeout(() => {
+      const escaped = q.replace(/'/g, "''");
+      const url = `?$select=contactid,fullname&$filter=statecode eq 0 and contains(fullname,'${encodeURIComponent(escaped)}')&$top=8&$orderby=fullname asc`;
+      webApi
+        .retrieveMultipleRecords('contact', url)
+        .then((result: { entities?: Array<{ contactid?: string; fullname?: string }> }) => {
+          if (cancelled) return;
+          const mapped = (result.entities ?? [])
+            .filter(e => !!e.contactid && !!e.fullname)
+            .map(e => ({ id: e.contactid as string, name: e.fullname as string }));
+          setAssignedToResults(mapped);
+          setShowAssignedToResults(true);
+          setIsSearchingContacts(false);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setAssignedToResults([]);
+          setShowAssignedToResults(false);
+          setIsSearchingContacts(false);
+        });
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [quickAddAssignedTo, defaultAssignedToName]);
+
+  const handleSelectAssignedTo = React.useCallback((id: string, name: string) => {
+    setQuickAddAssignedTo(name);
+    setQuickAddAssignedToContactId(id);
+    setShowAssignedToResults(false);
+  }, []);
+
+  const handleAssignedToBlur = React.useCallback(() => {
+    window.setTimeout(() => setShowAssignedToResults(false), 150);
+  }, []);
+
+  const handleAssignedToFocus = React.useCallback(() => {
+    if (assignedToResults.length > 0) setShowAssignedToResults(true);
+  }, [assignedToResults.length]);
 
   const handleQuickAddKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLInputElement>) => {
@@ -436,14 +515,51 @@ export const Header: React.FC<HeaderProps> = ({
             aria-label="Due date"
             className={styles.quickAddDateInput}
           />
-          <Input
-            size="small"
-            value={quickAddAssignedTo}
-            onChange={handleQuickAddAssignedToChange}
-            placeholder="Assigned to"
-            aria-label="Assigned to"
-            className={styles.quickAddAssignedInput}
-          />
+          <div className={styles.assignedToWrap}>
+            <Input
+              size="small"
+              value={quickAddAssignedTo}
+              onChange={handleQuickAddAssignedToChange}
+              onFocus={handleAssignedToFocus}
+              onBlur={handleAssignedToBlur}
+              placeholder="Assigned to"
+              aria-label="Assigned to"
+              aria-autocomplete="list"
+              aria-expanded={showAssignedToResults}
+              aria-controls="smart-todo-header-assignedto-results"
+              role="combobox"
+            />
+            {showAssignedToResults && (
+              <div
+                id="smart-todo-header-assignedto-results"
+                role="listbox"
+                className={styles.assignedToResults}
+              >
+                {isSearchingContacts && (
+                  <div className={styles.assignedToResultsHint}>Searching…</div>
+                )}
+                {!isSearchingContacts && assignedToResults.length === 0 && (
+                  <div className={styles.assignedToResultsHint}>No contacts found</div>
+                )}
+                {!isSearchingContacts &&
+                  assignedToResults.map(c => (
+                    <button
+                      key={c.id}
+                      type="button"
+                      role="option"
+                      aria-selected={c.id === quickAddAssignedToContactId}
+                      className={styles.assignedToResultItem}
+                      onMouseDown={e => {
+                        e.preventDefault();
+                        handleSelectAssignedTo(c.id, c.name);
+                      }}
+                    >
+                      {c.name}
+                    </button>
+                  ))}
+              </div>
+            )}
+          </div>
           <Tooltip
             content="Add to-do (Enter)"
             relationship="label"

--- a/src/solutions/SmartTodo/src/components/Modal/SmartTodoModal.tsx
+++ b/src/solutions/SmartTodo/src/components/Modal/SmartTodoModal.tsx
@@ -182,7 +182,9 @@ export const SmartTodoModal: React.FC<SmartTodoModalProps> = ({
   //    listener; for task 040 we plumb the window reference so the shell
   //    is ready to use it the moment 041 lands).
   const [iframeWindow, setIframeWindow] = React.useState<Window | null>(null);
+  const iframeNodeRef = React.useRef<HTMLIFrameElement | null>(null);
   const iframeRef = React.useCallback((node: HTMLIFrameElement | null) => {
+    iframeNodeRef.current = node;
     setIframeWindow(node?.contentWindow ?? null);
   }, []);
 
@@ -193,6 +195,57 @@ export const SmartTodoModal: React.FC<SmartTodoModalProps> = ({
   React.useEffect(() => {
     setIframeLoading(true);
   }, [iframeSrc]);
+
+  // ── UAT 2026-06-21 round 6 — close-on-iframe-navigation guard.
+  //
+  // The OOB MDA form's "Save & Close" button calls `Xrm.Page.ui.close()`
+  // which, when the form is loaded inside an iframe, navigates the IFRAME
+  // away from the form URL (typically to a "back" URL — which in some
+  // environments resolves to the user's home workspace, e.g. SpaarkeAi).
+  // Without intercepting this we get: dialog stays open showing the wrong
+  // page underneath, OR (worse) the parent window navigates and the user
+  // is whisked off the Code Page entirely.
+  //
+  // Mitigation: each iframe `load` event after the FIRST one, compare the
+  // iframe's current URL against the intended form URL. If they no longer
+  // match, the form has closed itself — call onClose to dismiss the modal
+  // before any further parent navigation can cascade.
+  //
+  // Same-origin guard: we read `contentWindow.location.href` only when
+  // same-origin (else the access throws). Cross-origin reads return null
+  // and we treat that as "navigated away" too (defensive).
+  const initialLoadRef = React.useRef<boolean>(true);
+  React.useEffect(() => {
+    // Reset the first-load gate whenever the intended src changes (next
+    // record navigated via prev/next chrome).
+    initialLoadRef.current = true;
+  }, [iframeSrc]);
+
+  const handleIframeLoad = React.useCallback(() => {
+    setIframeLoading(false);
+    if (initialLoadRef.current) {
+      // First load — this IS the form rendering. Don't close.
+      initialLoadRef.current = false;
+      return;
+    }
+    // Subsequent load — the iframe navigated. Compare URL against the
+    // intended form URL; if different (or unreadable), treat as close.
+    const node = iframeNodeRef.current;
+    if (!node) {
+      onClose();
+      return;
+    }
+    let currentHref: string | null = null;
+    try {
+      currentHref = node.contentWindow?.location?.href ?? null;
+    } catch {
+      // Cross-origin access throws — treat as navigated away.
+      currentHref = null;
+    }
+    if (!currentHref || (iframeSrc && !currentHref.startsWith(iframeSrc.split('?')[0]))) {
+      onClose();
+    }
+  }, [iframeSrc, onClose]);
 
   // ── Navigation handler ──────────────────────────────────────────────────
   // Shell guarantees `direction` is 'prev' | 'next' and is only invoked when
@@ -245,7 +298,7 @@ export const SmartTodoModal: React.FC<SmartTodoModalProps> = ({
                   ? `${styles.iframe} ${styles.iframeLoading}`
                   : styles.iframe
               }
-              onLoad={() => setIframeLoading(false)}
+              onLoad={handleIframeLoad}
               title={`To Do ${safeIndex + 1} of ${navTotal}`}
               // Allow the iframe to navigate same-origin Dataverse links
               // without being blocked. The OOB form needs `allow-scripts`

--- a/src/solutions/SmartTodo/src/components/Modal/SmartTodoModal.tsx
+++ b/src/solutions/SmartTodo/src/components/Modal/SmartTodoModal.tsx
@@ -223,6 +223,78 @@ export const SmartTodoModal: React.FC<SmartTodoModalProps> = ({
 
   const handleIframeLoad = React.useCallback(() => {
     setIframeLoading(false);
+
+    // UAT 2026-06-22 round 9 — PARENT-SIDE Save&Close interceptor.
+    //
+    // Originally we shipped a form-script (sprk_todo_dirty_check.js v1.1.0)
+    // that monkey-patched `Xrm.Page.ui.close` from inside the iframe via the
+    // form's OnLoad handler. Console verification confirmed the script was
+    // NEVER REGISTERED on the form designer's OnLoad event — so the patch
+    // never applied and Save & Close still cascade-navigated the parent.
+    //
+    // This block does the same monkey-patch but from the PARENT side. The
+    // iframe loads same-origin Dataverse content (both URLs are
+    // *.dynamics.com / same host), so we can reach into
+    // `iframeNode.contentWindow.Xrm` directly. The patch:
+    //   - Replaces `formContext.ui.close` and `Xrm.Page.ui.close` with a
+    //     function that calls `onClose()` (which dismisses our modal)
+    //     instead of MDA's default close-and-navigate-parent behaviour.
+    //   - This way the parent page (Code Page modal / embedded Code Page /
+    //     SpaarkeAi) stays intact when the user clicks Save & Close.
+    //
+    // Defensive: same-origin access can throw in sandbox / cross-origin
+    // edge cases; failures are caught and logged but never block render.
+    // We re-apply on EVERY load so the prev/next chrome's iframe re-loads
+    // also get patched.
+    const node = iframeNodeRef.current;
+    if (node?.contentWindow) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const iframeWin = node.contentWindow as any;
+        // Xrm may take a moment to initialize inside the iframe — retry
+        // briefly. MDA typically has Xrm ready by the time `load` fires
+        // but defensive against slow loads.
+        const tryPatch = (attempt: number): void => {
+          const xrm = iframeWin.Xrm;
+          if (!xrm?.Page?.ui) {
+            if (attempt < 20) {
+              window.setTimeout(() => tryPatch(attempt + 1), 100);
+            }
+            return;
+          }
+          const closeHandler = (): void => {
+            // eslint-disable-next-line no-console
+            console.log('[SmartTodoModal] intercepted Xrm.Page.ui.close → dismissing modal');
+            onClose();
+          };
+          // Patch the legacy Xrm.Page.ui.close (used by the OOB Save & Close
+          // ribbon command in classic-MDA contexts).
+          try {
+            if (typeof xrm.Page.ui.close === 'function') {
+              xrm.Page.ui.close = closeHandler;
+            }
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.warn('[SmartTodoModal] Xrm.Page.ui.close patch failed', err);
+          }
+          // Patch formContext.ui.close (used by modern command formulas).
+          try {
+            const fc = xrm.Page; // Xrm.Page IS the formContext in classic MDA
+            if (fc?.ui && typeof fc.ui.close === 'function') {
+              fc.ui.close = closeHandler;
+            }
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.warn('[SmartTodoModal] formContext.ui.close patch failed', err);
+          }
+        };
+        tryPatch(0);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[SmartTodoModal] iframe-side patch failed (cross-origin?)', err);
+      }
+    }
+
     if (initialLoadRef.current) {
       // First load — this IS the form rendering. Don't close.
       initialLoadRef.current = false;
@@ -230,7 +302,6 @@ export const SmartTodoModal: React.FC<SmartTodoModalProps> = ({
     }
     // Subsequent load — the iframe navigated. Compare URL against the
     // intended form URL; if different (or unreadable), treat as close.
-    const node = iframeNodeRef.current;
     if (!node) {
       onClose();
       return;

--- a/src/solutions/SmartTodo/src/components/Modal/SmartTodoModal.tsx
+++ b/src/solutions/SmartTodo/src/components/Modal/SmartTodoModal.tsx
@@ -247,6 +247,27 @@ export const SmartTodoModal: React.FC<SmartTodoModalProps> = ({
     }
   }, [iframeSrc, onClose]);
 
+  // ── UAT 2026-06-21 round 8 — Save & Close interceptor protocol.
+  //
+  // The iframe-side form script `sprk_todo_dirty_check.js` (v1.1.0)
+  // monkey-patches `formContext.ui.close` and `Xrm.Page.ui.close` so the
+  // OOB "Save & Close" button posts a `sprk_todo_form_close_intent`
+  // message to us instead of navigating the iframe's parent. We dismiss
+  // the modal on receipt. This preserves the OOB command bar UX (user
+  // still clicks the same Save & Close button) while keeping the parent
+  // page (Code Page modal / embedded Code Page / SpaarkeAi) intact —
+  // closing only the SmartTodoModal layer.
+  React.useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const data = event?.data;
+      if (data && typeof data === 'object' && (data as { type?: unknown }).type === 'sprk_todo_form_close_intent') {
+        onClose();
+      }
+    };
+    window.addEventListener('message', handler, false);
+    return () => window.removeEventListener('message', handler, false);
+  }, [onClose]);
+
   // ── Navigation handler ──────────────────────────────────────────────────
   // Shell guarantees `direction` is 'prev' | 'next' and is only invoked when
   // the corresponding affordance is enabled (i.e. within bounds). Still

--- a/src/solutions/SmartTodo/src/components/SmartToDo.tsx
+++ b/src/solutions/SmartTodo/src/components/SmartToDo.tsx
@@ -649,7 +649,12 @@ export const SmartToDo: React.FC<ISmartToDoProps> = ({
       // Bind set name is `contacts` (plural of the OOB contact table).
       const assignedToContactId = detail.assignedToId || contactId || '';
       if (assignedToContactId) {
-        payload['sprk_assignedto@odata.bind'] = `/contacts(${assignedToContactId})`;
+        // UAT 2026-06-22 round 13: bind key MUST be PascalCase nav-prop
+        // name `sprk_AssignedTo` (verified via EntityDefinitions metadata),
+        // not the lookup column logical name `sprk_assignedto`. The
+        // lowercase form fails with "An undeclared property
+        // 'sprk_assignedto' which only has property annotations..."
+        payload['sprk_AssignedTo@odata.bind'] = `/contacts(${assignedToContactId})`;
       }
       if (detail.dueDate) {
         const [y, m, d] = detail.dueDate.split('-').map(Number);

--- a/src/solutions/SmartTodo/src/components/SmartToDo.tsx
+++ b/src/solutions/SmartTodo/src/components/SmartToDo.tsx
@@ -643,12 +643,13 @@ export const SmartToDo: React.FC<ISmartToDoProps> = ({
         return;
       }
       const payload: Record<string, unknown> = { sprk_name: detail.title };
-      // UAT 2026-06-19 — sprk_assignedto now binds to sprk_contact.
+      // UAT 2026-06-20 — sprk_assignedto binds to the OOB `contact` entity.
       // detail.assignedToId is a contact GUID (the Header's quick-add
       // Assigned To field). When unset, fall back to current user's contactId.
+      // Bind set name is `contacts` (plural of the OOB contact table).
       const assignedToContactId = detail.assignedToId || contactId || '';
       if (assignedToContactId) {
-        payload['sprk_assignedto@odata.bind'] = `/sprk_contacts(${assignedToContactId})`;
+        payload['sprk_assignedto@odata.bind'] = `/contacts(${assignedToContactId})`;
       }
       if (detail.dueDate) {
         const [y, m, d] = detail.dueDate.split('-').map(Number);

--- a/src/solutions/SmartTodo/src/types/entities.ts
+++ b/src/solutions/SmartTodo/src/types/entities.ts
@@ -182,11 +182,16 @@ export interface IOrganization {
   sprk_name: string;
 }
 
-/** Dataverse sprk_contact entity */
+/**
+ * Dataverse `contact` (OOB Person) entity — the entity backing
+ * `sprk_todo.sprk_assignedto` post UAT 2026-06-21 migration. There is no
+ * custom `sprk_contact` table; this interface uses the OOB field names
+ * (`contactid`, `fullname`) so callers serialize/deserialize correctly.
+ */
 export interface IContact {
-  sprk_contactid: string;
-  sprk_name: string;
-  sprk_email?: string;
+  contactid: string;
+  fullname: string;
+  emailaddress1?: string;
 }
 
 /** Dataverse sprk_userpreference entity for storing user-specific settings. */


### PR DESCRIPTION
## Summary

UAT round 4 surfaced 6 bugs against the 2026-06-20 deploy. Root cause discovery: prototype harness mocked a custom `sprk_contact` entity **that does not exist**. The actual schema uses the OOB `contact` (Person) table extended with a custom `sprk_systemuser` lookup. All client code that queried `sprk_contact` / `sprk_contactid` / `sprk_name` / `/sprk_contacts(...)` was silently broken — kanban empty, widget leaked all system todos via no-filter fallback, wizard create would have failed with type mismatch.

## UAT 6 fixes — all deployed to spaarkedev1

| # | Bug | Fix |
|---|---|---|
| 1 | Widget orientation default wrong | Widget defaults to **vertical** (stacked rows); Code Page stays **horizontal** (columns) |
| 2 | Horizontal collapse same-width | Collapsed column adds `flex: 0 0 auto` alongside `alignSelf: flex-start` → shrinks BOTH axes to header content |
| 3 | Open opens TWO stacked modals | LW shim calls `Xrm.Navigation.openForm({entityName:'sprk_todo', entityId})` directly when `todoId` present — no Code Page hop |
| 4 | Future column hidden at narrow width | `KanbanBoard.board` `overflow: hidden` → `overflowX: auto, overflowY: hidden` — horizontal scroll reveals clipped columns |
| 5 | Code Page kanban empty | `useCurrentContactId` queries OOB `contact` entity (not `sprk_contact`) with `contactid` / `fullname` fields |
| 5a | **Security regression**: widget showed all 14 active sprk_todos system-wide | `buildSmartTodoQuery` returns zero-row filter when contactId is null AND no regarding context (was falling back to activeClause-only — data isolation breach) |
| 6 | Assigned To not a real lookup | Replaced plain Input with debounced typeahead picker — searches OOB contact by fullname (2+ chars), shows up to 8 results, click to select. Applied to both widget AND Code Page Header. |

## CreateTodoWizard sub-fix (also bundled)

Without this, every NEW To Do created via the `+` wizard would fail with Dataverse type mismatch:
- `todoService` bind `/systemusers(${id})` → `/contacts(${id})`
- `TodoWizardDialog`: Assignee LookupField wired to `searchContactsAsLookup` (not `searchUsersAsLookup`)
- `CreateTodoStep` placeholder "Search users..." → "Search contacts..."
- Unit test asserts contact entity + bind

## Deploys (already on spaarkedev1)

| Surface | Web Resource | Bundle |
|---|---|---|
| SmartTodo Code Page | `sprk_smarttodo` | 1719 KB |
| SpaarkeAi (LW shell + widget) | `sprk_spaarkeai` | 3851 KB |
| CreateTodoWizard | `sprk_createtodowizard` | 1617 KB |

## Schema verification (via MCP)

- `sprk_todo.sprk_assignedto` → Contact lookup ✓
- User contact `2e419a4f-010d-f111-8342-7ced8d1dc988` ("Ralph Schroeder") linked via `sprk_systemuser` to systemuser `1d02f31c-1872-f011-b4cb-7c1e52671ad0` ✓

## Process gap

Prototype harness mocked `sprk_contact` perfectly — entirely hiding the entity-name bug. Future R-cycles MUST add a "real Dataverse smoke" gate before merge. Noted in R4-092 task notes.

## Test plan

- [ ] Widget: opens in vertical orientation on first visit (3 sections stacked)
- [ ] Widget: toggle to horizontal; collapse a column → shrinks to thin tab strip
- [ ] Widget: click Open on a card → single record form modal (no Code Page wrapper)
- [ ] Widget: in horizontal mode at narrow width → can horizontally scroll to Future
- [ ] Code Page: opens in horizontal orientation; renders user's To Dos (was empty)
- [ ] Widget + Code Page: type "Ral" in Assigned To field → typeahead dropdown shows matching contacts → click selects
- [ ] CreateTodoWizard: opens, Assignee picker searches contacts (not users), create succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)