### PR TITLE
chore(pcf-orphan-cleanup-r1): project scaffolding + research artifacts

### DIFF
--- a/projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md
+++ b/projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md
@@ -1,0 +1,488 @@
+# Orphan PCF Cleanup + React Types Alignment — Procedure
+
+> **Date**: 2026-06-22
+> **Companion to**: [pcf-deployment-inventory-2026-06-22.md](pcf-deployment-inventory-2026-06-22.md)
+> **Trigger**: chat-routing-redesign-r1 raised TypeScript drift in `@spaarke/ui-components` consumers (bucket A/B/C/D in the original report); inventory pass confirmed UQC and 10 other PCFs are orphans.
+> **Status**: APPROVED 2026-06-22 — owner confirmed DTW + SDV are unused; expanded scope; bucket D shrunk to VisualHost-only.
+> **Scope**: source-tree cleanup (UQC + DTW + SDV) + Dataverse-side cleanup (12 PCFs, ~6 canvas apps) + shared-lib @types/react alignment + VisualHost re-pin.
+> **Estimated effort**: 3–5 days end-to-end across 4 PRs + 1 Dataverse cleanup session.
+>
+> **Revision 2026-06-22 (post owner confirmation)**:
+> - DrillThroughWorkspace + SpeDocumentViewer confirmed unused. Folded into Part B (source delete) and Part C (Dataverse delete).
+> - PR-D2 shrunk from 3 PCFs to 1 (VisualHost only) — DTW + SDV go away in Part C instead of being re-pinned.
+> - Added §3.5 explicit resurrection / recovery playbook.
+
+---
+
+## 0. Why this is one procedure, not three
+
+Three distinct fix-streams emerged from the chat-routing-redesign-r1 audit:
+
+1. **Source-tree drift** — UQC has source but no live deployment use.
+2. **Dataverse drift** — 10 published `customcontrol` records have no source backing.
+3. **Type-system drift** — shared lib `@types/react ^19` collides with PCF `@types/react ^16/^18` pins; ribbon-of-elements typing errors (bucket D in the original report).
+
+They share one root cause (no system has been the authoritative inventory of which PCFs exist + which are alive) and one fix vehicle (one focused project that cleans both source and Dataverse and re-pins the type contract). Doing them separately invites re-drift between PRs.
+
+---
+
+## 1. Pre-flight (binding, before ANY destructive action)
+
+### 1.1 Capture a baseline backup
+
+```powershell
+# Replace {ENV} with spaarkedev1, etc.
+pac auth select --name {ENV}
+pac solution list --output table > baseline-solution-list-2026-06-22.txt
+# For each solution that contains an orphan control, export it unmanaged BEFORE editing
+pac solution export --name {SolutionName} --path baseline-{SolutionName}-pre-cleanup-2026-06-22.zip --managed false --include general
+```
+
+Park the ZIPs in `projects/ai-procedure-quality-r1/notes/inventory/backups-2026-06-22/`. These are the rollback source if any cleanup step proves wrong.
+
+### 1.2 Per-control "still-referenced?" check
+
+For every PCF and canvas app slated for deletion, confirm zero live references BEFORE removing. Run these checks via Dataverse MCP `read_query` (or PAC CLI for the FormXML body, since MCP can't fetch `formxml` directly):
+
+**Check 1 — Solution memberships** (which solutions contain this control?):
+```sql
+-- objectid = customcontrolid
+SELECT TOP 20 sc.solutionid, sc.objectid, s.uniquename
+FROM solutioncomponent sc
+JOIN solution s ON sc.solutionid = s.solutionid
+WHERE sc.objectid = '{CUSTOMCONTROL_GUID}'
+```
+
+**Check 2 — Form references** (does any systemform's formxml mention the constructor?):
+```powershell
+# PAC CLI - export the unmanaged solution containing the suspected forms and grep
+# (Dataverse MCP cannot fetch formxml body directly)
+pac solution export --name Default --path Default-temp.zip --managed false
+Expand-Archive Default-temp.zip -DestinationPath Default-temp/
+Select-String -Path Default-temp\customizations.xml -Pattern "Spaarke.Controls.UniversalDocumentUpload"
+```
+
+**Check 3 — Ribbon references** (does any ribbon JS or RibbonDefinition reference the canvas app?):
+```powershell
+Select-String -Path Default-temp\customizations.xml -Pattern "sprk_documentuploaddialog_e52db"
+```
+Also grep `src/solutions/*/` and `src/client/pcf/*/` source for the same string.
+
+**Check 4 — Canvas app dependencies** (what does each orphan canvas app reference?):
+```sql
+SELECT TOP 5 name, appcomponentdependencies, cdsdependencies FROM canvasapp WHERE canvasappid = '{GUID}'
+```
+
+**Gate**: a control / canvas app is safe to delete ONLY when:
+- Check 1 lists only solutions YOU intend to remove it from
+- Check 2 returns zero matches in any form definition
+- Check 3 returns zero matches in any ribbon JS or `RibbonDefinitions`
+- Check 4 confirms no incoming dependencies from other live artifacts
+
+If ANY check returns unexpected results, **stop and reconcile** — do not proceed with deletion. File the finding as an "unexpected reference" note in the project log.
+
+### 1.3 Environment scope
+
+All Dataverse-side operations execute against **spaarkedev1 first**. After successful spaarkedev1 cleanup + 1-week soak with no regression reports, apply to spaarkedev2 and any prod-class envs in turn.
+
+---
+
+## 2. Part B — source-tree deletion (PR 1)
+
+### 2.1 Goal
+
+Delete three orphan PCF folders. After this PR, the source tree has 11 PCFs, not 14:
+- `src/client/pcf/UniversalQuickCreate/` — orphan per ribbon migration evidence
+- `src/client/pcf/DrillThroughWorkspace/` — built but never deployed (per 2026-05-14 bundle audit; reconfirmed 2026-06-22)
+- `src/client/pcf/SpeDocumentViewer/` — confirmed unused 2026-06-22 (no external importers in source; owner confirms)
+
+### 2.2 Steps
+
+1. **Identify residual importers** for all three:
+   ```powershell
+   # From repo root
+   Select-String -Path "src\**\*.ts","src\**\*.tsx","src\**\*.js" -Pattern "UniversalQuickCreate|UniversalDocumentUpload|DrillThroughWorkspace|SpeDocumentViewer|@spaarke/ui-components/src/services/document-upload|@spaarke/ui-components/dist/utils/themeStorage" -SimpleMatch
+   ```
+   Expected matches (safe to ignore — these are inside the folders being deleted):
+   - `src/client/pcf/UniversalQuickCreate/**`, `src/client/pcf/DrillThroughWorkspace/**`, `src/client/pcf/SpeDocumentViewer/**` (all files — going away)
+   - `src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js` lines 582-585 (the version-history comment block — keep, it's documentation)
+
+   Unexpected matches: STOP and reconcile.
+
+2. **Delete the three folders**:
+   ```powershell
+   git rm -r src/client/pcf/UniversalQuickCreate/
+   git rm -r src/client/pcf/DrillThroughWorkspace/
+   git rm -r src/client/pcf/SpeDocumentViewer/
+   ```
+
+3. **Verify the deprecated SSE re-export stub is gone**. The original bucket B finding (broken `useSseStream.ts` stub re-exporting nonexistent `SseStreamStatus` / `SseDataChunk` / `UseSseStreamOptions` / `UseSseStreamResult`) lives at `src/client/pcf/UniversalQuickCreate/control/services/useSseStream.ts` — `git rm -r` removes it automatically. Confirm no other file imports from it:
+   ```powershell
+   Select-String -Path "src\**\*.ts","src\**\*.tsx" -Pattern "from ['""].*UniversalQuickCreate.*useSseStream"
+   ```
+
+4. **Update any script that lists PCFs to deploy** if it hard-codes the three controls. Search:
+   ```powershell
+   Select-String -Path "scripts\**\*.ps1","scripts\**\*.sh","scripts\**\*.js" -Pattern "UniversalQuickCreate|UniversalDocumentUpload|DrillThroughWorkspace|SpeDocumentViewer"
+   ```
+
+5. **Build the workspace** to confirm no consumer broke:
+   ```powershell
+   # Repo root
+   dotnet build src\server\api\Sprk.Bff.Api\
+   # PCF workspace
+   pushd src\client\pcf; npm run build; popd
+   ```
+
+6. **Commit**:
+   ```
+   chore(pcf): retire 3 orphan PCFs (UQC + DrillThroughWorkspace + SpeDocumentViewer)
+
+   - UQC: ribbon migrated to Code Page in sprk_subgrid_commands.js v4.0.0
+   - DrillThroughWorkspace: built locally, never deployed (per 2026-05-14 bundle audit)
+   - SpeDocumentViewer: no external importers; confirmed unused 2026-06-22
+
+   Dataverse-side cleanup follows in subsequent PR.
+   See: projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md §4
+   ```
+
+### 2.3 Rollback
+
+`git revert {sha}`. All three folders restored verbatim. No external state changed.
+
+> **Why "all three in one PR" vs three PRs**: each deletion is independent (no cross-folder dependencies), the validation is the same single grep, and one PR keeps the review burden contained. If a reviewer challenges any one of the three, that one can be backed out with a targeted `git restore` before merge.
+
+---
+
+## 3. Part C — Dataverse cleanup (single session, gated)
+
+### 3.1 Cleanup targets
+
+12 `customcontrol` records + 4-6 canvas apps. Ordered by risk (lowest first — the ones with documented evidence of orphan status come first):
+
+| Order | customcontrol | Hosting canvas app | Why orphan | Verify before deleting |
+|---:|---|---|---|---|
+| 1 | `sprk_Spaarke.Controls.UniversalDocumentUpload` v3.15.2 | `sprk_documentuploaddialog_e52db` | Ribbon migrated to Code Page v4.0.0 (sprk_subgrid_commands.js:582-585) | §1.2 checks 1–4 |
+| 2 | `sprk_Spaarke.SpeDocumentViewer` v1.0.27 | (none — verify) | No external importers in source (confirmed 2026-06-22) | §1.2 checks 1–4 **MANDATORY** — SDV was likely bound to forms; verify FormXML grep is clean |
+| 3 | `sprk_Spaarke.Controls.AnalysisBuilder` v2.9.2 | `sprk_analysisbuilder_40af8` | Superseded by AnalysisBuilder Code Page | §1.2 checks 1–4 |
+| 4 | `sprk_Spaarke.Controls.AnalysisWorkspace` v1.3.5 | `sprk_analysisworkspace_8bc0b` | Superseded by AnalysisWorkspace Code Page (`src/client/code-pages/AnalysisWorkspace/`) | §1.2 checks 1–4 |
+| 5 | `sprk_Spaarke.Controls.DueDatesWidget` v1.0.8 | (none — verify) | Retired | §1.2 checks 1–4 |
+| 6 | `sprk_Spaarke.Controls.EventAutoAssociate` v1.0.0 | (none — verify) | Retired | §1.2 checks 1–4 |
+| 7 | `sprk_Spaarke.Controls.EventCalendarFilter` v1.0.5 | (none — verify) | Superseded by `@spaarke/events-components` CalendarFilterPane | §1.2 checks 1–4 |
+| 8 | `sprk_Spaarke.Controls.EventFormController` v1.0.6 | (none — verify) | Retired | §1.2 checks 1–4 |
+| 9 | `sprk_Spaarke.Controls.FieldMappingAdmin` v1.1.0 | (none — verify) | Admin UI consolidated | §1.2 checks 1–4 |
+| 10 | `sprk_Spaarke.Controls.RegardingLink` v1.1.6 | (none — verify) | Predecessor of RegardingResolver (still deployed) | §1.2 checks 1–4 |
+| 11 | `sprk_Spaarke.LegalWorkspace` v1.0.1 | (none — verify; the `sprk_eventspage_786f4` canvas may be related) | Superseded by LegalWorkspace Code Page | §1.2 checks 1–4 |
+| 12 | (DrillThroughWorkspace — source delete only; never deployed to Dataverse, so no Part C action) | `sprk_visualizationdrillthroughworkspace_e48a5` (canvas app exists but hosts a control that isn't deployed — verify and delete the empty canvas if confirmed) | Built but never deployed | §1.2 check 4 on the canvas app only |
+| (open) | `sprk_Spaarke.Controls.PlaybookBuilderHost` v2.25.0 | `sprk_playbookbuilder_eb5ad` | Source layout non-standard — needs owner triage BEFORE listing as orphan | OWNER DECISION REQUIRED — do NOT delete in this pass |
+
+> **Why SDV comes second**: it has the most pre-existing form-binding risk of the orphans (PCFs bound to document-bearing entity forms). The §1.2 check 2 (FormXML grep) is the load-bearing safety check — do not skip on SDV.
+> **Why DTW is in this table at all**: its source goes away in Part B, but its hosting canvas app `sprk_visualizationdrillthroughworkspace_e48a5` is still deployed (2026-03-09). Verify the canvas is truly orphaned (no ribbon button opens it) before deleting; if confirmed, delete the canvas in step 6 of the per-control sequence.
+
+> Order matters: UQC first because it has the cleanest evidence chain (ribbon migration documented in source). PlaybookBuilderHost is NOT in this pass — it needs a separate owner triage (see [pcf-deployment-inventory-2026-06-22.md §6.4](pcf-deployment-inventory-2026-06-22.md)).
+
+### 3.2 Per-control deletion sequence
+
+For each row in §3.1 (in the listed order), execute these steps in `spaarkedev1`:
+
+**Step 1 — Run §1.2 checks**. Document the output in a per-control log. STOP if any check returns unexpected references.
+
+**Step 2 — Remove form references first** (if §1.2 check 2 surfaced any). For each form that includes the PCF as a control:
+- In Power Apps Maker: open the form → select the field/section with the control → "Remove custom control" → save → publish.
+- OR: edit the form via `pac solution clone --name {SolutionName}` → modify `customizations.xml` → re-pack → import.
+- Verify the form opens correctly without the PCF.
+
+**Step 3 — Unpublish the canvas app** (if applicable):
+- Power Apps Maker → Apps → find the canvas app by `name` (e.g., `sprk_documentuploaddialog_e52db`) → "..." → Unpublish.
+
+**Step 4 — Remove canvas app from solution**:
+- Power Apps Maker → Solutions → open each solution containing the canvas app → Objects → select canvas → Remove → "Remove from this solution" (not "Delete from this environment" — keep that for Step 6).
+
+**Step 5 — Remove customcontrol from solution**:
+- Same UI flow: open each owning solution → Objects → select the PCF → Remove → "Remove from this solution".
+
+**Step 6 — Delete the canvas app** (now unsolutioned + unpublished):
+- Power Apps Maker → Apps → "..." → Delete. Confirm.
+
+**Step 7 — Delete the customcontrol** (now unsolutioned):
+- Easiest path: from a maker session with the customizations area open, find the PCF under "Custom controls" → Delete.
+- Alternative (Web API): `DELETE /api/data/v9.2/customcontrols({customcontrolid})` with `Authorization: Bearer {token}`. Requires `System Administrator` role.
+
+**Step 8 — Verify**:
+- Re-run §1.2 check 1 for this control's GUID — should return empty.
+- `mcp__dataverse__read_query` against `customcontrol` with the deleted name — should return empty.
+- Quick smoke test of any nearby live PCFs (e.g., after deleting UQC, open a Matter → confirm Documents subgrid still works; after deleting EventCalendarFilter, open the Events Page Code Page → confirm filtering still works).
+
+**Step 9 — Log**:
+Per-control log entry in `projects/ai-procedure-quality-r1/notes/inventory/dataverse-cleanup-log-2026-06-22.md`:
+```
+- 2026-MM-DD HH:MM — {control name} v{x.y.z}
+  - §1.2 results: refs = none (or list)
+  - Hosting canvas: {name or none}
+  - Solutions touched: {list}
+  - Deletion confirmed: PCF GUID {GUID}; canvas GUID {GUID}
+  - Smoke test: PASS / FAIL ({details})
+```
+
+### 3.3 Rollback
+
+If a deletion turns out to break something:
+- Re-import the relevant baseline solution backup from §1.1 (`pac solution import --path baseline-{X}-pre-cleanup-2026-06-22.zip`). This re-creates the PCF and canvas-app records.
+- Note: importing a backup will NOT restore form references that were edited in Step 2 — those need manual re-add.
+
+### 3.4 Soak
+
+After all 11 deletions + canvas-app cleanups complete in spaarkedev1, wait **7 days** of business use. If no regression reports, repeat the sequence in spaarkedev2. Do NOT batch-fire across environments.
+
+---
+
+### 3.5 Resurrection / recovery — explicit playbook
+
+If a Part C deletion turns out to have broken something live, recovery is straightforward IF the §1.1 baseline backups exist. Three recovery paths, by what got deleted:
+
+#### 3.5.1 Source-tree deletion (Part B) was wrong
+
+Recovery cost: **seconds**. Either:
+```powershell
+# Surgical — bring back just one folder
+git checkout {pre-deletion-sha}~1 -- src/client/pcf/SpeDocumentViewer/
+
+# OR full PR revert (if all three deletions need to come back)
+git revert {part-B-merge-sha}
+```
+The folder is restored verbatim. Re-run `npm install --legacy-peer-deps` in the workspace; build with `npm run build:prod`; redeploy if Part C also ran on this control (see 3.5.2).
+
+#### 3.5.2 Dataverse `customcontrol` deletion (Part C) was wrong
+
+Recovery cost: **5–10 min**. From the §1.1 baseline backup:
+```powershell
+pac auth select --name spaarkedev1
+pac solution import --path baseline-{SolutionName}-pre-cleanup-2026-06-22.zip --force-overwrite --publish-changes
+```
+
+This restores the PCF record with its bundle.js and manifest. **The `customcontrolid` GUID will be different from the deleted one.** Implications:
+- Form bindings that reference the control by name (the common case) — work immediately after publish.
+- Anything that hardcoded the old GUID (rare — verify by grepping `customizations.xml` from the imported solution for the new GUID and any form that was edited in Part C step 2) — needs re-wire.
+
+After import, if any form had its PCF binding manually removed in Part C step 2, re-add the binding via the Power Apps Maker form designer (it'll resolve the control by name automatically).
+
+#### 3.5.3 Canvas app deletion (Part C) was wrong
+
+Recovery cost: **5–10 min**. Same `pac solution import` as 3.5.2 — the canvas app's `.msapp` blob is preserved in the solution backup. The `canvasappid` GUID will be different from the deleted one; any ribbon JS that hardcoded the old GUID needs to be updated to the new one.
+
+In practice, ribbon JS in this codebase references canvas apps by NAME (see [sprk_subgrid_commands.js:361](../../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js#L361) — `webresourceName: "sprk_documentuploadwizard"`) — so name-based refs survive. GUID-based refs are the exception; the §1.2 check 3 ribbon grep would have surfaced any during pre-flight.
+
+#### 3.5.4 No baseline backup exists (worst case)
+
+If the §1.1 backup ZIPs were skipped (DO NOT skip them — that's the whole point of §1):
+
+- **Source-deletion recovery still works** — git history is permanent.
+- **Customcontrol recovery is harder for the 9 already-source-less PCFs** (AnalysisBuilder, etc.): trace git history for the last commit that had the source folder (`git log --all -- src/client/pcf/{X}`), restore via `git checkout {sha} -- {path}`, rebuild, deploy as a new solution. Hours-to-days depending on how far back the source was removed.
+- **Customcontrol recovery for UQC/DTW/SDV without backup**: still doable from current source (or from the Part B `git revert`). Build with `npm run build:prod`, deploy via the PCF deployment guide. ~1 hour per control.
+
+The §1.1 backup is the difference between "5-minute panic" and "afternoon of forensic recovery." Make the backups.
+
+---
+
+## 4. Part D — Shared lib + PCF React-types alignment (PRs 2 + 3)
+
+### 4.1 Current state (post Part B)
+
+After deleting UQC + DrillThroughWorkspace + SpeDocumentViewer in Part B, the remaining 11 PCFs split into two camps:
+
+| Camp | Count | PCFs | Pins |
+|---|---:|---|---|
+| **React 16** (matches platform-library runtime, ADR-022 canonical) | 9 | AssociationResolver, DocumentRelationshipViewer, EmailProcessingMonitor, RegardingResolver, RelatedDocumentCount, ScopeConfigEditor, SemanticSearchControl, SpaarkeGridCustomizer, UpdateRelatedButton | `react ^16.14.0`, `@types/react ^16.14.x` |
+| **React 18** (drift — does not match platform-library runtime) | 1 | VisualHost | `react ^18.2.0`, `@types/react ^18.2.0` |
+| **n/a** (shared-lib-published, not a standalone PCF) | 1 | ThemeEnforcer | `react ^16.14.0`, `@types/react ^16.14.x` |
+
+Plus the shared lib at `@types/react ^19.0.0` in `devDependencies` ([`Spaarke.UI.Components/package.json:69`](../../../../src/client/shared/Spaarke.UI.Components/package.json#L69)).
+
+> Owner-confirmed 2026-06-22: VisualHost source contains zero React 18-only API usage (`useId`, `useTransition`, `useDeferredValue`, `useSyncExternalStore`, `useInsertionEffect`, `createRoot`, `hydrateRoot`, `startTransition`) — verified via grep of `src/client/pcf/VisualHost/control/**/*.{ts,tsx}`. Re-pin to React 16 is feature-preserving.
+
+### 4.2 Target state
+
+Canonical contract:
+- **PCF runtime**: React 16.14.0 (platform-library, per ADR-022 — unchanged).
+- **PCF type pins**: `@types/react ^16.14.x` and `react ^16.14.0` across all 11 PCFs (VisualHost re-pinned down from ^18; DTW + SDV go away in Part B/C instead).
+- **Shared lib `@spaarke/ui-components`**:
+  - `peerDependencies`: `react: >=16.14.0` (already there), `react-dom: >=16.14.0` (already there), **`@types/react: >=16.14 || >=17 || >=18 || >=19`** (NEW), **`@types/react-dom: >=16.14 || >=17 || >=18 || >=19`** (NEW).
+  - `devDependencies`: keep `@types/react ^19.0.0` for the lib's own type-checking. The peerDep tells consumers "bring your own".
+- **Code Pages and `src/solutions/*`** (Vite SPAs): continue with their own React 18+ / `@types/react` 18+ pins. The shared lib's peerDep range accepts them.
+
+This is consistent with ADR-022 ("React 16 APIs only" for PCFs — the shared lib must avoid React 18+ APIs to be safe to consume from a React 16 PCF).
+
+### 4.3 PR-D1 — Shared lib peerDep fix
+
+**File**: [`src/client/shared/Spaarke.UI.Components/package.json`](../../../../src/client/shared/Spaarke.UI.Components/package.json)
+
+**Change** — add to `peerDependencies` (keep devDeps as-is for self-build):
+```json
+"peerDependencies": {
+  "@types/react": ">=16.14 || >=17 || >=18 || >=19",
+  "@types/react-dom": ">=16.14 || >=17 || >=18 || >=19",
+  ... existing react / react-dom peerDeps ...
+}
+```
+
+**Verify** — before merging, run an audit of the shared lib source for React 18+ APIs that would silently break React-16 consumers:
+
+```powershell
+# From src/client/shared/Spaarke.UI.Components
+Select-String -Path "src\**\*.ts","src\**\*.tsx" -Pattern "\b(useId|useTransition|useDeferredValue|useSyncExternalStore|useInsertionEffect|createRoot|hydrateRoot|startTransition)\b"
+```
+
+If hits — for EACH hit, decide:
+- **Replace with a React-16-compatible equivalent** (e.g., `useId` → manual id generator with `useRef`; `useSyncExternalStore` → manual `useEffect` + `useState`).
+- **OR feature-gate** the hook behind a runtime check (acceptable for opt-in features used only by React 18+ Code Pages).
+- **OR document the surface as React-18-only** and prevent React-16 consumers (PCFs) from importing it.
+
+Run the build matrix to confirm:
+```powershell
+pushd src\client\shared\Spaarke.UI.Components; npm run build; popd
+pushd src\client\pcf; npm run build; popd  # All 13 PCFs
+# Plus each Code Page that consumes @spaarke/ui-components — spot-check 3:
+pushd src\solutions\SmartTodo; npm run build; popd
+pushd src\solutions\SpaarkeAi; npm run build; popd
+pushd src\solutions\LegalWorkspace; npm run build; popd
+```
+
+**Commit**:
+```
+fix(ui-components): declare @types/react as peerDep (multi-major)
+
+Allows React 16 PCF consumers and React 18+ Code Page consumers to share
+the same lib without duplicate ReactElement type identities (bucket D from
+chat-routing-redesign-r1 audit). Shared lib audited for React 18+ APIs;
+none in load-bearing components.
+```
+
+### 4.4 PR-D2 — Re-pin VisualHost to React 16
+
+**File** — one PCF `package.json`:
+
+| File | Change `react` | Change `@types/react` |
+|---|---|---|
+| [`src/client/pcf/VisualHost/package.json`](../../../../src/client/pcf/VisualHost/package.json) | `^18.2.0` → `^16.14.0` | `^18.2.0` → `^16.14.60` |
+
+```powershell
+pushd src\client\pcf\VisualHost
+Remove-Item -Recurse -Force node_modules
+Remove-Item -Force package-lock.json
+npm install --legacy-peer-deps --no-audit --no-fund
+npm run build:prod  # MUST be build:prod, not build (per CLAUDE.md §11 / FAILURE-MODES.md#AP-1)
+popd
+```
+
+Check the bundle.js size before/after — should NOT grow significantly. If bundle grows >20%, investigate (could mean React 16 isn't being properly externalized via platform-library).
+
+**Re-verify VisualHost source for React 18-only API usage** (defensive — already audited 2026-06-22, but re-run before merging the PR in case any new code lands):
+```powershell
+Select-String -Path "src\client\pcf\VisualHost\control\**\*.ts","src\client\pcf\VisualHost\control\**\*.tsx" -Pattern "\b(useId|useTransition|useDeferredValue|useSyncExternalStore|useInsertionEffect|createRoot|hydrateRoot|startTransition)\b"
+```
+Expected: zero hits (confirmed 2026-06-22 grep returned empty). Any hit → STOP and reconcile.
+
+Deploy VisualHost to spaarkedev1 and smoke-test (chart rendering, drill-through, MetricCard matrix layouts — full feature surface). Bump manifest version (e.g., 1.4.16 → 1.4.17).
+
+**Commit**:
+```
+fix(pcf): re-pin VisualHost to React 16 type pins (match platform-library runtime, ADR-022)
+
+Closes bucket D from chat-routing-redesign-r1 audit. VisualHost was on
+@types/react ^18.2.0 while the platform-library runtime is React 16.14.0.
+This drift produced duplicate-ReactElement TS2322 errors when consuming
+@spaarke/ui-components from VisualHost. Re-pin to ^16.14.x for type/runtime
+parity. Shared lib's peerDep range (PR-D1) accepts both 16 and 18+ consumers.
+
+Source audited for React 18-only APIs (2026-06-22, re-verified pre-merge):
+zero hits. Feature surface preserved.
+
+(DrillThroughWorkspace + SpeDocumentViewer were initially also slated for re-pin
+but were instead deleted in Part B as orphans — owner confirmed unused 2026-06-22.)
+```
+
+### 4.5 Test matrix after PR-D2
+
+| Workspace | Build | Smoke test |
+|---|---|---|
+| `Spaarke.UI.Components` | `npm run build` | n/a (lib) |
+| 9 React-16 PCFs | `npm run build:prod` each | spot-check 2-3 in spaarkedev1 |
+| VisualHost (newly aligned) | `npm run build:prod` | smoke in spaarkedev1 (charts, drill-through, MetricCard, your recent enhancements) |
+| 3 React 18+ Code Pages (spot-check) | `npm run build` each | smoke each as deployed web resource |
+
+---
+
+## 5. Sequencing + acceptance gates
+
+```
+Day 1-2:  PR 1 (Part B source deletion: UQC + DTW + SDV) — owner review + merge
+Day 3:    Pre-flight §1.1 + §1.2 in spaarkedev1
+Day 4:    Part C cleanup session in spaarkedev1 (4-6 hours, one focused block — 11 customcontrols + canvas apps)
+Day 4-10: 1-week soak — monitor for regressions
+Day 11:   PR-D1 (shared lib peerDep)
+Day 12:   PR-D2 (VisualHost re-pin) — deploy, smoke test
+Day 13:   Part C cleanup in spaarkedev2 (replay)
+Day 14+:  Promote to prod env per the standard release procedure
+```
+
+Acceptance gate to call this work complete:
+
+- [ ] UQC + DrillThroughWorkspace + SpeDocumentViewer folders absent from `main`
+- [ ] 11 orphan `customcontrol` records absent from spaarkedev1 (Dataverse MCP query returns empty)
+- [ ] 4–6 orphan canvas apps absent from spaarkedev1
+- [ ] VisualHost re-pinned to React 16 + rebuild + deploy + smoke-test pass (charts, drill-through, MetricCard, recent enhancements)
+- [ ] Shared lib peerDep range accepts both React 16 and React 19 consumers (verified by build matrix)
+- [ ] No new TS2322 / TS2305 / TS2307 errors in any of the 11 PCFs or 4 code-pages
+- [ ] §1.1 baseline solution backup ZIPs filed in `projects/ai-procedure-quality-r1/notes/inventory/backups-2026-06-22/`
+- [ ] `pcf-deployment-inventory-2026-06-22.md` updated with "as of YYYY-MM-DD: cleanup complete" footnote
+- [ ] `dataverse-cleanup-log-2026-06-22.md` exists with per-control entries
+
+---
+
+## 6. Risk register
+
+| Risk | Likelihood | Severity | Mitigation |
+|---|---|---|---|
+| §1.2 checks miss a form reference; deleting PCF breaks a form | LOW | HIGH | Always do PAC CLI customizations.xml grep, not just MCP. Test in spaarkedev1 first; 7-day soak. Recovery via §3.5.2 (baseline backup re-import). |
+| **SpeDocumentViewer was bound to forms we didn't find** | MED | HIGH | §1.2 check 2 (FormXML grep) is MANDATORY on SDV — flagged as "do not skip" in the §3.1 cleanup-targets table. Recovery via §3.5.2 if the grep missed something. |
+| Canvas app is referenced by an unknown ribbon / business process | LOW | MED | Grep all PowerShell scripts + JS resource code for the canvas app name before deletion. |
+| Shared lib uses a React 18+ API that breaks React 16 PCFs after PR-D1 | MED | MED | PR-D1 §4.3 audit step is mandatory before merge. Any hit → replace or feature-gate. |
+| **Re-pinning VisualHost breaks recent enhancements** | LOW | HIGH | Owner-verified 2026-06-22: VisualHost source has zero React 18-only API usage. §4.4 re-verifies pre-merge. Smoke-test covers chart/drill-through/MetricCard. |
+| PlaybookBuilderHost is more "live" than the inventory thinks | MED | HIGH | Explicitly OUT of scope (§3.1). Separate owner triage required. |
+| Production env (not spaarkedev1) has different ribbon JS that still calls UQC's canvas | MED | HIGH | Spaarkedev2 / prod replay only AFTER 7-day soak in spaarkedev1. Each env independently runs §1.2 checks. |
+| **Baseline backup ZIPs were skipped in §1.1** | LOW | HIGH | Acceptance gate (§5) now requires the backup ZIPs to exist in `backups-2026-06-22/`. §3.5.4 documents the "no backup" recovery path so the impact is bounded but the cost is steep — DO NOT skip §1.1. |
+
+---
+
+## 7. Formalization
+
+This document is a procedure draft. To formalize as a project (recommended given the 3-5 day scope and the production blast radius), spin up a new project folder following the standard pattern:
+
+```
+projects/pcf-orphan-cleanup-r1/
+├── README.md           # Project overview
+├── spec.md             # FRs / NFRs / Success Criteria
+├── design.md           # This document, refactored as design.md
+├── CLAUDE.md           # Project-scoped AI context
+├── current-task.md     # Active task pointer
+└── tasks/              # POML decomposition (suggest 7 tasks)
+    ├── 001-preflight-backups.poml
+    ├── 002-source-deletion-uqc-dtw-sdv.poml
+    ├── 003-dataverse-cleanup-spaarkedev1.poml
+    ├── 004-shared-lib-peerdep-fix.poml
+    ├── 005-visualhost-react16-realign.poml
+    ├── 006-dataverse-cleanup-spaarkedev2.poml
+    └── 007-cleanup-log-finalize.poml
+```
+
+The procedure-vs-project decision is the owner's call. The cleanup itself can run from this doc alone if preferred (the steps are concrete enough); the project pattern is overhead only worth paying if multiple contributors will share the work or if the spaarkedev1/spaarkedev2/prod replay needs to be sequenced over multiple weeks.
+
+---
+
+## 8. Cross-references
+
+- [pcf-deployment-inventory-2026-06-22.md](pcf-deployment-inventory-2026-06-22.md) — the data backing this procedure
+- [pcf-bundle-sizes.md](pcf-bundle-sizes.md) — 2026-05-14 bundle-size baseline (still applies to remaining 13 PCFs post-cleanup; UQC entry becomes obsolete)
+- [`.claude/adr/ADR-022-pcf-platform-libraries.md`](../../../../.claude/adr/ADR-022-pcf-platform-libraries.md) — binding constraint for "React 16 APIs only" in PCFs
+- [`docs/guides/PCF-DEPLOYMENT-GUIDE.md`](../../../../docs/guides/PCF-DEPLOYMENT-GUIDE.md) — full PCF redeploy procedure (referenced from §4.4 / §3.2 step 4)
+- [`.claude/FAILURE-MODES.md#AP-1`](../../../../.claude/FAILURE-MODES.md) — `build:prod` not `build` (referenced from §4.4)

--- a/projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md
+++ b/projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md
@@ -1,0 +1,257 @@
+# PCF + Code Page Deployment Inventory
+
+> **Date**: 2026-06-22
+> **Triggered by**: chat-routing-redesign-r1 raised TypeScript drift in `@spaarke/ui-components` consumers; UQC was implicated. Owner asked: *"is UQC actually still in use, and is there a definitive inventory we can rely on?"*
+> **Methodology**: source-tree enumeration (Glob + manifest reads) + live Dataverse query (`spaarkedev1` via Dataverse MCP) + ribbon-command source inspection.
+> **Companion artifacts**: [`pcf-bundle-sizes.md`](pcf-bundle-sizes.md) (2026-05-14 bundle-size baseline; the present doc is the deployment-side complement); [`projects/sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md`](../../../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md) (test-rot audit, not deployment).
+
+---
+
+## 1. Executive summary
+
+- **Source tree**: 14 PCFs with `ControlManifest.Input.xml`, 4 code-pages under `src/client/code-pages/`, 22 React/Vite Code Pages under `src/solutions/`.
+- **Dataverse (spaarkedev1)**: 23 Spaarke/Sprk-publisher PCFs deployed (all Published, all unmanaged), 20 most-recent `sprk_*` HTML web resources, 6 Spaarke-publisher canvas apps (Custom Pages).
+- **UQC verdict — CONFIRMED ORPHAN**. The `Spaarke.Controls.UniversalDocumentUpload` PCF is deployed (v3.15.2) and its hosting Custom Page `sprk_documentuploaddialog_e52db` exists, but the ribbon command that drove all traffic to it migrated to a Code Page in **v4.0.0** ([sprk_subgrid_commands.js:582-585](../../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js#L582-L585)). Local source has been bumped to v3.15.3 with an uncommitted bundle on disk — that bump never deployed and is not in `git log`.
+- **9 PCFs are deployed without a source-tree folder** — stale deployments from removed/superseded controls (AnalysisBuilder, DueDatesWidget, EventAutoAssociate, EventCalendarFilter, EventFormController, FieldMappingAdmin, RegardingLink, LegalWorkspace PCF, plus the AnalysisWorkspace PCF whose namesake lives as a Code Page instead).
+- **1 PCF is in source but not deployed**: DrillThroughWorkspace v1.1.1 — consistent with the 2026-05-14 bundle-size audit ("Built but not deployed yet").
+
+---
+
+## 2. Source-tree PCFs (14)
+
+| # | Folder | Full name (namespace.constructor) | Source ver | Deployed ver | Match | Notes |
+|---|---|---|---:|---:|:---:|---|
+| 1 | `AssociationResolver/` | `Spaarke.Controls.AssociationResolver` | 1.1.0 | 1.1.0 | ✅ | |
+| 2 | `DocumentRelationshipViewer/DocumentRelationshipViewer/` | `Spaarke.Controls.DocumentRelationshipViewer` | 1.0.36 | 1.0.36 | ✅ | |
+| 3 | `DrillThroughWorkspace/control/` | `Spaarke.Controls.DrillThroughWorkspace` | 1.1.1 | **— (not deployed)** | ❌ | Built locally; never pushed. Decide deploy-or-delete. |
+| 4 | `EmailProcessingMonitor/control/` | `Spaarke.EmailProcessingMonitor` | 1.1.2 | 1.1.2 | ✅ | |
+| 5 | `RegardingResolver/RegardingResolver/` | `Spaarke.Controls.RegardingResolver` | 1.1.0 | 1.1.0 | ✅ | |
+| 6 | `RelatedDocumentCount/RelatedDocumentCount/` | `Spaarke.Pcf.RelatedDocumentCount.RelatedDocumentCount` | 1.21.3 | 1.21.3 | ✅ | |
+| 7 | `ScopeConfigEditor/ScopeConfigEditor/` | `Sprk.ScopeConfigEditor` | 1.2.7 | 1.2.7 | ✅ | |
+| 8 | `SemanticSearchControl/SemanticSearchControl/` | `Sprk.SemanticSearchControl` | 1.1.76 | 1.1.76 | ✅ | |
+| 9 | `SpaarkeGridCustomizer/` | `Spaarke.Controls.SpaarkeGridCustomizer` | 1.0.0 | 1.0.0 | ✅ | |
+| 10 | `SpeDocumentViewer/control/` | `Spaarke.SpeDocumentViewer` | 1.0.27 | 1.0.27 | ✅ | |
+| 11 | `ThemeEnforcer/` | `Spaarke.ThemeEnforcer` | 1.0.0 | 1.0.0 | ✅ | |
+| 12 | **`UniversalQuickCreate/control/`** | **`Spaarke.Controls.UniversalDocumentUpload`** | **3.15.3** | **3.15.2** | **⚠ src ahead** | **ORPHAN — see §4** |
+| 13 | `UpdateRelatedButton/` | `Spaarke.Controls.UpdateRelatedButton` | 1.0.0 | 1.0.0 | ✅ | |
+| 14 | `VisualHost/control/` | `Spaarke.Visuals.VisualHost` | 1.4.16 | 1.4.16 | ✅ | |
+
+> **Note** — folder name ≠ constructor name in two cases: `UniversalQuickCreate/` builds `UniversalDocumentUpload` (3.15.x), and `RegardingResolver/` is *distinct from* the deployed-but-unsourced `RegardingLink` PCF (1.1.6).
+
+---
+
+## 3. Deployed-but-no-source PCFs (10)
+
+These PCFs exist as published `customcontrol` records in Dataverse but have **no `ControlManifest.Input.xml`** in `src/client/pcf/`. They are leftover deployments from prior projects that did not clean up the Dataverse side when the source was removed/superseded.
+
+| # | Deployed name | Ver | Likely status | Evidence |
+|---|---|---:|---|---|
+| 1 | `sprk_Spaarke.Controls.AnalysisBuilder` | 2.9.2 | Superseded by AnalysisBuilder Code Page (canvas `sprk_analysisbuilder_40af8`, modified 2026-01-14) | No source folder |
+| 2 | `sprk_Spaarke.Controls.AnalysisWorkspace` (PCF) | 1.3.5 | Superseded by `src/client/code-pages/AnalysisWorkspace/` Code Page (canvas `sprk_analysisworkspace_8bc0b`, modified 2026-03-15) | No PCF source folder; Code Page exists |
+| 3 | `sprk_Spaarke.Controls.DueDatesWidget` | 1.0.8 | Retired | No source folder |
+| 4 | `sprk_Spaarke.Controls.EventAutoAssociate` | 1.0.0 | Retired (events flow folded into ribbons / SmartTodo) | No source folder |
+| 5 | `sprk_Spaarke.Controls.EventCalendarFilter` | 1.0.5 | Superseded by `@spaarke/events-components` CalendarFilterPane | No source folder |
+| 6 | `sprk_Spaarke.Controls.EventFormController` | 1.0.6 | Retired | No source folder |
+| 7 | `sprk_Spaarke.Controls.FieldMappingAdmin` | 1.1.0 | Retired (admin UI consolidated) | No source folder |
+| 8 | `sprk_Spaarke.Controls.PlaybookBuilderHost` | 2.25.0 | Deployed PCF; source under `src/client/pcf/PlaybookBuilderHost/` does NOT have a top-level `ControlManifest.Input.xml` — folder is a non-standard layout per 2026-05-14 audit | Folder exists; no manifest at standard path |
+| 9 | `sprk_Spaarke.Controls.RegardingLink` | 1.1.6 | Predecessor of RegardingResolver | No source folder |
+| 10 | `sprk_Spaarke.LegalWorkspace` (PCF) | 1.0.1 | Superseded by LegalWorkspace Code Page (`src/solutions/LegalWorkspace/`) | No PCF source folder; Code Page exists |
+
+> **PlaybookBuilderHost** is the borderline case — there IS a source folder, but it doesn't follow the standard PCF layout. Verify with the playbook-builder owners whether the deployed v2.25.0 still matches the live source.
+
+---
+
+## 4. UQC deep-dive — confirmed orphan
+
+The reason this audit was commissioned. Findings:
+
+### 4.1 Dataverse-side state (live, queried 2026-06-22)
+
+| Artifact | Name | Version / mod date | State |
+|---|---|---|---|
+| PCF control | `sprk_Spaarke.Controls.UniversalDocumentUpload` | v3.15.2 | Published, unmanaged |
+| Custom Page (canvas app, hosts the PCF) | `sprk_documentuploaddialog_e52db` | mod 2026-03-15 | Published, unmanaged |
+| Successor Code Page (HTML web resource) | `sprk_documentuploadwizard` | mod 2026-06-18 | Published, unmanaged — **this is what the ribbon now opens** |
+
+### 4.2 The ribbon command migration — primary evidence
+
+[`src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js`](../../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js) is the ribbon JS that drives "Add Documents" on every Documents subgrid (Matter, Project, Invoice, Account, Contact, Communication). Its version-history block at lines 582-585:
+
+```
+4.0.0: Code Page (webresource) dialog approach with React 18 (sprk_documentuploadwizard)
+3.0.x: Custom Page dialog approach with PCF control (sprk_documentuploaddialog_e52db)
+2.1.0: Form Dialog approach using sprk_uploadcontext utility entity
+2.0.0: Initial release for Custom Page architecture (deprecated)
+```
+
+At [line 361](../../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js#L361) and again at [line 512](../../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js#L512), the command opens `webresourceName: "sprk_documentuploadwizard"` (the Code Page). Neither call path touches `sprk_documentuploaddialog_e52db` (the UQC-hosting Custom Page) anymore.
+
+### 4.3 Source-tree drift
+
+- Local manifest is at **v3.15.3** ([UniversalQuickCreate/control/ControlManifest.Input.xml:3](../../../../src/client/pcf/UniversalQuickCreate/control/ControlManifest.Input.xml#L3)) but Dataverse has **v3.15.2**.
+- A `bundle.js` exists on disk at `solution/src/WebResources/sprk_Spaarke.Controls.UniversalDocumentUpload/bundle.js` but **is not in git history** (verified: `git log --all -- {path}` returns empty). It was built locally and never committed.
+- Consistent with the 2026-05-14 bundle-size audit, which already classified UQC as "Built but not deployed yet" (no committed bundle in solution).
+
+### 4.4 Likely cause of the version bump
+
+A general PCF rebuild pass (probably `spaarke-auth-v2-and-hardening` task 028 "verify-rebuild-pcfs" or a similar sweep) bumped UQC's manifest along with the rest of the fleet but never actually deployed it because no one was driving traffic to UQC anymore. The bundle artifact stayed local.
+
+---
+
+## 5. Source-tree code-pages + solutions
+
+Two top-level locations: `src/client/code-pages/` (4 entries) and `src/solutions/` (22 entries, all Vite/React). Both deploy as `webresource` records.
+
+### 5.1 `src/client/code-pages/` (4)
+
+| Folder | Deployed web resource | Last modified (DV) | Notes |
+|---|---|---|---|
+| `AnalysisWorkspace/` | (not found in top-20 most-recent — older than cutoff or different name) | — | Has tests but per Track A audit, 2 deprecated test files |
+| `DocumentRelationshipViewer/` | — | — | Code Page complement to the PCF; needs separate verification |
+| `PlaybookBuilder/` | — | — | Needs separate verification |
+| `SemanticSearch/` | — | — | Per Track A audit: 17 test files orphaned, no jest config (HIGH) |
+
+### 5.2 `src/solutions/` Vite Code Pages — confirmed deployed (top-20 most-recent)
+
+| Local folder | Deployed `sprk_*` name | Last modified (DV) |
+|---|---|---|
+| `SmartTodo/` | `sprk_smarttodo` | 2026-06-21 22:20 |
+| `SpaarkeAi/` | `sprk_spaarkeai` | 2026-06-21 22:19 |
+| `CreateTodoWizard/` | `sprk_createtodowizard` | 2026-06-21 15:10 |
+| `DailyBriefing/` (DailyUpdate) | `sprk_dailyupdate` | 2026-06-21 13:53 |
+| `Reporting/` | `sprk_reporting` | 2026-06-18 22:52 |
+| `CalendarSidePane/` | `sprk_calendarsidepane.html` | 2026-06-18 22:51 |
+| `EventDetailSidePane/` | `sprk_eventdetailsidepane.html` | 2026-06-18 22:51 |
+| `SpeAdminApp/` | `sprk_speadmin` | 2026-06-18 22:51 |
+| `SummarizeFilesWizard/` | `sprk_summarizefileswizard` | 2026-06-18 22:50 |
+| `PlaybookLibrary/` | `sprk_playbooklibrary` | 2026-06-18 22:50 |
+| `WorkspaceLayoutWizard/` | `sprk_workspacelayoutwizard` | 2026-06-18 22:50 |
+| `FindSimilarCodePage/` | `sprk_findsimilar` | 2026-06-18 22:50 |
+| `CreateWorkAssignmentWizard/` | `sprk_createworkassignmentwizard` | 2026-06-18 22:50 |
+| `CreateEventWizard/` | `sprk_createeventwizard` | 2026-06-18 22:50 |
+| `CreateMatterWizard/` | `sprk_creatematterwizard` | 2026-06-18 22:50 |
+| `CreateProjectWizard/` | `sprk_createprojectwizard` | 2026-06-18 22:50 |
+| `AllDocuments/` | `sprk_alldocuments` | 2026-06-18 22:50 |
+| `DocumentUploadWizard/` | `sprk_documentuploadwizard` | 2026-06-18 22:50 |
+| `EventsPage/` | `sprk_eventspage.html` | 2026-06-12 22:15 |
+| (matter insight card host) | `sprk_/html/matter_insight_card_host.html` | 2026-06-16 17:30 |
+
+Out of top-20 (older or not yet probed) — but folders exist locally: `LegalWorkspace/`, `sprk_invoicespage/`, `sprk_kpiassessmentspage/`. Recommend a follow-up query specifically for those names.
+
+### 5.3 Canvas apps (Custom Pages, `canvasapptype = 2`)
+
+6 Spaarke-publisher canvas apps deployed:
+
+| Name | Display name | Last modified | Likely host of |
+|---|---|---|---|
+| `sprk_documentuploaddialog_e52db` | File Upload | 2026-03-15 | **UQC PCF (orphan — see §4)** |
+| `sprk_eventspage_786f4` | Events Page | 2026-03-15 | (predecessor of EventsPage Code Page) |
+| `sprk_analysisworkspace_8bc0b` | Analysis Workspace | 2026-03-15 | AnalysisWorkspace PCF (orphan; superseded by code-page) |
+| `sprk_visualizationdrillthroughworkspace_e48a5` | Visualization Drill Through Documents | 2026-03-09 | DrillThroughWorkspace PCF (PCF source v1.1.1 exists but isn't even deployed — see §2 row 3) |
+| `sprk_playbookbuilder_eb5ad` | Playbook Builder | 2026-01-18 | PlaybookBuilderHost PCF |
+| `sprk_analysisbuilder_40af8` | Analysis Builder | 2026-01-14 | AnalysisBuilder PCF (orphan; §3 row 1) |
+
+All 6 are older than the most-recent Code Page redeploys (2026-06-18 onwards), consistent with a fleet-wide migration from Custom-Page-hosted PCFs to React Code Pages.
+
+---
+
+## 6. Recommended cleanup actions
+
+### 6.1 Source-side — safe to delete from `src/`
+
+| Folder | Justification |
+|---|---|
+| `src/client/pcf/UniversalQuickCreate/` | Ribbon migrated to Code Page in v4.0.0 (§4.2). No call path touches it. |
+
+> **Caveat**: deleting from source does NOT remove the deployed Dataverse artifacts. Pair with §6.2.
+
+### 6.2 Dataverse-side — needs cleanup pass
+
+The following published `customcontrol` records should be reviewed for unpublish/delete (each requires verification that no form/ribbon/page still references it):
+
+- `sprk_Spaarke.Controls.UniversalDocumentUpload` (v3.15.2)
+- `sprk_Spaarke.Controls.AnalysisBuilder` (v2.9.2)
+- `sprk_Spaarke.Controls.AnalysisWorkspace` (v1.3.5)
+- `sprk_Spaarke.Controls.DueDatesWidget` (v1.0.8)
+- `sprk_Spaarke.Controls.EventAutoAssociate` (v1.0.0)
+- `sprk_Spaarke.Controls.EventCalendarFilter` (v1.0.5)
+- `sprk_Spaarke.Controls.EventFormController` (v1.0.6)
+- `sprk_Spaarke.Controls.FieldMappingAdmin` (v1.1.0)
+- `sprk_Spaarke.Controls.RegardingLink` (v1.1.6)
+- `sprk_Spaarke.LegalWorkspace` (v1.0.1)
+
+Plus the canvas apps that host them: `sprk_documentuploaddialog_e52db`, `sprk_analysisworkspace_8bc0b`, `sprk_visualizationdrillthroughworkspace_e48a5`, `sprk_analysisbuilder_40af8`, possibly `sprk_eventspage_786f4` and `sprk_playbookbuilder_eb5ad` (PlaybookBuilder Code Page is in `src/client/code-pages/PlaybookBuilder/`).
+
+### 6.3 DrillThroughWorkspace — open decision
+
+PCF source at v1.1.1 exists but has never been deployed. The 2026-05-14 bundle-size audit and this audit agree. Decision needed: **deploy v1.1.1** (if the Drill-Through Custom Page is still desired) or **delete the source** (if drill-through is now covered by other surfaces, e.g., the Reporting Code Page).
+
+### 6.4 PlaybookBuilderHost — needs owner triage
+
+Source layout doesn't match other PCFs (no top-level `ControlManifest.Input.xml`). Deployed v2.25.0 is recent. Confirm with the playbook-builder owners whether (a) the source is fine and the layout is intentional, (b) source is stale and the deployed v2.25.0 originates from a different repo path, or (c) it needs realignment.
+
+---
+
+## 7. Methodology & data sources
+
+### 7.1 Source-tree enumeration
+
+- `Glob src/client/pcf/*/ControlManifest.Input.xml` (top-level) + `src/client/pcf/*/*/ControlManifest.Input.xml` (nested) → 14 manifests.
+- Read every manifest for `namespace` + `constructor` + `version` attributes.
+- `Glob src/client/code-pages/*/package.json` → 4 code-pages.
+- `Glob src/solutions/*/package.json` → 22 Vite solutions.
+
+### 7.2 Dataverse queries (via Dataverse MCP)
+
+```sql
+-- PCFs (Spaarke namespace, first batch)
+SELECT TOP 20 name, version, componentstate, ismanaged
+FROM customcontrol
+WHERE name LIKE 'Spaarke%' AND componentstate = 0
+ORDER BY name
+
+-- PCFs (Sprk + Visuals + DrillThrough — second batch to cover 20-cap cut-off)
+SELECT TOP 20 name, version, componentstate, ismanaged
+FROM customcontrol
+WHERE name LIKE 'sprk_Sprk%'
+   OR name LIKE 'sprk_Spaarke.Visuals%'
+   OR name LIKE 'sprk_Spaarke.Controls.DrillThroughWorkspace%'
+
+-- Web resources (HTML Code Pages, top-20 most-recent)
+SELECT TOP 20 name, displayname, ismanaged, modifiedon
+FROM webresource
+WHERE name LIKE 'sprk_%' AND webresourcetype = 1 AND componentstate = 0
+ORDER BY modifiedon DESC
+
+-- Canvas apps (Custom Pages, top-20 most-recent)
+SELECT TOP 20 name, displayname, canvasapptype, ismanaged, lastmodifiedtime
+FROM canvasapp
+WHERE componentstate = 0
+ORDER BY lastmodifiedtime DESC
+```
+
+Dataverse MCP `read_query` is capped at TOP 20 — multi-query batches are required for full enumeration.
+
+### 7.3 Ribbon-command source
+
+[`src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js`](../../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js) — read in full. Version-history block (lines 582-585) is the primary evidence for the UQC orphan finding.
+
+### 7.4 What this audit does NOT cover
+
+- Form-level / view-level references to specific PCF controls (would require reading every `systemform` and `savedquery` record's FormXML — large scan; deferred).
+- Ribbon definitions for non-Document-subgrid ribbons (other ribbons may still drive traffic to deployed-but-orphan PCFs).
+- Managed solutions imported from external publishers (filter was `sprk_*`/`Spaarke*`/`Sprk*` only).
+- Other environments (only `spaarkedev1` was queried via MCP).
+
+### 7.5 Reproducibility
+
+Re-run by: (a) repeating §7.1's globs; (b) re-issuing §7.2's queries against the target environment via Dataverse MCP; (c) re-reading [sprk_subgrid_commands.js](../../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js)'s version-history block for ribbon-side claims about UQC.
+
+---
+
+## 8. Cross-references
+
+- [`pcf-bundle-sizes.md`](pcf-bundle-sizes.md) — 2026-05-14 bundle-size baseline (precursor; this doc is the deployment complement).
+- [`projects/sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md`](../../../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md) — 2026-06-01 test-rot audit (different lens; complementary).
+- [`projects/spaarke-auth-v2-and-hardening/tasks/028-verify-rebuild-pcfs.poml`](../../../spaarke-auth-v2-and-hardening/tasks/028-verify-rebuild-pcfs.poml) — likely origin of the UQC v3.15.2 → v3.15.3 manifest bump.
+- [`projects/production-environment-setup-r2/tasks/030-migrate-pcf-universal-quick-create.poml`](../../../production-environment-setup-r2/tasks/030-migrate-pcf-universal-quick-create.poml) — predecessor UQC deployment task.

--- a/projects/pcf-orphan-cleanup-r1/CLAUDE.md
+++ b/projects/pcf-orphan-cleanup-r1/CLAUDE.md
@@ -1,0 +1,177 @@
+# pcf-orphan-cleanup-r1 — AI Context
+
+> **Purpose**: Project-scoped AI context for Claude Code when working on `pcf-orphan-cleanup-r1`.
+> **Always load this file first** when working on any task in this project.
+
+---
+
+## Project Status
+
+- **Phase**: Phase 0 — Project Setup
+- **Created**: 2026-06-22
+- **Current Task**: see [`current-task.md`](current-task.md)
+- **Next Action**: execute Task 001 (pre-flight backups) — can run in parallel with Task 002 (source deletion)
+
+## Quick Reference
+
+### Key Files
+
+- [`README.md`](README.md) — project overview + graduation criteria
+- [`spec.md`](spec.md) — 8 FRs / 7 NFRs / 12 SCs / 6 binding decisions
+- [`design.md`](design.md) — decision rationale (operational procedure lives elsewhere — see below)
+- [`current-task.md`](current-task.md) — active task pointer
+- [`tasks/TASK-INDEX.md`](tasks/TASK-INDEX.md) — task tracker
+- [`notes/research-findings-2026-06-22.md`](notes/research-findings-2026-06-22.md) — compiled session research that scoped this project
+
+### Operational procedure (canonical step-by-step)
+
+📋 **[`../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md)**
+
+This is THE step-by-step reference. Every task file in `tasks/` is a slice of this procedure. Always read the relevant procedure section before running a task.
+
+### Authoritative source artifacts
+
+- [`../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md) — the inventory this project acts on
+- [`../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md`](../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md) — 2026-05-14 bundle baseline; will be refreshed in Task 007
+- [`../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md`](../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md) — 2026-06-01 test-rot audit (different lens; complementary data)
+
+### Project metadata
+
+- **Project Name**: pcf-orphan-cleanup-r1
+- **Type**: Quality / hygiene (production fixes + cleanup)
+- **Complexity**: MEDIUM (3-5 days, 7 tasks, 1 Dataverse-mutation session that needs explicit gating)
+- **Predecessor research**: chat-routing-redesign-r1 (TypeScript drift report) + ai-procedure-quality-r1 (inventory home)
+- **Production blast radius**: HIGH (Dataverse customcontrol deletions are not GUID-stable for restoration — see [design.md §3.5 resurrection playbook in the procedure doc])
+
+---
+
+## Context Loading Rules
+
+When working on this project, Claude Code MUST:
+
+1. **Always load this file first** when starting work on any task
+2. **Check [`current-task.md`](current-task.md)** for active work state (especially after compaction / new session)
+3. **Reference [`spec.md`](spec.md)** for FR / NFR / Success Criteria
+4. **Reference [`design.md`](design.md)** for Decisions D-01 through D-06
+5. **Load the procedure doc section that maps to the current task** — every task POML cites its procedure-section anchor
+6. **Apply ADRs** relevant to PCFs (loaded automatically via `adr-aware`):
+   - **ADR-022** (PCF platform libraries) — DIRECTLY binding for FR-05 (VisualHost re-pin DOWN, not UP)
+   - **ADR-006** (PCF over webresources) — relevant context (this project retires unused PCFs but doesn't change the preference for PCFs over webresources)
+   - **ADR-012** (Shared component library) — FR-04 multi-major peerDep range is consistent with ADR-012's context-agnostic goal
+
+**Context Recovery**: see [Context Recovery Protocol](../../docs/procedures/context-recovery.md)
+
+---
+
+## 🚨 MANDATORY: Task Execution Protocol
+
+**ABSOLUTE RULE**: All task work MUST use the `task-execute` skill. DO NOT read POML files directly and implement manually.
+
+### Auto-Detection Rules (Trigger Phrases)
+
+| User Says | Required Action |
+|---|---|
+| "work on task X" | Execute task X via `task-execute` |
+| "continue" / "keep going" / "next task" | Read `tasks/TASK-INDEX.md`, find first 🔲, invoke `task-execute` |
+| "continue with task X" / "resume task X" | Execute task X via `task-execute` |
+| "pick up where we left off" | Load `current-task.md`, invoke `task-execute` |
+
+**Implementation**: When user triggers task work, invoke Skill tool with `skill="task-execute"` and task file path.
+
+### Parallel Task Execution
+
+Two parallel-safe windows in this project:
+
+**P1-W1 (early)** — Tasks 001 + 002 in parallel:
+- Task 001 (pre-flight backups) writes to `projects/pcf-orphan-cleanup-r1/backups-2026-06-22/`
+- Task 002 (source deletion PR) writes to `src/client/pcf/*`
+- Disjoint write paths → safe to dispatch in parallel as ONE message with TWO Skill invocations
+
+**P5-W1 (closeout)** — Tasks 006 + 007 sequence (006 → 007 sequential dependency; 007 needs 006 complete to write the cleanup-log)
+
+Mid-project tasks (003, 004, 005) are sequential (003 = Dataverse mutation must complete + soak before 004/005 hit; 004 → 005 sequential because PR-D1 enables PR-D2's peerDep-resolved type matrix).
+
+---
+
+## Key Technical Constraints
+
+### Binding ADRs
+
+- **ADR-022** (PCF platform libraries) — DIRECTLY binding for FR-05 VisualHost re-pin
+- **ADR-006** (PCF over webresources) — relevant for understanding why PCFs are even on Dataverse
+- **ADR-012** (Shared component library) — relevant for FR-04 peerDep contract
+
+### Binding MUSTs (NFRs)
+
+- ✅ MUST capture §1.1 baseline solution backups before ANY Dataverse-side deletion (NFR-01)
+- ✅ MUST run §1.2 4-check per control before deletion; FormXML grep is MANDATORY for SDV (NFR-02; D-02)
+- ✅ MUST wait 7 calendar days between spaarkedev1 and spaarkedev2 cleanup (NFR-03)
+- ✅ MUST re-verify VisualHost React-18-API grep pre-merge of PR-D2 (NFR-05)
+- ✅ MUST spot-test the resurrection path before any deletion in production (NFR-07)
+- ❌ MUST NOT re-introduce UQC / DTW / SDV in parallel projects during this project's window (NFR-04)
+- ❌ MUST NOT include PlaybookBuilderHost in this project's deletion scope (D-03)
+
+### Project-specific discipline
+
+- **One PR per workstream**: source delete (FR-01), shared lib peerDep (FR-04), VisualHost re-pin (FR-05). Dataverse-side work is NOT a PR — it's a managed maker-portal session logged per FR-07.
+
+---
+
+## Decisions Made
+
+See [`spec.md §5`](spec.md#5-decisions-made-binding-for-this-project) for the binding decisions table.
+
+Notable decisions:
+
+- **D-01**: UQC + DTW + SDV deleted from source in ONE PR (not three separate).
+- **D-02**: SDV FormXML grep is MANDATORY (not advisory).
+- **D-03**: PlaybookBuilderHost EXPLICITLY out of scope.
+- **D-04**: VisualHost re-pinned DOWN to React 16 (not UP to 19). Source verified zero React 18-only API usage.
+- **D-05**: 7-day soak between environments.
+- **D-06**: Project lifespan ends at spaarkedev2 completion.
+
+---
+
+## Implementation Notes
+
+### Why this is one project, not three PRs
+
+The three workstreams (source delete, Dataverse cleanup, React-types fix) share:
+- One inventory of "what's alive" (built during chat-routing-redesign-r1's investigation)
+- One execution flow (pre-flight → source → Dataverse → types → replay)
+- One production blast-radius gate
+
+Doing them separately invites re-drift between PRs. The cleanup is small enough (3-5 days) to bundle but big enough to warrant project-level discipline.
+
+### Anti-time-waster takeaway
+
+After this project lands, the workspace stops building / testing / lint-checking UQC + DTW + SDV. The next CI run's PCF workspace build step will be visibly faster.
+
+### Recovery is real but GUID-changing
+
+The §3.5 resurrection playbook (in the procedure doc) makes recovery a 5-10 minute operation IF the §1.1 backups exist. GUIDs change on re-import — anything that hardcoded a customcontrol/canvas-app GUID will need rewiring. Name-based references (the common case) survive.
+
+---
+
+## Resources
+
+### Applicable ADRs
+
+- **ADR-022** — PCF Platform Libraries (React 16 APIs only)
+- **ADR-006** — PCF Over Webresources (PCF as extension surface)
+- **ADR-012** — Shared Component Library
+
+### Related Projects
+
+- **[`ai-procedure-quality-r1`](../ai-procedure-quality-r1/)** — HOST of the inventory + procedure source artifacts; this project is a "child" execution
+- **[`chat-routing-redesign-r1`](../spaarke-ai-platform-chat-routing-redesign-r1/)** — originating audit (TypeScript drift report)
+- **[`sdap.bff.api-test-suite-repair-r2`](../sdap.bff.api-test-suite-repair-r2/)** — complementary test-rot audit (2026-06-01)
+
+### External Documentation
+
+- [`docs/guides/PCF-DEPLOYMENT-GUIDE.md`](../../docs/guides/PCF-DEPLOYMENT-GUIDE.md) — full PCF redeploy procedure (used in FR-05 / Task 005)
+- [`.claude/FAILURE-MODES.md#AP-1`](../../.claude/FAILURE-MODES.md) — `build:prod` not `build` reminder
+
+---
+
+*This file should be kept updated throughout project lifecycle. Add to "Decisions Made" and "Implementation Notes" as work progresses.*

--- a/projects/pcf-orphan-cleanup-r1/README.md
+++ b/projects/pcf-orphan-cleanup-r1/README.md
@@ -1,0 +1,68 @@
+# PCF Orphan Cleanup — R1
+
+> **Status**: Phase 0 — Project Setup (created 2026-06-22)
+> **Type**: Quality / hygiene — source-tree cleanup + Dataverse cleanup + type-system alignment
+> **Predecessor research**: chat-routing-redesign-r1 TypeScript drift audit → triggered the inventory pass
+> **Estimated effort**: 3–5 days end-to-end (1 source PR, 1 Dataverse session, 2 React-types PRs, 1 replay session)
+> **Production blast radius**: HIGH (Dataverse customcontrol deletions are not name-stable for restoration — see [design.md §3.5 Resurrection playbook](design.md))
+
+## What this project does
+
+Retires PCFs and canvas apps that no production traffic flows to. Aligns the remaining workspace on one canonical React-types contract.
+
+**Three streams of work that share one execution flow**:
+
+1. **Source-tree cleanup** — delete 3 PCF folders that no consumer imports (UQC, DrillThroughWorkspace, SpeDocumentViewer).
+2. **Dataverse cleanup** — delete 11 published `customcontrol` records + 4–6 hosting canvas apps that no live ribbon / form / page references.
+3. **React-types alignment** — `@spaarke/ui-components` declares `@types/react` as peerDep (multi-major); VisualHost re-pinned from React 18 to React 16 to match its `platform-library` runtime per ADR-022 (closes the "bucket D" drift from the chat-routing-redesign-r1 audit).
+
+## Why this is one project, not three PRs
+
+The three streams share:
+- One inventory of "what's alive and what isn't" (built during chat-routing-redesign-r1's TypeScript-drift investigation).
+- One execution flow (pre-flight backups → source PR → Dataverse session → types PRs → replay).
+- One production blast-radius gate (Dataverse cleanup can't be safely batched with source-only PRs).
+
+Doing them separately invites re-drift between PRs and risks deleting the wrong artifact at the wrong time.
+
+## Graduation criteria
+
+This project is done when:
+
+- [ ] UQC + DrillThroughWorkspace + SpeDocumentViewer folders absent from `main`.
+- [ ] 11 orphan `customcontrol` records absent from spaarkedev1 + spaarkedev2 (Dataverse MCP query returns empty).
+- [ ] 4–6 orphan canvas apps absent from both environments.
+- [ ] VisualHost re-pinned to React 16; deployed; smoke-test of recent enhancements passes.
+- [ ] `@spaarke/ui-components` declares `@types/react` as peerDep with multi-major range.
+- [ ] No new TS2322 / TS2305 / TS2307 errors across the 11 remaining PCFs and 4 code-pages.
+- [ ] [`pcf-deployment-inventory-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md) updated with completion footnote.
+- [ ] Per-control deletion log filed in [`notes/dataverse-cleanup-log.md`](notes/dataverse-cleanup-log.md).
+- [ ] Baseline solution backups archived in `backups-2026-06-22/`.
+
+## Key files
+
+| Where | What |
+|---|---|
+| [README.md](README.md) | This file |
+| [spec.md](spec.md) | FRs / NFRs / Success Criteria |
+| [design.md](design.md) | Full procedure — pre-flight, source delete, Dataverse cleanup, React-types fix, resurrection playbook |
+| [CLAUDE.md](CLAUDE.md) | Project-scoped AI context (always load first) |
+| [current-task.md](current-task.md) | Active task pointer |
+| [plan.md](plan.md) | Phase breakdown + parallel groups |
+| [notes/research-findings-2026-06-22.md](notes/research-findings-2026-06-22.md) | All research compiled during the chat-routing-redesign-r1 investigation that led to this project |
+| [tasks/TASK-INDEX.md](tasks/TASK-INDEX.md) | Task tracker |
+| `backups-2026-06-22/` | Baseline solution ZIPs (captured in Task 001 — the safety net for Dataverse-side recovery) |
+
+## Cross-references (authoritative source artifacts)
+
+- [`projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md) — the inventory this project acts on
+- [`projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md) — the operational procedure (this project's `design.md` references it as canonical)
+- [`projects/ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md`](../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md) — 2026-05-14 bundle-size baseline (will need refresh post-cleanup)
+- [`projects/sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md`](../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md) — 2026-06-01 test-rot audit (different lens; complementary data)
+- [`.claude/adr/ADR-022-pcf-platform-libraries.md`](../../.claude/adr/ADR-022-pcf-platform-libraries.md) — binding constraint for "React 16 APIs only" in PCFs
+
+## Origin note
+
+This project was scoped during a 2026-06-22 investigation triggered by the chat-routing-redesign-r1 report on TypeScript drift in `@spaarke/ui-components` consumers (4 buckets: A=mixed `dist/`+`src/` imports, B=broken SSE re-export stub, C=tsconfig module mismatch, D=`@types/react` 18-vs-19 collision). The investigation found that 3 of the 4 buckets (A, B, C) only mattered for UniversalQuickCreate, which the inventory pass then confirmed was an orphan (ribbon command migrated to a Code Page in v4.0.0). Bucket D remains as one VisualHost re-pin.
+
+The wider Dataverse orphan-PCF cleanup was discovered "for free" during the inventory query and added to scope to avoid leaving the cleanup half-done.

--- a/projects/pcf-orphan-cleanup-r1/current-task.md
+++ b/projects/pcf-orphan-cleanup-r1/current-task.md
@@ -1,0 +1,37 @@
+# Current Task — pcf-orphan-cleanup-r1
+
+> Last updated: 2026-06-22 (project setup)
+
+## Active Task
+
+**None yet** — project just initialized. Ready to begin execution.
+
+## Next Action
+
+Begin with **Task 001 (pre-flight backups)** OR **Task 002 (source deletion PR)** — both are parallel-safe and can run as the first wave (see CLAUDE.md "Parallel Task Execution" → P1-W1).
+
+To begin execution, the user can say one of:
+- "work on task 001" (or 002) → triggers `task-execute` on the chosen task
+- "continue" → loads `tasks/TASK-INDEX.md`, picks the first 🔲, dispatches `task-execute`
+- "run wave 1" → dispatches Tasks 001 + 002 in parallel as ONE message with TWO Skill invocations
+
+## Recent Files Modified
+
+- (none — project freshly initialized)
+
+## Recent Decisions
+
+See [`spec.md §5`](spec.md#5-decisions-made-binding-for-this-project) for the binding decisions table. All six were made during the 2026-06-22 setup session.
+
+## Blockers
+
+- (none — project is unblocked and ready to execute)
+
+## Recovery Notes
+
+If context is lost mid-execution:
+
+1. Read [`CLAUDE.md`](CLAUDE.md) for project context
+2. Read this `current-task.md` for active task state
+3. Read [`tasks/TASK-INDEX.md`](tasks/TASK-INDEX.md) for what's done / pending
+4. Resume via `task-execute` on the next 🔲 task

--- a/projects/pcf-orphan-cleanup-r1/current-task.md
+++ b/projects/pcf-orphan-cleanup-r1/current-task.md
@@ -1,37 +1,66 @@
 # Current Task — pcf-orphan-cleanup-r1
 
-> Last updated: 2026-06-22 (project setup)
+> Last updated: 2026-06-22 (Wave P1-W1 partial complete; paused for PR review)
 
 ## Active Task
 
-**None yet** — project just initialized. Ready to begin execution.
+**None — paused for PR review.**
+
+## Session 1 Outcomes (2026-06-22)
+
+### ✅ Completed
+
+| Task | Outcome |
+|---|---|
+| Project scaffolding | PR **#411** open — `chore(pcf-orphan-cleanup-r1): project scaffolding + research artifacts` |
+| Task 002 — Source deletion | PR **#412** open — `chore(pcf): retire 3 orphan PCFs (UQC + DrillThroughWorkspace + SpeDocumentViewer)` |
+
+### 🔲 Remaining (in dependency order)
+
+| Task | Status | Blocker |
+|---|---|---|
+| 001 — Pre-flight backups (spaarkedev1) | NOT started | None — PAC CLI confirmed authenticated to spaarkedev1; ready to execute |
+| 003 — Dataverse cleanup spaarkedev1 | Blocked on 001 | Single managed maker-portal session, ~4-6 hours |
+| (7-day soak) | — | Calendar gate after 003 |
+| 004 — Shared lib `@types/react` peerDep | Blocked on 003 + soak | |
+| 005 — VisualHost re-pin React 16 | Blocked on 004 | |
+| 006 — Dataverse cleanup spaarkedev2 | Blocked on 005 + soak | |
+| 007 — Cleanup-log finalize | Blocked on 006 | |
+
+## Branches in flight
+
+- `chore/pcf-orphan-cleanup-setup` → PR #411 (project scaffolding)
+- `chore/pcf-orphan-cleanup-source-delete` → PR #412 (source deletion)
 
 ## Next Action
 
-Begin with **Task 001 (pre-flight backups)** OR **Task 002 (source deletion PR)** — both are parallel-safe and can run as the first wave (see CLAUDE.md "Parallel Task Execution" → P1-W1).
+After PR #411 and #412 are reviewed and merged:
 
-To begin execution, the user can say one of:
-- "work on task 001" (or 002) → triggers `task-execute` on the chosen task
-- "continue" → loads `tasks/TASK-INDEX.md`, picks the first 🔲, dispatches `task-execute`
-- "run wave 1" → dispatches Tasks 001 + 002 in parallel as ONE message with TWO Skill invocations
+1. **Schedule a 4-6 hour focused block** for Task 001 + Task 003 (Dataverse cleanup spaarkedev1).
+2. Resume execution by saying one of the trigger phrases:
+   - "work on task 001" → preflight backups
+   - "continue" → loads TASK-INDEX, picks first 🔲, dispatches `task-execute`
 
-## Recent Files Modified
+3. Reference materials remain in:
+   - `projects/pcf-orphan-cleanup-r1/` (this project)
+   - `projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md` (canonical procedure)
 
-- (none — project freshly initialized)
+## Notes for the next session
 
-## Recent Decisions
-
-See [`spec.md §5`](spec.md#5-decisions-made-binding-for-this-project) for the binding decisions table. All six were made during the 2026-06-22 setup session.
+- PAC CLI is authenticated to **spaarkedev1** (profile [3] = `ralph.schroeder@spaarke.com` @ `https://spaarkedev1.crm.dynamics.com/`). No re-auth needed.
+- Husky pre-commit hook + lint-staged require `npm install` at repo root (already done this session — `node_modules/` exists at root with prettier).
+- Setup PR (#411) introduces the `backups-2026-06-22/` folder — empty at session end; Task 001 fills it.
+- DocumentUploadWizard Code Page imports services from `@spaarke/ui-components/services/document-upload`. Those services stay in the shared lib. They were created for UQC but the successor Code Page consumes them too.
 
 ## Blockers
 
-- (none — project is unblocked and ready to execute)
+- (none active — paused by owner choice for PR review)
 
 ## Recovery Notes
 
-If context is lost mid-execution:
+If context is lost mid-execution next session:
 
 1. Read [`CLAUDE.md`](CLAUDE.md) for project context
-2. Read this `current-task.md` for active task state
+2. Read this `current-task.md` for session-1 outcomes + branch state
 3. Read [`tasks/TASK-INDEX.md`](tasks/TASK-INDEX.md) for what's done / pending
-4. Resume via `task-execute` on the next 🔲 task
+4. Resume via `task-execute` on the next 🔲 task (001 is the natural starting point)

--- a/projects/pcf-orphan-cleanup-r1/design.md
+++ b/projects/pcf-orphan-cleanup-r1/design.md
@@ -1,0 +1,122 @@
+# PCF Orphan Cleanup — Design
+
+> **Project**: pcf-orphan-cleanup-r1
+> **Design version**: 1.0 (2026-06-22)
+> **Operational reference**: this design document points to the existing [orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md) as the canonical procedure. This file captures decisions + rationale + cross-links; the procedure doc captures the step-by-step.
+
+---
+
+## 1. The decision tree that led to this project
+
+Triggered 2026-06-22 by a chat-routing-redesign-r1 report flagging TypeScript drift in `@spaarke/ui-components` consumers. Four buckets:
+
+```
+Bucket A — Mixed dist/+src/ imports     ← UQC-only
+Bucket B — Broken SSE re-export stub    ← UQC-only
+Bucket C — tsconfig module mismatch     ← UQC-only
+Bucket D — @types/react 18 vs 19/16     ← affects 3 PCFs + shared lib
+```
+
+The investigation followed this chain:
+
+1. **Is UQC even in use?** → discovered no project literally named "PCF-code-page-inventory" but found two adjacent inventory artifacts (bundle-sizes from 2026-05-14; test-rot from 2026-06-01). Neither answered the deployment question.
+2. **New inventory pass** → built [`pcf-deployment-inventory-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md) using source-tree enumeration + live Dataverse MCP query.
+3. **UQC verdict**: deployed in Dataverse (v3.15.2) but ribbon command migrated to a Code Page in v4.0.0 (evidence: [sprk_subgrid_commands.js:582-585](../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js#L582-L585)) — confirmed orphan.
+4. **Adjacent finding**: 9 other PCFs deployed in Dataverse without any source-tree backing. Orphans of prior migrations that never completed cleanup. Folded into scope.
+5. **VisualHost question**: owner has recent enhancements; downversioning concerns. Verified with grep of `src/client/pcf/VisualHost/control/**/*.{ts,tsx}` for React 18-only APIs → zero hits. Safe to re-pin.
+6. **DTW + SDV question**: owner unsure if used; source-tree grep returned no external importers. Confirmed unused 2026-06-22; folded into Part B (source delete) and Part C (Dataverse delete for SDV; just canvas-app cleanup for DTW since DTW PCF was never deployed).
+
+## 2. Three streams, one execution flow
+
+The procedure doc structures execution as five Parts:
+
+- **Part A** — Pre-flight (backups + 4-check verification per control) — see [procedure §1](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#1-pre-flight-binding-before-any-destructive-action)
+- **Part B** — Source-tree deletion (UQC + DTW + SDV) — see [procedure §2](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#2-part-b--source-tree-deletion-pr-1)
+- **Part C** — Dataverse cleanup (11 customcontrols + 4-6 canvas apps) — see [procedure §3](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#3-part-c--dataverse-cleanup-single-session-gated)
+- **Part D** — React-types alignment (shared lib peerDep + VisualHost re-pin) — see [procedure §4](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#4-part-d--shared-lib--pcf-react-types-alignment-prs-2--3)
+- **Recovery** — Resurrection playbook for "we deleted something we needed" — see [procedure §3.5](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#35-resurrection--recovery--explicit-playbook)
+
+The procedure doc is the binding step-by-step. This design.md captures the WHY behind the choices.
+
+## 3. Sequencing (the 14-day plan)
+
+```
+Day 1-2:  PR 1 (Part B source deletion: UQC + DTW + SDV) — owner review + merge   [Task 002]
+Day 3:    Pre-flight §1.1 + §1.2 in spaarkedev1                                    [Task 001]
+Day 4:    Part C cleanup session in spaarkedev1 (4-6 hours, one focused block)     [Task 003]
+Day 4-10: 1-week soak — monitor for regressions
+Day 11:   PR-D1 (shared lib peerDep)                                                [Task 004]
+Day 12:   PR-D2 (VisualHost re-pin) — deploy, smoke test                            [Task 005]
+Day 13:   Part C cleanup in spaarkedev2 (replay)                                    [Task 006]
+Day 14+:  Cleanup log finalize + inventory refresh                                  [Task 007]
+```
+
+Note Task 001 runs in parallel with Task 002 — pre-flight verification doesn't block source deletion (orthogonal write paths).
+
+## 4. Key design decisions
+
+### D-01 — Source delete in one PR vs three
+
+One PR. Each of UQC, DTW, SDV is independent (no cross-folder dependencies). Bundling reduces review overhead. If a reviewer challenges any one, `git restore` removes that folder from the PR pre-merge.
+
+### D-02 — SDV FormXML grep is a hard gate, not advisory
+
+SpeDocumentViewer was the only one of the three source-delete candidates that was actively deployed AND likely to be bound to specific forms (document-viewer PCFs typically land on form sections of document-bearing entities). Treating its FormXML grep as mandatory protects against the "we forgot about that one form" failure mode.
+
+### D-03 — PlaybookBuilderHost explicitly excluded
+
+PlaybookBuilderHost has:
+- Non-standard source layout (no top-level `ControlManifest.Input.xml` per inventory §2)
+- Recent Dataverse activity (modified 2026-01-20)
+- Higher version number than most orphans (v2.25.0)
+- A canvas-app host that may still be referenced
+
+This combination suggests it's NOT a simple orphan. Owner triage required before any deletion action.
+
+### D-04 — Bucket D fixes VisualHost DOWN to React 16, not UP to React 19
+
+Two reasons:
+1. **Platform-library runtime is React 16.14.0** (declared in VisualHost's manifest at line 148). Type pin should match runtime per ADR-022.
+2. **VisualHost source has zero React 18-only API usage** (verified 2026-06-22). Aligning DOWN is feature-preserving.
+
+The shared lib stays at `@types/react ^19.0.0` for its own self-build but declares peerDeps as `>=16.14 || >=17 || >=18 || >=19` so each consumer's pin wins. ADR-022's "React 16 APIs only" constraint applies to the shared lib too — verified by the same grep as part of PR-D1.
+
+### D-05 — 7-day soak between environments
+
+Mirrors the production-release procedure cadence. Allows business-hours regression discovery in spaarkedev1 before spaarkedev2 takes the same hit. The cost (slower rollout) is much smaller than the cost of double-environment recovery if a regression slips through.
+
+### D-06 — Project ends at spaarkedev2
+
+Production replication is governed by [deploy-new-release skill](../../.claude/skills/deploy-new-release/SKILL.md) and is a separate execution. The cleanup project's job is to prove the procedure works in two non-prod environments; production rollout is the standard release-procedure's job.
+
+## 5. Risk register
+
+See [procedure §6](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#6-risk-register) for the full 8-row risk register. The two HIGH-severity risks specific to this project:
+
+| Risk | Mitigation |
+|---|---|
+| SpeDocumentViewer was bound to forms we didn't find | NFR-02 elevates the FormXML grep to a hard gate on SDV specifically. Recovery via §3.5.2 (baseline backup re-import) if the grep missed something. |
+| Re-pinning VisualHost breaks recent enhancements | Owner-verified 2026-06-22: VisualHost source has zero React 18-only API usage. PR-D2 re-verifies pre-merge. Smoke-test covers chart / drill-through / MetricCard / recent enhancements. |
+
+## 6. Applicable ADRs
+
+- **[ADR-022 — PCF Platform Libraries](../../.claude/adr/ADR-022-pcf-platform-libraries.md)** — DIRECTLY binding. "React 16 APIs only" is the rationale for D-04 (VisualHost re-pin DOWN, not UP).
+- **[ADR-006 — PCF Over Webresources](../../.claude/adr/ADR-006-pcf-over-webresources.md)** — relevant context (PCFs are the preferred extension surface for in-form UI; this project doesn't violate that, just retires unused PCFs).
+- **[ADR-012 — Shared Component Library](../../.claude/adr/ADR-012-shared-component-library.md)** — `@spaarke/ui-components` peerDep contract change in FR-04 is consistent with ADR-012's "context-agnostic" goal (multi-major peerDep range = more consumers).
+
+## 7. What this project intentionally does NOT do
+
+See [spec.md §4 Explicitly out of scope](spec.md#4-explicitly-out-of-scope). Notable exclusions:
+
+- PlaybookBuilderHost retirement
+- Code Page / Vite SPA cleanup
+- Shared lib React-18 API removal beyond what the FR-04 audit surfaces
+- Production environment deployment (deferred to standard release procedure)
+
+## 8. Operational procedure (canonical reference)
+
+For step-by-step execution, see:
+
+📋 **[orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md)**
+
+The procedure doc is the binding operational reference. This design.md captures the rationale; the tasks in [tasks/](tasks/) capture the decomposition.

--- a/projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md
+++ b/projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md
@@ -1,0 +1,178 @@
+# Research Findings — 2026-06-22
+
+> **Purpose**: Capture the chain of investigation that scoped this project. This is the "WHY" record — future-you returns here to understand why specific decisions were made.
+> **Style**: chronological-ish, evidence-first.
+
+---
+
+## 1. The originating report
+
+On 2026-06-22, the chat-routing-redesign-r1 project filed a report flagging TypeScript drift in `@spaarke/ui-components` consumers. The report identified 4 buckets:
+
+| Bucket | Symptom | Affected |
+|---|---|---|
+| A | Mixed `@spaarke/ui-components/dist/...` + `/src/...` imports breaking when `dist/` not built | UQC only |
+| B | Broken SSE type re-export stub (`SseStreamStatus` / `SseDataChunk` / `UseSseStreamOptions` / `UseSseStreamResult` — names that don't exist in shared lib) | UQC only |
+| C | TS1323 dynamic-import error caused by PCF tsconfig `module: es2015` not matching shared-lib usage | UQC only (surfaced via UQC's `src/` deep-imports) |
+| D | `ReactElement` type identity collision between PCF `@types/react ^18` and shared lib `@types/react ^19` | 3 PCFs (DTW, SDV, VisualHost) + UQC |
+
+Initial assessment: A, B, C are UQC-specific; D is the only workspace-wide issue.
+
+## 2. The "is UQC even used?" question
+
+User asked: "I thought we moved away from UQC — does that PCF still matter?"
+
+Verified:
+- UQC source folder exists at `src/client/pcf/UniversalQuickCreate/`
+- Most recent source commit: `ec1d188e7` (chat-routing-redesign-r1 wave 0-A — the very project that filed the bucket report)
+- Bundle.js exists on disk at `solution/src/WebResources/sprk_Spaarke.Controls.UniversalDocumentUpload/bundle.js` but **`git log --all -- {path}` returns empty** → file is local-only / gitignored, never committed
+- 27 files reference `UniversalQuickCreate` or `UniversalDocumentUpload` across the repo (verified by Grep)
+
+Conclusion at this point: source is alive but uncertain about Dataverse-side use.
+
+## 3. Hunting for a prior PCF inventory
+
+User recalled a project named "PCF-code-page-inventory." Verified: no such project exists.
+
+Adjacent inventory artifacts found:
+
+| Artifact | Date | Scope | Verdict on UQC |
+|---|---|---|---|
+| [`projects/ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md`](../../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md) | 2026-05-14 | Bundle-size baseline; PCF folder enumeration + build:prod correctness | "Built but not deployed yet" (no committed bundle in solution) |
+| [`projects/sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md`](../../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md) | 2026-06-01 | Test-rot audit per surface | `clean` (3 test files, ~65 tests, all running) |
+
+Neither audited deployment status — both were lens-specific. Decision: build a third inventory focused on deployment.
+
+## 4. The 2026-06-22 deployment inventory
+
+Methodology:
+- Glob `src/client/pcf/*/ControlManifest.Input.xml` (4 hits at top level) + `src/client/pcf/*/*/ControlManifest.Input.xml` (10 hits one level deep) → 14 source-tree PCFs
+- Read each manifest for `namespace.constructor.version`
+- Dataverse MCP query: `SELECT * FROM customcontrol WHERE (name LIKE 'sprk_Spaarke%' OR name LIKE 'sprk_Sprk%') AND componentstate = 0` (with 20-record cap → 2 batches)
+- Read [`src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js`](../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js) for ribbon evidence
+
+Results captured in [`pcf-deployment-inventory-2026-06-22.md`](../../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md). Key data points:
+
+**Source tree (14 PCFs with manifests)**: AssociationResolver, DocumentRelationshipViewer, DrillThroughWorkspace, EmailProcessingMonitor, RegardingResolver, RelatedDocumentCount, ScopeConfigEditor, SemanticSearchControl, SpaarkeGridCustomizer, SpeDocumentViewer, ThemeEnforcer, UniversalQuickCreate, UpdateRelatedButton, VisualHost.
+
+**Dataverse-deployed (24 PCFs)**: 13 of the 14 source PCFs (DrillThroughWorkspace missing — never deployed) + 11 "ghost" PCFs deployed without any source-tree backing:
+- `sprk_Spaarke.Controls.AnalysisBuilder` v2.9.2 — predates AnalysisWorkspace Code Page
+- `sprk_Spaarke.Controls.AnalysisWorkspace` v1.3.5 — superseded by AnalysisWorkspace Code Page
+- `sprk_Spaarke.Controls.DueDatesWidget` v1.0.8
+- `sprk_Spaarke.Controls.EventAutoAssociate` v1.0.0
+- `sprk_Spaarke.Controls.EventCalendarFilter` v1.0.5 — superseded by `@spaarke/events-components` CalendarFilterPane
+- `sprk_Spaarke.Controls.EventFormController` v1.0.6
+- `sprk_Spaarke.Controls.FieldMappingAdmin` v1.1.0
+- `sprk_Spaarke.Controls.PlaybookBuilderHost` v2.25.0 — source layout non-standard, NOT triaged as orphan
+- `sprk_Spaarke.Controls.RegardingLink` v1.1.6 — predecessor of RegardingResolver
+- `sprk_Spaarke.LegalWorkspace` v1.0.1 — superseded by LegalWorkspace Code Page
+- `sprk_Spaarke.UI.Components.UniversalDatasetGrid` v2.3.1 — built from shared lib, not standalone PCF
+
+**6 canvas apps (Custom Pages, type=2)**: documentuploaddialog (UQC's host), eventspage, analysisworkspace (PCF host), visualizationdrillthroughworkspace (DTW's host — but DTW PCF isn't deployed!), playbookbuilder, analysisbuilder.
+
+## 5. The UQC smoking gun
+
+[`src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js`](../../../src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js) lines 582-585 — version-history comment block:
+
+```
+4.0.0: Code Page (webresource) dialog approach with React 18 (sprk_documentuploadwizard)
+3.0.x: Custom Page dialog approach with PCF control (sprk_documentuploaddialog_e52db)
+2.1.0: Form Dialog approach using sprk_uploadcontext utility entity
+2.0.0: Initial release for Custom Page architecture (deprecated)
+```
+
+The ribbon command that drove "Add Documents" on every Documents subgrid migrated from UQC's Custom Page → Code Page in v4.0.0. The PCF and its hosting Custom Page (`sprk_documentuploaddialog_e52db`) are deployed but **no traffic reaches them** — verified by reading both `openDocumentUploadDialog` call paths at lines 361 and 512, both of which target `sprk_documentuploadwizard` (the Code Page).
+
+This is the foundational evidence that made UQC retirement actionable.
+
+## 6. The Dataverse version drift detail
+
+- Source manifest: UQC v3.15.3 ([`UniversalQuickCreate/control/ControlManifest.Input.xml:3`](../../../src/client/pcf/UniversalQuickCreate/control/ControlManifest.Input.xml#L3))
+- Dataverse-deployed: UQC v3.15.2 (modified 2026-03-24)
+- Local bundle.js exists but uncommitted
+
+Interpretation: a fleet rebuild pass (likely `spaarke-auth-v2-and-hardening` task 028 "verify-rebuild-pcfs") bumped UQC's manifest along with everything else but never deployed because traffic had already migrated. Local bundle is dead-code from that uncompleted rebuild.
+
+## 7. DTW + SDV — confirming the suspicion
+
+User stated: "I'm not sure DrillThroughWorkspace or SpeDocumentViewer are used."
+
+Verified by source-tree grep:
+- **DrillThroughWorkspace**: 11 hits — all inside `src/client/pcf/DrillThroughWorkspace/` itself. Zero external importers.
+- **SpeDocumentViewer**: 6 hits — all inside `src/client/pcf/SpeDocumentViewer/` itself (manifest, package, solution files). Zero external importers.
+
+Cross-referenced with Dataverse modifiedon:
+- DTW: not deployed (consistent with 2026-05-14 bundle audit's "Built but not deployed yet")
+- SDV: deployed v1.0.27, last modified 2026-05-25 (so deployed AND somewhat recent — but no source-tree references, suggesting it was bound to forms via Dataverse-side configuration that left no source-tree footprint)
+
+User confirmed 2026-06-22: both unused. Folded into Part B (source delete) + Part C (Dataverse delete for SDV; canvas-app cleanup for DTW).
+
+## 8. VisualHost — the can-we-downversion question
+
+User concern: "VisualHost is used and we made enhancement recently — does downversioning React 18 → React 16 break those?"
+
+Critical test: grep `src/client/pcf/VisualHost/control/**/*.{ts,tsx}` for React 18-only APIs (`useId`, `useTransition`, `useDeferredValue`, `useSyncExternalStore`, `useInsertionEffect`, `createRoot`, `hydrateRoot`, `startTransition`).
+
+**Result: zero hits in source.** Only match anywhere is a historical comment in [`control/index.ts:4`](../../../src/client/pcf/VisualHost/control/index.ts#L4) — "Migrated from ComponentFramework.StandardControl (imperative ReactDOM.render)" — describing what it migrated AWAY from.
+
+All earlier noise (storybook-static + bundle.js hits) was build artifacts:
+- `storybook-static/` — Storybook docs site, separate React 18 runtime
+- `bundle.js` (SpeDocumentViewer) — bundled third-party Fluent + Griffel polyfilled hooks, not the PCF's own code
+
+Foundational fact: VisualHost's manifest declares `<platform-library name="React" version="16.14.0" />` ([line 148](../../../src/client/pcf/VisualHost/control/ControlManifest.Input.xml#L148)). The PCF runtime is ALWAYS React 16.14.0 regardless of `@types/react` pin. If VisualHost source had used React 18 runtime APIs, it would already be broken in production. It isn't. So it doesn't.
+
+Conclusion: safe to re-pin DOWN from `@types/react ^18` to `^16.14.x`. Recent enhancements use React 16-compatible APIs only.
+
+## 9. The "is recovery real?" question
+
+User: "If we run into an area where we inadvertently deleted a PCF that was actually needed can we resurrect OR recreate?"
+
+Three deletion types, three recovery paths:
+
+| Deletion | Recovery | Cost | GUID stable? |
+|---|---|---|---|
+| Source-tree | `git revert {sha}` or `git checkout {sha}~1 -- path/` | seconds (local) | n/a |
+| Dataverse customcontrol | `pac solution import --path baseline-{X}-pre-cleanup-2026-06-22.zip` | 5-10 min | **NO — new GUID** |
+| Dataverse canvas app | Same as above | 5-10 min | **NO — new GUID** |
+
+The GUID-change gotcha is the only real risk: if any form/ribbon hardcoded the old GUID (rare — most are name-based), re-wire is needed.
+
+The §1.1 backup ZIPs are the safety net. Without them, recovery for the 9 already-source-less PCFs means digging through git history to find the last commit that had their source, which gets expensive months after the fact.
+
+## 10. Scope finalization
+
+Final project scope established 2026-06-22:
+
+| Workstream | Count | What |
+|---|---:|---|
+| Source delete (1 PR) | 3 | UQC, DTW, SDV |
+| Dataverse customcontrol delete (2 environments) | 11 | UQC, SDV, AnalysisBuilder, AnalysisWorkspace PCF, DueDatesWidget, EventAutoAssociate, EventCalendarFilter, EventFormController, FieldMappingAdmin, RegardingLink, LegalWorkspace PCF |
+| Canvas app delete (2 environments) | 4-6 | documentuploaddialog, analysisbuilder, analysisworkspace, visualizationdrillthroughworkspace (DTW's empty host); verify eventspage and playbookbuilder |
+| Shared lib peerDep (1 PR) | 1 | `@spaarke/ui-components` package.json |
+| VisualHost re-pin (1 PR) | 1 | VisualHost package.json + manifest version bump |
+| Explicitly excluded | 1 | PlaybookBuilderHost — separate owner triage |
+
+Net effect:
+- Source tree: 14 PCFs → 11 PCFs
+- Dataverse (per env): 24 deployed PCFs → 13 deployed PCFs
+- Canvas apps (per env): 6 Spaarke-owned → 0-2 Spaarke-owned (playbookbuilder + eventspage pending verification)
+
+## 11. Why this needed to be a project, not a procedure doc alone
+
+The procedure doc ([`orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md`](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md)) is operationally complete. Reasons to wrap it in project structure anyway:
+
+1. **Production blast radius** — Dataverse mutations are not GUID-stable for restoration. Project structure forces explicit gating (current-task.md, TASK-INDEX.md, per-task POMLs).
+2. **Multi-week timeline** — 7-day soak between environments means the work spans calendar weeks. Project structure provides recovery anchors after compaction or session breaks.
+3. **Multiple workstreams that must sequence correctly** — source delete → Dataverse cleanup → React-types fix → environment replay. Encoding the dependency graph in `tasks/TASK-INDEX.md` is cheaper than re-deriving it from memory.
+4. **Audit trail** — the cleanup-log per FR-07 is the post-execution audit artifact. Project structure makes that log a first-class deliverable rather than ad-hoc note.
+
+## 12. Open questions resolved at project setup
+
+| Question | Answer | Resolved |
+|---|---|---|
+| Is the only PCF being retired UQC, or are there more? | 3 source + 11 Dataverse, not just UQC | §10 |
+| Is VisualHost re-pinning safe? | YES — zero React 18 APIs in source | §8 |
+| Is recovery possible after deletion? | YES, with §1.1 backups; GUID changes on re-import | §9 |
+| Where does PlaybookBuilderHost fit? | OUT of scope — needs separate triage | §10 |
+| Should source delete and Dataverse delete be one PR or separate? | One PR for source (FR-01); Dataverse is NOT a PR (logged session per FR-07) | spec.md / D-01 / NFR-06 |
+| Should VisualHost re-pin go UP to React 19 or DOWN to React 16? | DOWN to React 16 to match platform-library runtime per ADR-022 | D-04 |

--- a/projects/pcf-orphan-cleanup-r1/plan.md
+++ b/projects/pcf-orphan-cleanup-r1/plan.md
@@ -1,0 +1,83 @@
+# PCF Orphan Cleanup — Plan
+
+> **Project**: pcf-orphan-cleanup-r1
+> **Plan version**: 1.0 (2026-06-22)
+
+## Phased delivery — 14-day plan
+
+```
+P1: Days 1-3  — Source delete PR + pre-flight backups (Tasks 001, 002 in parallel)
+P2: Day 4     — Dataverse cleanup spaarkedev1 (Task 003, blocking — single session)
+P3: Days 4-10 — 7-day soak (no work — monitor for regressions)
+P4: Day 11    — Shared lib peerDep PR (Task 004)
+P5: Day 12    — VisualHost re-pin PR + deploy + smoke test (Task 005)
+P6: Day 13    — Dataverse cleanup spaarkedev2 replay (Task 006)
+P7: Day 14    — Cleanup-log finalize + inventory refresh (Task 007)
+```
+
+## Parallel execution groups
+
+| Group | Tasks | Why parallel-safe |
+|---|---|---|
+| **P1-W1** | 001 + 002 | Disjoint write paths: 001 writes `backups-2026-06-22/`; 002 writes `src/client/pcf/{UQC,DTW,SDV}/` (deletions). No shared files. |
+| (sequential) | 003 | Blocking — Dataverse mutation session, must run alone. Depends on 001 + 002 complete. |
+| (soak) | — | 7-day calendar wait. No task active. |
+| (sequential) | 004 | Depends on 003 complete (cleanup must be done before peerDep changes hit the build matrix). |
+| (sequential) | 005 | Depends on 004 (PR-D2 needs PR-D1's peerDep range to be in place for type resolution to work). |
+| (sequential) | 006 | Depends on 005 complete + 7-day soak complete from 003. spaarkedev2 mutations. |
+| (sequential) | 007 | Depends on 006 complete (final log writes cover both environments). |
+
+## Task dependency graph
+
+```
+001 (pre-flight)         002 (source PR)
+       \                    /
+        +------+   +-------+
+               \  /
+                v
+              003 (DV cleanup spaarkedev1)
+                |
+                | [7-day soak]
+                v
+              004 (shared lib peerDep PR)
+                |
+                v
+              005 (VisualHost re-pin PR)
+                |
+                v
+              006 (DV cleanup spaarkedev2)
+                |
+                v
+              007 (cleanup log + inventory refresh)
+```
+
+## Discovered resources (from chat-routing-redesign-r1 + ai-procedure-quality-r1 inventory work)
+
+- **Inventory data**: [`../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md) — 25 PCF tracked; 11 confirmed orphans
+- **Operational procedure**: [`../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md) — 9-section step-by-step
+- **Bundle-size baseline**: [`../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md`](../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md) — 2026-05-14 reference (needs refresh in Task 007)
+- **Test-rot audit**: [`../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md`](../sdap.bff.api-test-suite-repair-r2/baseline/phase4-track-a-pcf-audit-2026-06-01.md) — complementary view (test-rot, not deployment)
+- **Compiled research**: [`notes/research-findings-2026-06-22.md`](notes/research-findings-2026-06-22.md) — this project's chronicle of how the scope was established
+
+## Risk-driven sequencing rationale
+
+Tasks 001 + 002 run in parallel because they're the lowest-risk highest-value work — backups protect everything else, and source deletion is fully reversible via `git revert`.
+
+Task 003 is the single highest-blast-radius task. Runs alone in a focused 4-6 hour block. Followed by mandatory soak.
+
+Tasks 004 + 005 are low-blast-radius (PRs that affect build matrix, not production data). Run sequentially because PR-D2's success depends on PR-D1's peerDep range.
+
+Task 006 is a replay of 003 in a different environment. Same shape, lower risk (we've already done it once successfully and waited a week).
+
+Task 007 is purely documentation — final state capture.
+
+## What would change the plan
+
+- **§1.2 check finds unexpected references for any control** → reduce scope by removing that control from the FR-02/FR-03 deletion list; document deviation in `notes/`.
+- **Smoke test fails post-deletion** → halt; trigger resurrection (§3.5 in procedure doc); revisit the §1.2 check that missed the dependency.
+- **Soak surfaces a regression** → halt spaarkedev2 replay; investigate root cause; resume only after fix lands.
+- **VisualHost re-verify finds NEW React 18 API usage** → escalate; do not merge PR-D2 until either replaced with React-16-compatible code OR re-scoped.
+
+## Out of scope explicitly excluded
+
+See [spec.md §4](spec.md#4-explicitly-out-of-scope). Notable: PlaybookBuilderHost, Code Page / Vite SPA cleanup, shared-lib React-18 API removal beyond FR-04 audit, production deployment.

--- a/projects/pcf-orphan-cleanup-r1/spec.md
+++ b/projects/pcf-orphan-cleanup-r1/spec.md
@@ -1,0 +1,169 @@
+# PCF Orphan Cleanup — Specification
+
+> **Project**: pcf-orphan-cleanup-r1
+> **Spec version**: 1.0 (2026-06-22)
+> **Authority**: this spec is the binding contract for what gets done. [design.md](design.md) is the operational procedure; [tasks/](tasks/) is the execution decomposition.
+
+---
+
+## 1. Functional Requirements
+
+### FR-01 — Source-tree deletion
+
+Delete three PCF folders that no consumer imports:
+- `src/client/pcf/UniversalQuickCreate/` — orphan per ribbon migration (sprk_subgrid_commands.js v4.0.0)
+- `src/client/pcf/DrillThroughWorkspace/` — built but never deployed
+- `src/client/pcf/SpeDocumentViewer/` — confirmed unused 2026-06-22
+
+After this, the source tree has 11 PCFs (not 14) with `ControlManifest.Input.xml`.
+
+### FR-02 — Dataverse `customcontrol` deletion
+
+Delete 11 published `customcontrol` records from spaarkedev1, then spaarkedev2 (after 7-day soak):
+
+1. `sprk_Spaarke.Controls.UniversalDocumentUpload` (v3.15.2)
+2. `sprk_Spaarke.SpeDocumentViewer` (v1.0.27) ← MANDATORY FormXML grep before deletion
+3. `sprk_Spaarke.Controls.AnalysisBuilder` (v2.9.2)
+4. `sprk_Spaarke.Controls.AnalysisWorkspace` PCF (v1.3.5)
+5. `sprk_Spaarke.Controls.DueDatesWidget` (v1.0.8)
+6. `sprk_Spaarke.Controls.EventAutoAssociate` (v1.0.0)
+7. `sprk_Spaarke.Controls.EventCalendarFilter` (v1.0.5)
+8. `sprk_Spaarke.Controls.EventFormController` (v1.0.6)
+9. `sprk_Spaarke.Controls.FieldMappingAdmin` (v1.1.0)
+10. `sprk_Spaarke.Controls.RegardingLink` (v1.1.6)
+11. `sprk_Spaarke.LegalWorkspace` PCF (v1.0.1)
+
+### FR-03 — Canvas-app deletion
+
+Delete the orphan canvas apps that host the deleted PCFs (4 confirmed + 2 verify):
+
+- `sprk_documentuploaddialog_e52db` (hosted UQC)
+- `sprk_analysisbuilder_40af8` (hosted AnalysisBuilder)
+- `sprk_analysisworkspace_8bc0b` (hosted AnalysisWorkspace PCF)
+- `sprk_visualizationdrillthroughworkspace_e48a5` (hosted DrillThroughWorkspace — itself never deployed)
+- (verify) `sprk_eventspage_786f4` (canvas-app predecessor of the EventsPage Code Page)
+- (verify) `sprk_playbookbuilder_eb5ad` ← OUT OF SCOPE — PlaybookBuilderHost triage required first
+
+### FR-04 — Shared lib `@types/react` peerDep declaration
+
+In [`src/client/shared/Spaarke.UI.Components/package.json`](../../src/client/shared/Spaarke.UI.Components/package.json):
+
+- Add `@types/react` and `@types/react-dom` to `peerDependencies` with range `>=16.14 || >=17 || >=18 || >=19`.
+- Keep them in `devDependencies` for the lib's self-build.
+
+Pre-merge audit: zero React 18+ runtime API usage in shared lib source (`useId`, `useTransition`, `useDeferredValue`, `useSyncExternalStore`, `useInsertionEffect`, `createRoot`, `hydrateRoot`, `startTransition`). Any hits → replace or feature-gate before merge.
+
+### FR-05 — VisualHost React-16 realign
+
+In [`src/client/pcf/VisualHost/package.json`](../../src/client/pcf/VisualHost/package.json):
+
+- `react`: `^18.2.0` → `^16.14.0`
+- `@types/react`: `^18.2.0` → `^16.14.60`
+
+Re-verify zero React 18-only API usage in VisualHost source (already verified 2026-06-22; defensive re-run pre-merge). Deploy and smoke-test full feature surface (charts, drill-through, MetricCard, recent enhancements per b5b3118b1).
+
+Bump manifest version (1.4.16 → 1.4.17).
+
+### FR-06 — Environment replication
+
+Apply FR-02 + FR-03 deletions to spaarkedev1 first. After **7-day soak** with no regression reports, replicate to spaarkedev2. Production replication (if/when applicable) follows the standard release procedure ([deploy-new-release](../../.claude/skills/deploy-new-release/SKILL.md)).
+
+### FR-07 — Cleanup log
+
+Per-control deletion log filed at `notes/dataverse-cleanup-log.md` (one entry per FR-02 / FR-03 deletion). Entry shape:
+```
+- YYYY-MM-DD HH:MM — {control name} v{x.y.z}
+  - §1.2 results: refs = {none | list}
+  - Hosting canvas: {name | none}
+  - Solutions touched: {list}
+  - Deletion confirmed: PCF GUID {GUID}; canvas GUID {GUID}
+  - Smoke test: PASS / FAIL ({details})
+```
+
+### FR-08 — Inventory refresh
+
+Update [`pcf-deployment-inventory-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md) with a completion footnote when this project lands. Update [`pcf-bundle-sizes.md`](../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md) to remove the UQC + DTW + SDV entries from the baseline.
+
+---
+
+## 2. Non-Functional Requirements
+
+### NFR-01 — Baseline backups are MANDATORY
+
+Before ANY Dataverse-side deletion (FR-02 / FR-03), capture unmanaged solution-export ZIPs of every solution that contains a control slated for deletion. Park them in `projects/pcf-orphan-cleanup-r1/backups-2026-06-22/`. Without these, recovery from an over-deletion goes from "5-minute import" to "afternoon of forensic git+rebuild."
+
+### NFR-02 — Pre-flight 4-check is MANDATORY
+
+Per [design.md §1.2](design.md), before deleting any `customcontrol` or `canvasapp`:
+1. Solution memberships (Dataverse MCP `read_query` on `solutioncomponent`)
+2. **FormXML grep** (PAC CLI `pac solution export` + grep customizations.xml) ← **load-bearing**; Dataverse MCP cannot fetch FormXML body
+3. Ribbon JS grep across `src/solutions/*` + `src/client/pcf/*` + `scripts/*`
+4. Canvas-app dependencies (Dataverse MCP `read_query` on canvasapp)
+
+A control is safe to delete ONLY when all four return clean. SpeDocumentViewer is explicitly flagged "do not skip FormXML grep" because PCF form-bindings are the highest-risk drift mode.
+
+### NFR-03 — 7-day soak between environments
+
+After spaarkedev1 cleanup completes, wait 7 calendar days of business use. Monitor for regression reports. Do NOT batch the spaarkedev2 cleanup into the same week.
+
+### NFR-04 — No re-drift during execution
+
+Source folders deleted in FR-01 must not be re-introduced by parallel work. If another in-flight project adds back a reference to UQC / DTW / SDV during this project's execution window, that takes precedence — escalate and pause.
+
+### NFR-05 — Audit re-verification gate
+
+Before merging the VisualHost re-pin PR (FR-05), re-run the React-18-API grep. The 2026-06-22 audit found zero hits; this gate catches any post-audit code change that would have invalidated the verdict.
+
+### NFR-06 — One PR per workstream
+
+- PR 1: source deletion (FR-01)
+- PR 2: shared lib peerDep (FR-04)
+- PR 3: VisualHost re-pin (FR-05)
+
+Dataverse-side work (FR-02, FR-03, FR-06) is NOT a PR — it's a managed maker-portal + PAC CLI session, logged per FR-07.
+
+### NFR-07 — Resurrection path documented + tested
+
+[design.md §3.5](design.md) documents the resurrection playbook (source revert, customcontrol re-import, canvas app re-import). Before the Dataverse session runs in production, spot-test the recovery flow for one control in spaarkedev1: delete → verify gone → re-import baseline → verify restored. This proves the safety net works.
+
+---
+
+## 3. Success Criteria
+
+| SC | Verification |
+|---|---|
+| SC-01 — Source tree drops 14 → 11 PCFs | `Glob src/client/pcf/*/ControlManifest.Input.xml` returns 4 files; `Glob src/client/pcf/*/*/ControlManifest.Input.xml` returns 7 files; total = 11 |
+| SC-02 — spaarkedev1 customcontrol count drops appropriately | Dataverse MCP query: `SELECT COUNT(*) FROM customcontrol WHERE (name LIKE 'sprk_Spaarke%' OR name LIKE 'sprk_Sprk%') AND componentstate = 0` returns 13 (was 24) |
+| SC-03 — Each FR-02 control returns zero results when re-queried | Dataverse MCP query per control name |
+| SC-04 — Each FR-03 canvas app returns zero results when re-queried | Dataverse MCP query per canvas app name |
+| SC-05 — `@spaarke/ui-components/package.json` has multi-major `@types/react` peerDep | Read package.json; confirm peerDeps block matches FR-04 |
+| SC-06 — VisualHost deployed at v1.4.17 with React 16 type pins | Dataverse MCP query: VisualHost version = 1.4.17; smoke-test of charts + drill-through passes |
+| SC-07 — Bundle-size baseline updated | [`pcf-bundle-sizes.md`](../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md) no longer lists UQC / DTW / SDV |
+| SC-08 — No TS errors in build matrix | `npm run build:prod` in each of 11 PCFs and `npm run build` in each of 4 code-pages: zero new TS2322 / TS2305 / TS2307 |
+| SC-09 — spaarkedev2 mirrors spaarkedev1 post-soak | Re-run SC-02/03/04 against spaarkedev2 |
+| SC-10 — Cleanup log complete | `notes/dataverse-cleanup-log.md` has one entry per FR-02 / FR-03 deletion across both environments |
+| SC-11 — Backup ZIPs archived | `backups-2026-06-22/` contains one ZIP per touched unmanaged solution |
+| SC-12 — Inventory refresh footnote present | [`pcf-deployment-inventory-2026-06-22.md`](../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md) has "as of YYYY-MM-DD: cleanup complete" |
+
+---
+
+## 4. Explicitly out of scope
+
+- **PlaybookBuilderHost** retirement — non-standard source layout + recent Dataverse activity; needs separate owner triage before any deletion action.
+- **AIMetadataExtractor / SpeFileViewer / shared scaffolds** — folders that exist in `src/client/pcf/` but were never standalone PCFs per the 2026-05-14 bundle-size audit; not in Dataverse, no action needed.
+- **Code Pages / Vite SPAs cleanup** — `src/solutions/*` and `src/client/code-pages/*` are out of scope. The 2026-06-01 test-rot audit identified 2 rot pockets (SemanticSearch test runner not wired; AnalysisWorkspace deprecated tests) — those are tracked separately as the RB-CLIENT-001 / RB-CLIENT-002 r3-scope candidates.
+- **Shared lib React-18 API removal beyond what FR-04 audit surfaces** — if the pre-merge audit finds React 18+ APIs, they get fixed. If it finds none, no preemptive refactoring.
+- **Production environment deployment** — this project ends at spaarkedev2. Production replication follows the standard release procedure as a separate execution.
+
+---
+
+## 5. Decisions made (binding for this project)
+
+| ID | Date | Decision | Rationale |
+|---|---|---|---|
+| D-01 | 2026-06-22 | UQC + DTW + SDV deleted from source as a single PR | All three have zero external importers; bundling reduces review overhead; per-folder revert is still trivial if any one is challenged. |
+| D-02 | 2026-06-22 | SpeDocumentViewer FormXML grep is MANDATORY (not advisory) | SDV is the highest form-binding risk among the orphans; treat the grep as a hard gate. |
+| D-03 | 2026-06-22 | PlaybookBuilderHost EXPLICITLY out of scope | Non-standard source layout + recent Dataverse activity (2026-01-20); requires separate owner triage. |
+| D-04 | 2026-06-22 | Bucket D fix re-pins VisualHost to React 16 (not VisualHost up to 19) | Matches platform-library runtime per ADR-022; VisualHost source has zero React 18-only APIs (verified). |
+| D-05 | 2026-06-22 | 7-day soak between spaarkedev1 and spaarkedev2 | Match the production-release procedure cadence; allows business-hours regression discovery. |
+| D-06 | 2026-06-22 | Project lifespan ends at spaarkedev2 completion | Production replication is a separate work item under the standard release procedure. |

--- a/projects/pcf-orphan-cleanup-r1/tasks/001-preflight-backups.poml
+++ b/projects/pcf-orphan-cleanup-r1/tasks/001-preflight-backups.poml
@@ -1,0 +1,108 @@
+<task id="001" project="pcf-orphan-cleanup-r1">
+  <metadata>
+    <title>Pre-flight: solution backups + per-control 4-check (spaarkedev1)</title>
+    <phase>P1</phase>
+    <status>not-started</status>
+    <estimated-effort>2-4 hours</estimated-effort>
+    <dependencies>none</dependencies>
+    <blocks>003</blocks>
+    <tags>pcf, dataverse, pre-flight, backups, verification</tags>
+    <rigor-hint>STANDARD</rigor-hint>
+    <rigor-reason>Read-only audit + backup capture; no source code modifications. STANDARD rigor per CLAUDE.md §8.</rigor-reason>
+    <parallel-group>P1-W1</parallel-group>
+    <parallel-safe>true</parallel-safe>
+    <parallel-reason>Writes only to `backups-2026-06-22/`. Disjoint from Task 002 (which writes to `src/client/pcf/*`).</parallel-reason>
+    <production-fix-per-ledger>false</production-fix-per-ledger>
+  </metadata>
+
+  <prompt>
+    Execute the pre-flight phase of the orphan PCF cleanup procedure. Two parts:
+
+    1. **§1.1 Solution backups** — For every unmanaged solution in spaarkedev1 that contains a customcontrol slated for deletion in FR-02 / FR-03, export it unmanaged with `pac solution export --managed false --include general`. Park each ZIP in `projects/pcf-orphan-cleanup-r1/backups-2026-06-22/`.
+
+    2. **§1.2 Per-control 4-check verification** — For each of the 11 customcontrol records + 4-6 canvas apps in [`spec.md §FR-02 / §FR-03`](../spec.md), run the 4 checks documented in [procedure §1.2](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#12-per-control-still-referenced-check):
+       - Check 1: solution memberships (Dataverse MCP `read_query` on `solutioncomponent`)
+       - Check 2: FormXML grep (PAC CLI export + Select-String on customizations.xml) — **MANDATORY for SpeDocumentViewer per D-02**
+       - Check 3: ribbon JS grep across `src/solutions/*` + `src/client/pcf/*` + `scripts/*`
+       - Check 4: canvas app dependencies (Dataverse MCP `read_query`)
+
+    Document results per control in `notes/preflight-results-spaarkedev1.md` — one section per control, all 4 checks captured.
+
+    **Gate**: a control is safe to delete ONLY when all 4 checks return clean. ANY unexpected reference → STOP and reconcile (file a note in `notes/preflight-deviations.md`; do NOT proceed to Task 003 for that control).
+  </prompt>
+
+  <role>Dataverse + PCF engineer performing read-only verification + solution backup capture before destructive cleanup.</role>
+
+  <goal>
+    Two deliverables:
+    1. `backups-2026-06-22/` contains one unmanaged solution ZIP per touched solution.
+    2. `notes/preflight-results-spaarkedev1.md` contains per-control 4-check results for all 11 customcontrols + 4-6 canvas apps. Any unexpected references documented in `notes/preflight-deviations.md`.
+
+    NO source file modifications. NO Dataverse mutations. Read-only + backup-capture only.
+  </goal>
+
+  <inputs>
+    <file purpose="procedure-section">projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md</file>
+    <file purpose="spec">projects/pcf-orphan-cleanup-r1/spec.md</file>
+    <file purpose="design">projects/pcf-orphan-cleanup-r1/design.md</file>
+    <file purpose="claude-md">projects/pcf-orphan-cleanup-r1/CLAUDE.md</file>
+    <file purpose="inventory">projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md</file>
+  </inputs>
+
+  <constraints>
+    <constraint source="NFR-01">Baseline backups MUST be captured (no exceptions; this task's primary deliverable)</constraint>
+    <constraint source="NFR-02">4-check verification per control; FormXML grep MANDATORY for SpeDocumentViewer</constraint>
+    <constraint source="D-02">SpeDocumentViewer FormXML grep is a HARD GATE, not advisory</constraint>
+    <constraint source="ADR-022">PCF platform-libraries context (relevant for understanding why some controls bind to forms)</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>.claude/adr/ADR-022-pcf-platform-libraries.md</file>
+      <file>.claude/constraints/pcf.md</file>
+      <file>projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md</file>
+      <file>projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Authenticate to spaarkedev1: `pac auth select --name spaarkedev1` (or `pac auth create` if not yet registered).</step>
+    <step order="2">Enumerate solutions: `pac solution list --output table > backups-2026-06-22/solution-list-2026-06-22.txt`.</step>
+    <step order="3">For each customcontrol slated for deletion (per spec.md FR-02), run Dataverse MCP `read_query` against `solutioncomponent` to identify owning solutions. Capture in `notes/preflight-results-spaarkedev1.md`.</step>
+    <step order="4">Export each owning solution unmanaged: `pac solution export --name {SolutionName} --path backups-2026-06-22/baseline-{SolutionName}-pre-cleanup-2026-06-22.zip --managed false --include general`. Verify each ZIP exists + has non-zero size.</step>
+    <step order="5">For each customcontrol + canvas app: run all 4 checks per [procedure §1.2](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#12-per-control-still-referenced-check). Append results to `notes/preflight-results-spaarkedev1.md`.</step>
+    <step order="6">For SpeDocumentViewer specifically: confirm FormXML grep step actually ran on every exported solution's customizations.xml. Mark `MANDATORY ✅` or `MANDATORY ❌ STOPPED` in the SDV section.</step>
+    <step order="7">Any check returning unexpected references → write to `notes/preflight-deviations.md` with: control name, check that surfaced the reference, suggested resolution. Do NOT mark the control as ready for deletion.</step>
+    <step order="8">Final summary section in `notes/preflight-results-spaarkedev1.md`: per-control disposition table (`ready-to-delete` / `deviation-blocked` / `out-of-scope`).</step>
+    <step order="9">Update [`current-task.md`](../current-task.md): mark Task 001 ✅ if all 11 customcontrols + canvas apps are `ready-to-delete` OR `deviation-blocked` (deviations = future work, not failure of this task).</step>
+    <step order="10">Update [`tasks/TASK-INDEX.md`](TASK-INDEX.md): Task 001 status 🔲 → ✅.</step>
+  </steps>
+
+  <tools>
+    <tool name="Bash">PAC CLI for solution export + list</tool>
+    <tool name="mcp__dataverse__read_query">solutioncomponent + canvasapp dependency queries</tool>
+    <tool name="Grep">FormXML / ribbon JS searches across exported customizations.xml + repo source</tool>
+    <tool name="Write">notes/preflight-results-spaarkedev1.md, notes/preflight-deviations.md</tool>
+  </tools>
+
+  <outputs>
+    <output type="artifact">projects/pcf-orphan-cleanup-r1/backups-2026-06-22/*.zip (one per touched solution)</output>
+    <output type="docs">projects/pcf-orphan-cleanup-r1/notes/preflight-results-spaarkedev1.md</output>
+    <output type="docs">projects/pcf-orphan-cleanup-r1/notes/preflight-deviations.md (only if deviations found)</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">Every unmanaged solution containing a customcontrol from FR-02 / FR-03 has a corresponding ZIP in `backups-2026-06-22/`</criterion>
+    <criterion testable="true">`notes/preflight-results-spaarkedev1.md` has one section per customcontrol + canvas app (11+4-6 sections minimum)</criterion>
+    <criterion testable="true">Each section captures results of all 4 checks (solution membership, FormXML grep, ribbon JS grep, canvas-app deps)</criterion>
+    <criterion testable="true">SpeDocumentViewer's section explicitly confirms the FormXML grep ran on every exported customizations.xml</criterion>
+    <criterion testable="true">Final disposition table classifies each control as `ready-to-delete` / `deviation-blocked` / `out-of-scope`</criterion>
+    <criterion testable="true">If any control is `deviation-blocked`, `notes/preflight-deviations.md` exists with the deviation details</criterion>
+    <criterion testable="true">No source file modifications in `src/` (verified by `git status`)</criterion>
+    <criterion testable="true">No Dataverse mutations (read-only queries only — verified by re-querying customcontrol count post-task = pre-task count)</criterion>
+  </acceptance-criteria>
+
+  <execution>
+    Run via `task-execute` skill. STANDARD rigor (read-only + backup-capture; no production code changes).
+  </execution>
+</task>

--- a/projects/pcf-orphan-cleanup-r1/tasks/002-source-deletion.poml
+++ b/projects/pcf-orphan-cleanup-r1/tasks/002-source-deletion.poml
@@ -1,0 +1,103 @@
+<task id="002" project="pcf-orphan-cleanup-r1">
+  <metadata>
+    <title>Source-tree deletion PR (UQC + DTW + SDV)</title>
+    <phase>P1</phase>
+    <status>not-started</status>
+    <estimated-effort>1-2 hours</estimated-effort>
+    <dependencies>none</dependencies>
+    <blocks>003</blocks>
+    <tags>pcf, source-cleanup, git, react-types</tags>
+    <rigor-hint>STANDARD</rigor-hint>
+    <rigor-reason>Folder deletions + grep verification. No new feature code; no API changes. Fully reversible via `git revert`. STANDARD rigor per CLAUDE.md §8.</rigor-reason>
+    <parallel-group>P1-W1</parallel-group>
+    <parallel-safe>true</parallel-safe>
+    <parallel-reason>Writes to `src/client/pcf/{UQC,DTW,SDV}/` (deletions). Disjoint from Task 001 (which writes to `backups-2026-06-22/`).</parallel-reason>
+    <production-fix-per-ledger>false</production-fix-per-ledger>
+  </metadata>
+
+  <prompt>
+    Delete three orphan PCF source folders via one focused PR. Follow [procedure §2 Part B](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#2-part-b--source-tree-deletion-pr-1) verbatim.
+
+    The three folders going away:
+    - `src/client/pcf/UniversalQuickCreate/` — orphan per ribbon migration (sprk_subgrid_commands.js v4.0.0)
+    - `src/client/pcf/DrillThroughWorkspace/` — built but never deployed
+    - `src/client/pcf/SpeDocumentViewer/` — confirmed unused 2026-06-22 (no external importers)
+
+    Verification gate: the residual-importers grep from procedure §2.2 step 1 MUST return only the expected matches (inside the three deleted folders + the sprk_subgrid_commands.js version-history comment). Any unexpected match → STOP and reconcile.
+  </prompt>
+
+  <role>Software engineer performing surgical source-tree deletion with rigorous pre-delete verification.</role>
+
+  <goal>
+    One merged PR that:
+    - Removes `src/client/pcf/UniversalQuickCreate/` entirely (including the broken `useSseStream.ts` re-export stub flagged as bucket B in the chat-routing-redesign-r1 audit)
+    - Removes `src/client/pcf/DrillThroughWorkspace/` entirely
+    - Removes `src/client/pcf/SpeDocumentViewer/` entirely
+    - Updates any deploy scripts that hard-coded these PCFs
+    - Builds clean: `dotnet build src\server\api\Sprk.Bff.Api\` passes; `npm run build` from `src\client\pcf\` passes
+
+    After this PR, the source tree has 11 PCFs (down from 14) with `ControlManifest.Input.xml`.
+  </goal>
+
+  <inputs>
+    <file purpose="procedure-section">projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md</file>
+    <file purpose="spec">projects/pcf-orphan-cleanup-r1/spec.md</file>
+    <file purpose="design">projects/pcf-orphan-cleanup-r1/design.md</file>
+    <file purpose="claude-md">projects/pcf-orphan-cleanup-r1/CLAUDE.md</file>
+    <file purpose="evidence">src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js</file>
+  </inputs>
+
+  <constraints>
+    <constraint source="FR-01">Delete UQC + DTW + SDV folders</constraint>
+    <constraint source="D-01">All three in ONE PR (not three separate)</constraint>
+    <constraint source="NFR-04">Must not be undone by parallel project work during execution window</constraint>
+    <constraint source="NFR-06">One PR per workstream</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>.claude/adr/ADR-022-pcf-platform-libraries.md</file>
+      <file>.claude/constraints/pcf.md</file>
+      <file>projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md</file>
+      <file>projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Run the residual-importers grep per procedure §2.2 step 1: `Select-String -Path "src\**\*.ts","src\**\*.tsx","src\**\*.js" -Pattern "UniversalQuickCreate|UniversalDocumentUpload|DrillThroughWorkspace|SpeDocumentViewer|@spaarke/ui-components/src/services/document-upload|@spaarke/ui-components/dist/utils/themeStorage" -SimpleMatch`</step>
+    <step order="2">Verify expected-only matches: (a) inside the three deleted folders, (b) `src/solutions/DocumentUploadWizard/sprk_subgrid_commands.js` lines 582-585 (version-history comment). Any other match → STOP.</step>
+    <step order="3">Delete the three folders: `git rm -r src/client/pcf/UniversalQuickCreate/`; `git rm -r src/client/pcf/DrillThroughWorkspace/`; `git rm -r src/client/pcf/SpeDocumentViewer/`.</step>
+    <step order="4">Verify the broken `useSseStream.ts` re-export stub from bucket B is gone (it lived under UQC). Confirm no other file imports from it: `Select-String -Path "src\**\*.ts","src\**\*.tsx" -Pattern "from ['""].*UniversalQuickCreate.*useSseStream"`. Expected: zero matches.</step>
+    <step order="5">Search deploy scripts: `Select-String -Path "scripts\**\*.ps1","scripts\**\*.sh","scripts\**\*.js" -Pattern "UniversalQuickCreate|UniversalDocumentUpload|DrillThroughWorkspace|SpeDocumentViewer"`. Update any hits that hard-coded the three controls.</step>
+    <step order="6">Build the workspace: `dotnet build src\server\api\Sprk.Bff.Api\` (BFF still builds). `pushd src\client\pcf; npm run build; popd` (PCF workspace builds — 11 PCFs, not 14).</step>
+    <step order="7">Run `git status` — confirm only the three folder deletions + any deploy script updates from step 5.</step>
+    <step order="8">Commit with the message specified in procedure §2.2 step 6 (single commit; cite ribbon migration evidence + bundle-audit reference for DTW + 2026-06-22 owner confirmation for SDV).</step>
+    <step order="9">Push branch + open PR. Title: `chore(pcf): retire 3 orphan PCFs (UQC + DrillThroughWorkspace + SpeDocumentViewer)`.</step>
+    <step order="10">Update [`current-task.md`](../current-task.md) + [`tasks/TASK-INDEX.md`](TASK-INDEX.md) (Task 002 status → ✅ on merge).</step>
+  </steps>
+
+  <tools>
+    <tool name="Grep">residual-importer verification across `src/`, `scripts/`</tool>
+    <tool name="Bash">`git rm -r`, build commands, `git commit`, `gh pr create`</tool>
+    <tool name="Edit">deploy scripts if hardcoded refs found in step 5</tool>
+  </tools>
+
+  <outputs>
+    <output type="pr">One merged PR retiring three orphan PCF folders</output>
+    <output type="state-change">Source tree: 14 → 11 PCFs with ControlManifest.Input.xml</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">`src/client/pcf/UniversalQuickCreate/` does not exist on `main` post-merge</criterion>
+    <criterion testable="true">`src/client/pcf/DrillThroughWorkspace/` does not exist on `main` post-merge</criterion>
+    <criterion testable="true">`src/client/pcf/SpeDocumentViewer/` does not exist on `main` post-merge</criterion>
+    <criterion testable="true">`Glob src/client/pcf/*/ControlManifest.Input.xml` + `Glob src/client/pcf/*/*/ControlManifest.Input.xml` returns 11 total (was 14)</criterion>
+    <criterion testable="true">`dotnet build src\server\api\Sprk.Bff.Api\` succeeds post-merge</criterion>
+    <criterion testable="true">`npm run build` in `src\client\pcf\` succeeds post-merge</criterion>
+    <criterion testable="true">Residual-importer grep from step 1 returns zero unexpected matches (only expected ones inside deleted folders + sprk_subgrid_commands.js comment block)</criterion>
+  </acceptance-criteria>
+
+  <execution>
+    Run via `task-execute` skill. STANDARD rigor (folder deletions + grep verification; fully reversible).
+  </execution>
+</task>

--- a/projects/pcf-orphan-cleanup-r1/tasks/003-dataverse-cleanup-spaarkedev1.poml
+++ b/projects/pcf-orphan-cleanup-r1/tasks/003-dataverse-cleanup-spaarkedev1.poml
@@ -1,0 +1,113 @@
+<task id="003" project="pcf-orphan-cleanup-r1">
+  <metadata>
+    <title>Dataverse cleanup session — spaarkedev1 (11 customcontrols + 4-6 canvas apps)</title>
+    <phase>P2</phase>
+    <status>not-started</status>
+    <estimated-effort>4-6 hours (single focused block)</estimated-effort>
+    <dependencies>001, 002</dependencies>
+    <blocks>004</blocks>
+    <tags>pcf, dataverse, cleanup, destructive, production-shape</tags>
+    <rigor-hint>FULL</rigor-hint>
+    <rigor-reason>Production-shape Dataverse mutations. Not source code, but blast radius is high. FULL rigor per CLAUDE.md §8.</rigor-reason>
+    <parallel-group>(sequential — single Dataverse session)</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Blocking by design — destructive Dataverse session must be a focused single-actor block. Cannot interleave with other Dataverse mutations.</parallel-reason>
+    <production-fix-per-ledger>false</production-fix-per-ledger>
+  </metadata>
+
+  <prompt>
+    Execute the Dataverse-side cleanup against spaarkedev1. Follow [procedure §3 Part C](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#3-part-c--dataverse-cleanup-single-session-gated) verbatim. This is the highest-blast-radius task in the project.
+
+    Targets: the 11 customcontrols + 4-6 canvas apps from [spec.md FR-02 / FR-03](../spec.md), in the deletion order specified in [procedure §3.1](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#31-cleanup-targets).
+
+    Hard gates before each deletion:
+    - Task 001's preflight-results entry for this control = `ready-to-delete`
+    - SpeDocumentViewer specifically: confirm the FormXML grep MANDATORY check ran clean (per D-02)
+
+    For each control, follow the 9-step sequence in [procedure §3.2](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#32-per-control-deletion-sequence):
+    1. Re-run §1.2 checks (immediate-pre-deletion sanity)
+    2. Remove form references (if §1.2 check 2 surfaced any)
+    3. Unpublish canvas app
+    4. Remove canvas from solution
+    5. Remove customcontrol from solution
+    6. Delete canvas app
+    7. Delete customcontrol
+    8. Verify (re-query — should return empty)
+    9. Log entry in `notes/dataverse-cleanup-log.md`
+
+    Spot-test resurrection per NFR-07 ONCE during this session — pick a low-stakes control (e.g., EventAutoAssociate), delete it, immediately re-import from baseline backup, verify the resurrected control exists. This proves the safety net works. Document in the cleanup log.
+  </prompt>
+
+  <role>Dataverse administrator performing carefully-gated destructive cleanup in a focused single session, with explicit logging and resurrection spot-test.</role>
+
+  <goal>
+    11 customcontrol records + 4-6 canvas apps deleted from spaarkedev1. Each deletion logged with §1.2 results + smoke-test outcome. Resurrection spot-test passed.
+
+    On completion: Dataverse MCP query `SELECT COUNT(*) FROM customcontrol WHERE (name LIKE 'sprk_Spaarke%' OR name LIKE 'sprk_Sprk%') AND componentstate = 0` returns 13 (was 24).
+  </goal>
+
+  <inputs>
+    <file purpose="procedure-section">projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md</file>
+    <file purpose="spec">projects/pcf-orphan-cleanup-r1/spec.md</file>
+    <file purpose="design">projects/pcf-orphan-cleanup-r1/design.md</file>
+    <file purpose="claude-md">projects/pcf-orphan-cleanup-r1/CLAUDE.md</file>
+    <file purpose="preflight-input">projects/pcf-orphan-cleanup-r1/notes/preflight-results-spaarkedev1.md</file>
+    <file purpose="backups">projects/pcf-orphan-cleanup-r1/backups-2026-06-22/</file>
+  </inputs>
+
+  <constraints>
+    <constraint source="FR-02">11 customcontrol deletions per spec</constraint>
+    <constraint source="FR-03">4-6 canvas-app deletions per spec</constraint>
+    <constraint source="NFR-02">§1.2 4-check immediately pre-deletion</constraint>
+    <constraint source="NFR-07">Resurrection spot-test MUST be performed during this session</constraint>
+    <constraint source="D-02">SDV FormXML grep is HARD gate</constraint>
+    <constraint source="D-03">PlaybookBuilderHost EXPLICITLY out of scope</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>.claude/adr/ADR-022-pcf-platform-libraries.md</file>
+      <file>projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md</file>
+      <file>projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Confirm Task 001 outputs exist: `backups-2026-06-22/` has the expected ZIPs; `notes/preflight-results-spaarkedev1.md` classifies all 11 controls as `ready-to-delete`. STOP if any control is `deviation-blocked`.</step>
+    <step order="2">Authenticate to spaarkedev1: `pac auth select --name spaarkedev1`.</step>
+    <step order="3">For each control in [procedure §3.1 cleanup-targets table](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#31-cleanup-targets) (order matters — start with UQC, end with LegalWorkspace + DTW canvas): execute the 9-step per-control sequence per procedure §3.2.</step>
+    <step order="4">After the first deletion (UQC), pause for resurrection spot-test: re-import `backups-2026-06-22/baseline-{UQC-solution}-pre-cleanup-2026-06-22.zip` and confirm UQC's customcontrol reappears (with a new GUID — see §3.5.2). Then re-delete it (we're not actually keeping it; this is a recovery-drill verification only). Log spot-test outcome in `notes/dataverse-cleanup-log.md`.</step>
+    <step order="5">After EACH per-control deletion: append log entry per [spec.md FR-07 entry shape](../spec.md#fr-07--cleanup-log).</step>
+    <step order="6">After all deletions: run the smoke-test suite per procedure §3.2 step 8 — open a Matter and verify Documents subgrid still works (UQC's primary consumer was the ribbon there); open an Event and verify calendar filtering still works (EventCalendarFilter was the calendar PCF); open any AnalysisWorkspace Code Page and verify it renders (the PCF version is gone but the Code Page should be untouched).</step>
+    <step order="7">Verify counts post-session: `SELECT COUNT(*) FROM customcontrol WHERE (name LIKE 'sprk_Spaarke%' OR name LIKE 'sprk_Sprk%') AND componentstate = 0` returns 13. Run per-control re-queries: each of the 11 deleted controls returns empty.</step>
+    <step order="8">Run quality gates per CLAUDE.md §8 FULL rigor: invoke `code-review` skill on the cleanup log (does the log accurately reflect what was deleted?) + `adr-check` (no ADR violations introduced).</step>
+    <step order="9">Update [`current-task.md`](../current-task.md): Task 003 ✅; next action = wait 7 days for soak before Task 004.</step>
+    <step order="10">Update [`tasks/TASK-INDEX.md`](TASK-INDEX.md): Task 003 → ✅ with date.</step>
+  </steps>
+
+  <tools>
+    <tool name="Bash">PAC CLI: `pac auth select`, `pac solution import` (for resurrection drill), `pac solution publish`</tool>
+    <tool name="mcp__dataverse__read_query">solutioncomponent + customcontrol re-queries</tool>
+    <tool name="Write">notes/dataverse-cleanup-log.md (per-control entries + spot-test outcome + final summary)</tool>
+    <tool name="Skill">code-review + adr-check (Step 8 quality gates)</tool>
+  </tools>
+
+  <outputs>
+    <output type="state-change">spaarkedev1: 24 deployed Spaarke PCFs → 13</output>
+    <output type="state-change">spaarkedev1: 6 Spaarke canvas apps → 0-2</output>
+    <output type="docs">projects/pcf-orphan-cleanup-r1/notes/dataverse-cleanup-log.md (with 11+4-6 entries + resurrection spot-test)</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">All 11 customcontrols from FR-02 return empty when re-queried by name in spaarkedev1</criterion>
+    <criterion testable="true">All canvas apps from FR-03 (sans pending verification on eventspage + playbookbuilder) return empty when re-queried</criterion>
+    <criterion testable="true">Smoke tests pass: Matter / Documents subgrid renders; Event calendar filter works; AnalysisWorkspace Code Page renders</criterion>
+    <criterion testable="true">Resurrection spot-test logged with pass outcome</criterion>
+    <criterion testable="true">`notes/dataverse-cleanup-log.md` has one entry per deletion (11+4-6 minimum) + summary section</criterion>
+    <criterion testable="true">code-review + adr-check skills invoked and pass</criterion>
+  </acceptance-criteria>
+
+  <execution>
+    Run via `task-execute` skill. FULL rigor (destructive Dataverse mutations; Step 9.5 quality gates required).
+  </execution>
+</task>

--- a/projects/pcf-orphan-cleanup-r1/tasks/004-shared-lib-peerdep.poml
+++ b/projects/pcf-orphan-cleanup-r1/tasks/004-shared-lib-peerdep.poml
@@ -1,0 +1,104 @@
+<task id="004" project="pcf-orphan-cleanup-r1">
+  <metadata>
+    <title>Shared lib @types/react peerDep declaration (PR-D1)</title>
+    <phase>P4</phase>
+    <status>not-started</status>
+    <estimated-effort>2-4 hours</estimated-effort>
+    <dependencies>003</dependencies>
+    <blocks>005</blocks>
+    <tags>react-types, shared-lib, ui-components, bucket-d, fluent-v9</tags>
+    <rigor-hint>FULL</rigor-hint>
+    <rigor-reason>Changes the published peerDep contract of @spaarke/ui-components — affects every consumer (11 PCFs + 4 code-pages + 22 Vite solutions). FULL rigor per CLAUDE.md §8.</rigor-reason>
+    <parallel-group>(sequential)</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Depends on Task 003 completion + 7-day soak — cleanup must be stable before changing the type-system contract.</parallel-reason>
+    <production-fix-per-ledger>false</production-fix-per-ledger>
+  </metadata>
+
+  <prompt>
+    Move `@types/react` + `@types/react-dom` from `devDependencies` to `peerDependencies` in [`src/client/shared/Spaarke.UI.Components/package.json`](../../../src/client/shared/Spaarke.UI.Components/package.json) with a multi-major range (`>=16.14 || >=17 || >=18 || >=19`). Follow [procedure §4.3 PR-D1](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#43-pr-d1--shared-lib-peerdep-fix).
+
+    **Mandatory pre-merge audit** — grep shared lib source for React 18+ runtime APIs that would silently break React-16 PCF consumers. Per NFR-05.
+
+    Hits → for each, decide:
+    - Replace with React-16-compatible equivalent (e.g., `useId` → manual id generator with `useRef`; `useSyncExternalStore` → manual `useEffect` + `useState`)
+    - OR feature-gate behind a runtime check (acceptable for opt-in surfaces consumed only by React 18+ Code Pages)
+    - OR document the surface as React-18-only and add an export-time guard preventing React-16 consumers (PCFs) from importing it
+
+    Build matrix verification: shared lib + each of 11 PCFs + 3 spot-checked Code Pages must build cleanly.
+  </prompt>
+
+  <role>Shared-lib maintainer changing the type-system peerDep contract with rigorous pre-merge audit.</role>
+
+  <goal>
+    One merged PR that:
+    - Adds `@types/react` + `@types/react-dom` to `peerDependencies` with `>=16.14 || >=17 || >=18 || >=19` range
+    - Keeps them in `devDependencies` for the lib's own self-build
+    - Lands with documented evidence that the shared lib uses zero React 18+ runtime APIs (or any that exist have been addressed)
+    - Build matrix passes: 11 PCFs + 3 spot-checked Code Pages
+  </goal>
+
+  <inputs>
+    <file purpose="procedure-section">projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md</file>
+    <file purpose="spec">projects/pcf-orphan-cleanup-r1/spec.md</file>
+    <file purpose="design">projects/pcf-orphan-cleanup-r1/design.md</file>
+    <file purpose="claude-md">projects/pcf-orphan-cleanup-r1/CLAUDE.md</file>
+    <file purpose="target">src/client/shared/Spaarke.UI.Components/package.json</file>
+  </inputs>
+
+  <constraints>
+    <constraint source="FR-04">Multi-major @types/react peerDep declaration</constraint>
+    <constraint source="NFR-05">Pre-merge audit of shared lib for React 18+ runtime APIs is MANDATORY</constraint>
+    <constraint source="ADR-022">React 16 APIs only (shared lib must be safe to consume from React-16 PCFs)</constraint>
+    <constraint source="ADR-012">Shared component library (context-agnostic — multi-major peerDep is consistent)</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>.claude/adr/ADR-022-pcf-platform-libraries.md</file>
+      <file>.claude/adr/ADR-012-shared-component-library.md</file>
+      <file>projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Edit [`src/client/shared/Spaarke.UI.Components/package.json`](../../../src/client/shared/Spaarke.UI.Components/package.json): add to `peerDependencies` block: `"@types/react": ">=16.14 || >=17 || >=18 || >=19"`, `"@types/react-dom": ">=16.14 || >=17 || >=18 || >=19"`. Keep existing devDeps unchanged.</step>
+    <step order="2">Run the pre-merge React-18-API audit per procedure §4.3 verify block: `Select-String -Path "src\client\shared\Spaarke.UI.Components\src\**\*.ts","src\client\shared\Spaarke.UI.Components\src\**\*.tsx" -Pattern "\b(useId|useTransition|useDeferredValue|useSyncExternalStore|useInsertionEffect|createRoot|hydrateRoot|startTransition)\b"`</step>
+    <step order="3">For each hit (if any): document in `notes/shared-lib-react18-audit.md` with file, line, decision (replace / feature-gate / export-guard). Apply the fix.</step>
+    <step order="4">Build shared lib: `pushd src\client\shared\Spaarke.UI.Components; npm run build; popd` — must succeed.</step>
+    <step order="5">Build all 11 PCFs: `pushd src\client\pcf; npm run build; popd` — must succeed for all.</step>
+    <step order="6">Build 3 spot-checked Code Pages (SmartTodo, SpaarkeAi, LegalWorkspace): each `npm run build` must succeed.</step>
+    <step order="7">Verify no new TS errors: `npm run build` output for each must show zero TS2322 / TS2305 / TS2307 errors that weren't present pre-PR.</step>
+    <step order="8">Commit per procedure §4.3 commit block.</step>
+    <step order="9">Push branch + open PR. Title: `fix(ui-components): declare @types/react as peerDep (multi-major)`. Include audit findings in PR description.</step>
+    <step order="10">Quality gates per CLAUDE.md §8 FULL rigor: invoke `code-review` skill + `adr-check` skill.</step>
+    <step order="11">Update [`current-task.md`](../current-task.md) + [`tasks/TASK-INDEX.md`](TASK-INDEX.md) (Task 004 → ✅ on merge).</step>
+  </steps>
+
+  <tools>
+    <tool name="Edit">src/client/shared/Spaarke.UI.Components/package.json</tool>
+    <tool name="Grep">React-18-API audit across shared lib source</tool>
+    <tool name="Bash">npm builds across shared lib + 11 PCFs + 3 code-pages; `gh pr create`</tool>
+    <tool name="Write">notes/shared-lib-react18-audit.md (if hits found)</tool>
+    <tool name="Skill">code-review + adr-check (Step 10 quality gates)</tool>
+  </tools>
+
+  <outputs>
+    <output type="pr">One merged PR adding multi-major @types/react peerDep to shared lib</output>
+    <output type="docs">notes/shared-lib-react18-audit.md (only if hits found in Step 2)</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">`src/client/shared/Spaarke.UI.Components/package.json` peerDependencies block contains `@types/react` and `@types/react-dom` with `>=16.14 || >=17 || >=18 || >=19` range</criterion>
+    <criterion testable="true">Pre-merge audit grep returned zero hits OR all hits documented + addressed in `notes/shared-lib-react18-audit.md`</criterion>
+    <criterion testable="true">Shared lib builds: `pushd src\client\shared\Spaarke.UI.Components; npm run build` succeeds</criterion>
+    <criterion testable="true">All 11 PCFs build successfully with the new peerDep</criterion>
+    <criterion testable="true">3 spot-checked Code Pages (SmartTodo, SpaarkeAi, LegalWorkspace) build successfully</criterion>
+    <criterion testable="true">No new TS2322 / TS2305 / TS2307 errors in any build target</criterion>
+    <criterion testable="true">code-review + adr-check skills invoked and pass</criterion>
+  </acceptance-criteria>
+
+  <execution>
+    Run via `task-execute` skill. FULL rigor (cross-cutting type-system contract change).
+  </execution>
+</task>

--- a/projects/pcf-orphan-cleanup-r1/tasks/005-visualhost-react16-realign.poml
+++ b/projects/pcf-orphan-cleanup-r1/tasks/005-visualhost-react16-realign.poml
@@ -1,0 +1,108 @@
+<task id="005" project="pcf-orphan-cleanup-r1">
+  <metadata>
+    <title>VisualHost re-pin to React 16 (PR-D2) — deploy + smoke</title>
+    <phase>P5</phase>
+    <status>not-started</status>
+    <estimated-effort>3-5 hours</estimated-effort>
+    <dependencies>004</dependencies>
+    <blocks>006</blocks>
+    <tags>pcf, react-types, visualhost, bucket-d, deploy, adr-022</tags>
+    <rigor-hint>FULL</rigor-hint>
+    <rigor-reason>Production PCF re-pin + redeploy. ADR-022 binding. Recent enhancements at risk if React 18 APIs were missed. FULL rigor per CLAUDE.md §8.</rigor-reason>
+    <parallel-group>(sequential)</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Depends on Task 004 (PR-D1's peerDep range must be merged for PR-D2's type matrix to resolve cleanly).</parallel-reason>
+    <production-fix-per-ledger>false</production-fix-per-ledger>
+  </metadata>
+
+  <prompt>
+    Re-pin VisualHost from React 18 type pins to React 16 type pins to match its platform-library runtime (per ADR-022). Follow [procedure §4.4 PR-D2](../../ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md#44-pr-d2--re-pin-visualhost-to-react-16) verbatim.
+
+    Two-file edit:
+    - [`src/client/pcf/VisualHost/package.json`](../../../src/client/pcf/VisualHost/package.json): `react ^18.2.0` → `^16.14.0`; `@types/react ^18.2.0` → `^16.14.60`
+    - [`src/client/pcf/VisualHost/control/ControlManifest.Input.xml`](../../../src/client/pcf/VisualHost/control/ControlManifest.Input.xml): bump version `1.4.16` → `1.4.17`
+
+    Then: clean install, build:prod, deploy to spaarkedev1, smoke-test ALL VisualHost features.
+
+    **Mandatory defensive re-verification**: re-run the React-18-API grep on VisualHost source BEFORE merging. 2026-06-22 audit returned zero hits; this gate catches any post-audit code change. Per NFR-05.
+  </prompt>
+
+  <role>PCF engineer performing a type-system re-pin on a deployed PCF with rigorous smoke-test of the full feature surface (including recent enhancements).</role>
+
+  <goal>
+    One merged PR + one successful deploy that:
+    - VisualHost `package.json` pins React 16 (matching platform-library runtime)
+    - Manifest version bumped to 1.4.17
+    - Deployed to spaarkedev1 with smoke-test pass covering: chart rendering, drill-through, MetricCard matrix layout, recent enhancements per commit b5b3118b1
+    - Closes bucket D from the chat-routing-redesign-r1 audit
+  </goal>
+
+  <inputs>
+    <file purpose="procedure-section">projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md</file>
+    <file purpose="spec">projects/pcf-orphan-cleanup-r1/spec.md</file>
+    <file purpose="design">projects/pcf-orphan-cleanup-r1/design.md</file>
+    <file purpose="target-package">src/client/pcf/VisualHost/package.json</file>
+    <file purpose="target-manifest">src/client/pcf/VisualHost/control/ControlManifest.Input.xml</file>
+    <file purpose="deploy-guide">docs/guides/PCF-DEPLOYMENT-GUIDE.md</file>
+  </inputs>
+
+  <constraints>
+    <constraint source="FR-05">VisualHost re-pin to React 16 type pins</constraint>
+    <constraint source="NFR-05">React-18-API grep re-verification pre-merge is MANDATORY</constraint>
+    <constraint source="ADR-022">PCF runtime is React 16.14.0 (platform-library); type pin must match</constraint>
+    <constraint source="D-04">Re-pin DOWN to React 16 (not UP to React 19) — matches runtime, preserves features</constraint>
+    <constraint source="FAILURE-MODES.md#AP-1">Use `npm run build:prod`, NOT `npm run build`</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>.claude/adr/ADR-022-pcf-platform-libraries.md</file>
+      <file>.claude/FAILURE-MODES.md</file>
+      <file>.claude/skills/pcf-deploy/SKILL.md</file>
+      <file>docs/guides/PCF-DEPLOYMENT-GUIDE.md</file>
+      <file>projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">**Defensive re-verification** per NFR-05: `Select-String -Path "src\client\pcf\VisualHost\control\**\*.ts","src\client\pcf\VisualHost\control\**\*.tsx" -Pattern "\b(useId|useTransition|useDeferredValue|useSyncExternalStore|useInsertionEffect|createRoot|hydrateRoot|startTransition)\b"`. Expected: zero hits (confirmed 2026-06-22). ANY hit → STOP and reconcile.</step>
+    <step order="2">Edit `src/client/pcf/VisualHost/package.json`: change `"react": "^18.2.0"` → `"^16.14.0"`; change `"@types/react": "^18.2.0"` → `"^16.14.60"`.</step>
+    <step order="3">Edit `src/client/pcf/VisualHost/control/ControlManifest.Input.xml`: bump `version="1.4.16"` → `version="1.4.17"`.</step>
+    <step order="4">Clean install: `pushd src\client\pcf\VisualHost; Remove-Item -Recurse -Force node_modules; Remove-Item -Force package-lock.json; npm install --legacy-peer-deps --no-audit --no-fund; popd`.</step>
+    <step order="5">Production build: `pushd src\client\pcf\VisualHost; npm run build:prod; popd` (build:prod NOT build per FAILURE-MODES.md#AP-1).</step>
+    <step order="6">Bundle-size sanity: record `Solution\Controls\sprk_Spaarke.Visuals.VisualHost\bundle.js` file size before vs after. Must NOT grow >20% (would indicate React 16 isn't being externalized via platform-library).</step>
+    <step order="7">Deploy to spaarkedev1 per [PCF deployment guide](../../../docs/guides/PCF-DEPLOYMENT-GUIDE.md): pack solution, import via PAC CLI, publish all customizations.</step>
+    <step order="8">Smoke-test full VisualHost feature surface in spaarkedev1: (a) chart definitions render correctly on test pages, (b) drill-through opens the drill workspace, (c) MetricCard matrix layout displays per `chartDefinition.matrix` config, (d) recent enhancements per b5b3118b1 (whatever feature surface that commit added) work as designed. Document each smoke-test outcome in `notes/visualhost-smoke-test.md`.</step>
+    <step order="9">If smoke tests pass: commit per procedure §4.4 commit block; push branch; open PR with title `fix(pcf): re-pin VisualHost to React 16 type pins (match platform-library runtime, ADR-022)`.</step>
+    <step order="10">Quality gates per CLAUDE.md §8 FULL rigor: invoke `code-review` skill + `adr-check` skill (ADR-022 is the load-bearing ADR for this PR).</step>
+    <step order="11">Update [`current-task.md`](../current-task.md) + [`tasks/TASK-INDEX.md`](TASK-INDEX.md) (Task 005 → ✅ on merge + deploy).</step>
+  </steps>
+
+  <tools>
+    <tool name="Grep">React-18-API defensive re-verification</tool>
+    <tool name="Edit">VisualHost package.json + ControlManifest.Input.xml</tool>
+    <tool name="Bash">npm clean install + build:prod; PAC CLI deploy commands; `gh pr create`</tool>
+    <tool name="Write">notes/visualhost-smoke-test.md</tool>
+    <tool name="Skill">pcf-deploy (Step 7 deployment); code-review + adr-check (Step 10 quality gates)</tool>
+  </tools>
+
+  <outputs>
+    <output type="pr">One merged PR re-pinning VisualHost to React 16 type pins</output>
+    <output type="state-change">spaarkedev1 VisualHost: v1.4.16 → v1.4.17 deployed</output>
+    <output type="docs">notes/visualhost-smoke-test.md</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">Defensive React-18-API grep on VisualHost source returns zero hits</criterion>
+    <criterion testable="true">`src/client/pcf/VisualHost/package.json` has `"react": "^16.14.0"` and `"@types/react": "^16.14.60"`</criterion>
+    <criterion testable="true">VisualHost manifest version = `1.4.17`</criterion>
+    <criterion testable="true">`npm run build:prod` succeeds; bundle.js size growth < 20%</criterion>
+    <criterion testable="true">VisualHost v1.4.17 deployed to spaarkedev1 (Dataverse MCP query confirms)</criterion>
+    <criterion testable="true">Smoke tests pass for: charts, drill-through, MetricCard, recent enhancements per b5b3118b1</criterion>
+    <criterion testable="true">code-review + adr-check skills invoked and pass</criterion>
+  </acceptance-criteria>
+
+  <execution>
+    Run via `task-execute` skill. FULL rigor (PCF re-pin + redeploy; Step 9.5 quality gates required; ADR-022 is binding).
+  </execution>
+</task>

--- a/projects/pcf-orphan-cleanup-r1/tasks/006-dataverse-cleanup-spaarkedev2.poml
+++ b/projects/pcf-orphan-cleanup-r1/tasks/006-dataverse-cleanup-spaarkedev2.poml
@@ -1,0 +1,103 @@
+<task id="006" project="pcf-orphan-cleanup-r1">
+  <metadata>
+    <title>Dataverse cleanup session — spaarkedev2 replay</title>
+    <phase>P6</phase>
+    <status>not-started</status>
+    <estimated-effort>3-5 hours</estimated-effort>
+    <dependencies>005</dependencies>
+    <blocks>007</blocks>
+    <tags>pcf, dataverse, cleanup, destructive, environment-replication</tags>
+    <rigor-hint>FULL</rigor-hint>
+    <rigor-reason>Destructive Dataverse mutations in a second environment. Lower risk than Task 003 (we've done it once) but still FULL rigor per CLAUDE.md §8.</rigor-reason>
+    <parallel-group>(sequential)</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Depends on Task 005 + spaarkedev1's 7-day soak completion (per NFR-03).</parallel-reason>
+    <production-fix-per-ledger>false</production-fix-per-ledger>
+  </metadata>
+
+  <prompt>
+    Replay Task 003 against spaarkedev2. Same procedure (§3 Part C), same controls, same gates — but in a different environment.
+
+    **Pre-requisites**:
+    - Task 003 completed in spaarkedev1
+    - 7 calendar days elapsed since Task 003 completion (per NFR-03)
+    - No regression reports filed during the soak window
+    - Task 005 (VisualHost re-pin) merged + deployed
+
+    The replay benefits from the spaarkedev1 cleanup log: per-control deletion order, FormXML grep results, and smoke-test outcomes are reference data. Re-run all gates fresh against spaarkedev2 — do NOT skip §1.2 4-check just because spaarkedev1 was clean.
+
+    Resurrection spot-test is NOT required for the replay (already validated in Task 003).
+  </prompt>
+
+  <role>Dataverse administrator performing cleanup replay in a second environment with full pre-flight rigor.</role>
+
+  <goal>
+    spaarkedev2 mirrors spaarkedev1's cleaned state:
+    - 11 customcontrols deleted
+    - 4-6 canvas apps deleted
+    - VisualHost v1.4.17 deployed (from Task 005)
+    - Per-control log entries appended to `notes/dataverse-cleanup-log.md` (separate section: `## spaarkedev2 cleanup — YYYY-MM-DD`)
+  </goal>
+
+  <inputs>
+    <file purpose="procedure-section">projects/ai-procedure-quality-r1/notes/inventory/orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md</file>
+    <file purpose="spec">projects/pcf-orphan-cleanup-r1/spec.md</file>
+    <file purpose="design">projects/pcf-orphan-cleanup-r1/design.md</file>
+    <file purpose="claude-md">projects/pcf-orphan-cleanup-r1/CLAUDE.md</file>
+    <file purpose="spaarkedev1-reference">projects/pcf-orphan-cleanup-r1/notes/dataverse-cleanup-log.md</file>
+  </inputs>
+
+  <constraints>
+    <constraint source="FR-06">spaarkedev2 replay after 7-day soak</constraint>
+    <constraint source="NFR-02">§1.2 4-check per control fresh against spaarkedev2 (do NOT assume spaarkedev1 results apply)</constraint>
+    <constraint source="NFR-03">7-day soak completed; no regression reports</constraint>
+    <constraint source="D-05">7-day soak between environments</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>projects/pcf-orphan-cleanup-r1/notes/research-findings-2026-06-22.md</file>
+      <file>projects/pcf-orphan-cleanup-r1/notes/dataverse-cleanup-log.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Verify pre-requisites: (a) Task 005 ✅; (b) Task 003 completion date + 7 calendar days ≤ today; (c) no regression reports for the soak window — confirm via project log or stakeholder check-in.</step>
+    <step order="2">Authenticate to spaarkedev2: `pac auth select --name spaarkedev2`.</step>
+    <step order="3">Capture spaarkedev2 baseline backups per procedure §1.1 (mirror of Task 001). Store in `backups-2026-06-22/spaarkedev2/`.</step>
+    <step order="4">Run §1.2 4-check fresh against spaarkedev2 for all 11 controls + 4-6 canvas apps. Spaarkedev2 may have references that spaarkedev1 didn't (different forms, different ribbon JS deployment cadence). Document in `notes/preflight-results-spaarkedev2.md`.</step>
+    <step order="5">Any deviations → file in `notes/preflight-deviations.md` (append spaarkedev2 section). STOP for that control if reference found.</step>
+    <step order="6">For each `ready-to-delete` control: execute the 9-step per-control sequence per procedure §3.2 against spaarkedev2.</step>
+    <step order="7">Append per-control log entries to `notes/dataverse-cleanup-log.md` under a new `## spaarkedev2 cleanup — YYYY-MM-DD` section.</step>
+    <step order="8">Smoke-test in spaarkedev2: same surface as spaarkedev1 (Matter/Documents, Event/calendar filter, AnalysisWorkspace Code Page) + ensure VisualHost v1.4.17 (deployed in Task 005) renders correctly with its newly-aligned React 16 type pins.</step>
+    <step order="9">Verify counts: spaarkedev2 customcontrol count matches spaarkedev1 post-Task 003 (13 deployed Spaarke PCFs).</step>
+    <step order="10">Run quality gates per CLAUDE.md §8 FULL rigor: invoke `code-review` skill (log accuracy) + `adr-check` skill.</step>
+    <step order="11">Update [`current-task.md`](../current-task.md) + [`tasks/TASK-INDEX.md`](TASK-INDEX.md) (Task 006 → ✅).</step>
+  </steps>
+
+  <tools>
+    <tool name="Bash">PAC CLI for spaarkedev2 auth + backup export</tool>
+    <tool name="mcp__dataverse__read_query">spaarkedev2 customcontrol + canvasapp queries</tool>
+    <tool name="Write">notes/preflight-results-spaarkedev2.md; append to notes/dataverse-cleanup-log.md</tool>
+    <tool name="Skill">code-review + adr-check</tool>
+  </tools>
+
+  <outputs>
+    <output type="state-change">spaarkedev2: orphan PCFs + canvas apps cleaned (mirrors spaarkedev1)</output>
+    <output type="docs">notes/preflight-results-spaarkedev2.md</output>
+    <output type="docs">notes/dataverse-cleanup-log.md (with spaarkedev2 section appended)</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">spaarkedev2 customcontrol query returns same 13-count post-cleanup as spaarkedev1</criterion>
+    <criterion testable="true">All 11 customcontrol per-name queries return empty in spaarkedev2</criterion>
+    <criterion testable="true">Canvas-app cleanup mirrors spaarkedev1 (pending verification on eventspage + playbookbuilder)</criterion>
+    <criterion testable="true">Smoke tests pass: Matter/Documents, Event/calendar, AnalysisWorkspace Code Page, VisualHost v1.4.17 chart rendering</criterion>
+    <criterion testable="true">spaarkedev2-section of dataverse-cleanup-log.md has 11+4-6 entries</criterion>
+    <criterion testable="true">code-review + adr-check skills invoked and pass</criterion>
+  </acceptance-criteria>
+
+  <execution>
+    Run via `task-execute` skill. FULL rigor.
+  </execution>
+</task>

--- a/projects/pcf-orphan-cleanup-r1/tasks/007-cleanup-log-finalize.poml
+++ b/projects/pcf-orphan-cleanup-r1/tasks/007-cleanup-log-finalize.poml
@@ -1,0 +1,108 @@
+<task id="007" project="pcf-orphan-cleanup-r1">
+  <metadata>
+    <title>Cleanup-log finalize + inventory refresh</title>
+    <phase>P7</phase>
+    <status>not-started</status>
+    <estimated-effort>1-2 hours</estimated-effort>
+    <dependencies>006</dependencies>
+    <blocks>none</blocks>
+    <tags>docs, inventory, audit-trail, project-closeout</tags>
+    <rigor-hint>STANDARD</rigor-hint>
+    <rigor-reason>Documentation finalization only. No code, no Dataverse mutations. STANDARD rigor per CLAUDE.md §8.</rigor-reason>
+    <parallel-group>(sequential)</parallel-group>
+    <parallel-safe>false</parallel-safe>
+    <parallel-reason>Final task — depends on Task 006 completion to capture cross-environment state in the log.</parallel-reason>
+    <production-fix-per-ledger>false</production-fix-per-ledger>
+  </metadata>
+
+  <prompt>
+    Final project closeout. Three documentation deliverables:
+
+    1. **Finalize `notes/dataverse-cleanup-log.md`** — add a summary section at top covering: total controls deleted (across both envs), spot-test outcomes, any deviations encountered + how resolved, links to backup ZIPs used.
+
+    2. **Refresh [`pcf-deployment-inventory-2026-06-22.md`](../../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md)** — add a "## Cleanup complete — YYYY-MM-DD" footnote section that:
+       - Lists which controls were retired (mirrors FR-02 + FR-03 results)
+       - Updates §2's source-tree-PCF count (14 → 11)
+       - Updates §3's deployed-but-no-source count (10 → 0 — they're all gone)
+       - Notes VisualHost v1.4.16 → v1.4.17 with React 16 type pin alignment
+       - Marks PlaybookBuilderHost as remaining open item
+
+    3. **Refresh [`pcf-bundle-sizes.md`](../../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md)** — remove the UQC, DTW, SDV entries from the baseline table; add a "Refreshed 2026-MM-DD" note. Bundle-size validator (`scripts/quality/Check-BundleSizeDrift.ps1`) should still pass against the trimmed baseline.
+
+    Verify all 12 success criteria from [`spec.md §3`](../spec.md#3-success-criteria) one by one — check the box if verified, document the verification method.
+  </prompt>
+
+  <role>Project closeout — documentation finalizer ensuring the audit trail is complete and the inventory artifacts reflect post-cleanup reality.</role>
+
+  <goal>
+    Three updated docs:
+    - `notes/dataverse-cleanup-log.md` — with summary section
+    - `../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md` — with "Cleanup complete" footnote
+    - `../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md` — with UQC/DTW/SDV removed from baseline
+
+    Plus: all 12 SCs in spec.md §3 verified + checked off.
+  </goal>
+
+  <inputs>
+    <file purpose="spec">projects/pcf-orphan-cleanup-r1/spec.md</file>
+    <file purpose="design">projects/pcf-orphan-cleanup-r1/design.md</file>
+    <file purpose="claude-md">projects/pcf-orphan-cleanup-r1/CLAUDE.md</file>
+    <file purpose="log-source">projects/pcf-orphan-cleanup-r1/notes/dataverse-cleanup-log.md</file>
+    <file purpose="inventory-target">projects/ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md</file>
+    <file purpose="bundle-target">projects/ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md</file>
+  </inputs>
+
+  <constraints>
+    <constraint source="FR-07">Cleanup-log per-control entries (covered in Tasks 003/006); finalize summary section here</constraint>
+    <constraint source="FR-08">Inventory + bundle-size refresh with completion footnotes</constraint>
+    <constraint source="SC-01..SC-12">All 12 success criteria must be verified before project marked complete</constraint>
+  </constraints>
+
+  <knowledge>
+    <files>
+      <file>projects/pcf-orphan-cleanup-r1/spec.md</file>
+      <file>projects/pcf-orphan-cleanup-r1/notes/dataverse-cleanup-log.md</file>
+    </files>
+  </knowledge>
+
+  <steps>
+    <step order="1">Read [`notes/dataverse-cleanup-log.md`](../notes/dataverse-cleanup-log.md) — review for completeness (one entry per control per environment).</step>
+    <step order="2">Append summary section to top of `dataverse-cleanup-log.md`: total counts (controls + canvas apps), environments touched, spot-test outcomes, any deviations encountered.</step>
+    <step order="3">Edit [`pcf-deployment-inventory-2026-06-22.md`](../../ai-procedure-quality-r1/notes/inventory/pcf-deployment-inventory-2026-06-22.md): add "## Cleanup complete — YYYY-MM-DD" footnote section per task description bullet 2.</step>
+    <step order="4">Edit [`pcf-bundle-sizes.md`](../../ai-procedure-quality-r1/notes/inventory/pcf-bundle-sizes.md): remove UQC, DTW, SDV from the "Committed Bundles" + "PCF Folders WITHOUT a Committed Bundle" tables. Add `Refreshed: YYYY-MM-DD` line under the baseline-date header.</step>
+    <step order="5">If `scripts/quality/Check-BundleSizeDrift.ps1` exists and references `pcf-bundle-baseline.json`: refresh that JSON to match the trimmed `pcf-bundle-sizes.md` table.</step>
+    <step order="6">Verify all 12 SCs in spec.md §3 — for each: confirm it's met, document the verification method, check the box. If any SC is NOT met, file in `notes/closeout-gaps.md`.</step>
+    <step order="7">Update [`current-task.md`](../current-task.md): Active Task = "None — project complete"; Next Action = "Project closeout review with owner."</step>
+    <step order="8">Update [`tasks/TASK-INDEX.md`](TASK-INDEX.md): Task 007 → ✅; all 7 tasks ✅.</step>
+    <step order="9">Update [`README.md`](../README.md) status line: "Phase 0 — Project Setup" → "COMPLETE — YYYY-MM-DD".</step>
+    <step order="10">Commit the doc updates with message: `docs(pcf-orphan-cleanup): finalize cleanup log + refresh inventory + close project`.</step>
+  </steps>
+
+  <tools>
+    <tool name="Read">existing log + inventory docs</tool>
+    <tool name="Edit">dataverse-cleanup-log.md, pcf-deployment-inventory-2026-06-22.md, pcf-bundle-sizes.md, current-task.md, TASK-INDEX.md, README.md</tool>
+    <tool name="Bash">`git commit` for doc updates</tool>
+  </tools>
+
+  <outputs>
+    <output type="docs">finalized notes/dataverse-cleanup-log.md (with summary)</output>
+    <output type="docs">refreshed pcf-deployment-inventory-2026-06-22.md (with cleanup-complete footnote)</output>
+    <output type="docs">refreshed pcf-bundle-sizes.md (UQC/DTW/SDV removed)</output>
+    <output type="docs">notes/closeout-gaps.md (only if SCs not met)</output>
+    <output type="state-change">Project marked complete</output>
+  </outputs>
+
+  <acceptance-criteria>
+    <criterion testable="true">dataverse-cleanup-log.md has summary section + per-control entries for both environments</criterion>
+    <criterion testable="true">pcf-deployment-inventory-2026-06-22.md has "Cleanup complete" footnote section</criterion>
+    <criterion testable="true">pcf-bundle-sizes.md no longer lists UQC, DTW, SDV in any table</criterion>
+    <criterion testable="true">If pcf-bundle-baseline.json exists: refreshed to match trimmed pcf-bundle-sizes.md</criterion>
+    <criterion testable="true">All 12 SCs in spec.md §3 verified + boxes checked</criterion>
+    <criterion testable="true">README.md status reflects project completion</criterion>
+    <criterion testable="true">TASK-INDEX.md shows 7/7 tasks ✅</criterion>
+  </acceptance-criteria>
+
+  <execution>
+    Run via `task-execute` skill. STANDARD rigor (documentation only).
+  </execution>
+</task>

--- a/projects/pcf-orphan-cleanup-r1/tasks/TASK-INDEX.md
+++ b/projects/pcf-orphan-cleanup-r1/tasks/TASK-INDEX.md
@@ -1,0 +1,49 @@
+# Task Index — pcf-orphan-cleanup-r1
+
+> Generated: 2026-06-22 (project setup)
+> Status legend: 🔲 not-started | 🔄 in-progress | ✅ complete | ⏸ blocked
+
+---
+
+## Task tracker
+
+| # | Title | Status | Effort | Dependencies | Parallel group | Rigor | Notes |
+|---:|---|:---:|:---:|---|:---:|:---:|---|
+| 001 | Pre-flight: solution backups + per-control 4-check (spaarkedev1) | 🔲 | 2-4h | — | P1-W1 | STANDARD | Captures §1.1 backups + §1.2 verification |
+| 002 | Source-tree deletion PR (UQC + DTW + SDV) | 🔲 | 1-2h | — | P1-W1 | STANDARD | One PR, three folders, `git rm -r` each |
+| 003 | Dataverse cleanup session — spaarkedev1 (11 customcontrols + 4-6 canvas apps) | 🔲 | 4-6h | 001, 002 | (sequential) | **FULL** | Single focused block; logged per FR-07 |
+| **(soak)** | **7-day calendar wait — monitor for regressions** | — | 7 days | 003 | (sequential) | — | NO work; calendar gate only |
+| 004 | Shared lib `@types/react` peerDep declaration (PR-D1) | 🔲 | 2-4h | 003+soak | (sequential) | **FULL** | Includes React 18+ API audit pre-merge |
+| 005 | VisualHost re-pin to React 16 (PR-D2) — deploy + smoke | 🔲 | 3-5h | 004 | (sequential) | **FULL** | Re-verify VisualHost source pre-merge; bump v1.4.16 → v1.4.17 |
+| 006 | Dataverse cleanup session — spaarkedev2 replay | 🔲 | 3-5h | 005 | (sequential) | **FULL** | Same shape as 003, lower risk after spaarkedev1 success |
+| 007 | Cleanup-log finalize + inventory refresh | 🔲 | 1-2h | 006 | (sequential) | STANDARD | Updates `pcf-deployment-inventory-2026-06-22.md` + `pcf-bundle-sizes.md` |
+
+## Parallel execution groups
+
+### P1-W1 (early wave) — Tasks 001 + 002 in parallel
+
+**When**: project kickoff
+**Why parallel-safe**: disjoint write paths. Task 001 writes `backups-2026-06-22/`. Task 002 writes `src/client/pcf/{UQC,DTW,SDV}/` (deletions). No shared files.
+**Dispatch**: ONE message with TWO `Skill(task-execute)` invocations.
+
+### Sequential after P1-W1
+
+Tasks 003 → soak → 004 → 005 → 006 → 007. Each has a real dependency on the previous one — see [plan.md §"Task dependency graph"](../plan.md#task-dependency-graph) for the visual.
+
+## Acceptance gate
+
+This project is complete when:
+
+- [ ] All 7 tasks marked ✅
+- [ ] All 12 success criteria in [`spec.md §3`](../spec.md#3-success-criteria) verified
+- [ ] Cleanup log at [`notes/dataverse-cleanup-log.md`](../notes/dataverse-cleanup-log.md) contains entries for both environments
+- [ ] Backup ZIPs filed in [`backups-2026-06-22/`](../backups-2026-06-22/)
+- [ ] Inventory + bundle-size docs refreshed with completion footnotes (Task 007)
+
+## Decisions made during execution
+
+Track newly-discovered decisions here (additive to [`spec.md §5`](../spec.md#5-decisions-made-binding-for-this-project)):
+
+| Date | Task | Decision | Rationale |
+|---|---|---|---|
+| (none yet) | — | — | — |


### PR DESCRIPTION
## Summary

- Establishes `pcf-orphan-cleanup-r1` as a formal project to retire **3 orphan PCFs** from source (UQC, DrillThroughWorkspace, SpeDocumentViewer), **11 customcontrol records** from Dataverse, and **4-6 hosting canvas apps** — plus close **bucket D** of the chat-routing-redesign-r1 TypeScript drift report (VisualHost re-pin to React 16 + shared lib \`@types/react\` peerDep declaration).
- **NO production code changes in this PR.** This ships the project scaffolding + research artifacts only; source-tree deletions and Dataverse cleanup follow in subsequent PRs against the same project plan.

## What's included

\`projects/ai-procedure-quality-r1/notes/inventory/\` (research artifacts):
- **\`pcf-deployment-inventory-2026-06-22.md\`** — deployment-side inventory (Glob enumeration + live Dataverse MCP query against spaarkedev1). Identifies UQC as orphan via sprk_subgrid_commands.js v4.0.0 ribbon-migration evidence; identifies 10 deployed-without-source PCFs.
- **\`orphan-pcf-cleanup-and-react-types-procedure-2026-06-22.md\`** — canonical step-by-step operational procedure (§1 pre-flight, §2 source delete, §3 Dataverse cleanup, §3.5 resurrection playbook, §4 React-types fix, §5 sequencing, §6 risk register).

\`projects/pcf-orphan-cleanup-r1/\` (the project):
- **\`README.md\`**, **\`spec.md\`** (8 FRs / 7 NFRs / 12 SCs / 6 binding decisions), **\`design.md\`** (decision rationale), **\`CLAUDE.md\`** (project-scoped AI context), **\`current-task.md\`** (active pointer), **\`plan.md\`** (14-day phased delivery).
- **\`notes/research-findings-2026-06-22.md\`** — 12-section chronicle of how the scope was established. Future-you reads this to understand WHY.
- **\`tasks/TASK-INDEX.md\` + 7 POML tasks** — preflight backups, source delete, DV cleanup spaarkedev1, shared lib peerDep, VisualHost re-pin, DV cleanup spaarkedev2, cleanup-log finalize.

## Scope clarification — three PCFs deleted from source, eleven retired from Dataverse

| Action | Count |
|---|---:|
| Source folders deleted (Part B / subsequent PR) | **3** |
| Dataverse \`customcontrol\` records deleted (per env) | **11** |
| Canvas apps deleted (per env) | **4-6** |
| Out of scope explicitly | **1** (PlaybookBuilderHost — separate triage) |

The 8 already-source-less PCFs (AnalysisBuilder, AnalysisWorkspace PCF, DueDatesWidget, EventAutoAssociate, EventCalendarFilter, EventFormController, FieldMappingAdmin, RegardingLink, LegalWorkspace PCF) are zombie deployments that have been published in Dataverse for months without any source backing.

## Why a project, not just a procedure doc

Production blast radius (Dataverse customcontrol deletions are GUID-changing on re-import). Multi-week timeline (7-day soak between environments). Multiple workstreams must sequence correctly (source delete -> DV cleanup -> React-types fix -> environment replay). Audit trail (per-control cleanup log is a first-class deliverable).

## Test plan

This PR ships docs/scaffolding only — no code paths to test. Acceptance:

- [ ] Repository builds unchanged (no \`src/\` modifications in this PR)
- [ ] Reviewer can navigate project structure and follow the operational procedure
- [ ] Inventory + procedure docs are accurate vs current source-tree + Dataverse state
- [ ] Subsequent PRs reference this project for traceability

Follow-up PRs (will be opened against this project):
- \`chore(pcf): retire 3 orphan PCFs (UQC + DrillThroughWorkspace + SpeDocumentViewer)\` — Task 002 source delete
- (after Dataverse cleanup session) \`fix(ui-components): declare @types/react as peerDep (multi-major)\` — Task 004
- \`fix(pcf): re-pin VisualHost to React 16 type pins (match platform-library runtime, ADR-022)\` — Task 005

🤖 Generated with [Claude Code](https://claude.com/claude-code)