### PR TITLE
feat(daily-briefing-producer): Phase A fetchXml channel fixes + reusable patch script

### DIFF
--- a/projects/spaarke-daily-update-service-r2/current-task.md
+++ b/projects/spaarke-daily-update-service-r2/current-task.md
@@ -1,6 +1,6 @@
 # Current Task State
 
-> **Last Updated**: 2026-06-20 (R2.2 hotfix starting)
+> **Last Updated**: 2026-06-22 (Phase A Channels 1–5 patched LIVE; Ch.6 + Ch.7 deferred; moving to Phase B)
 > **Recovery**: Read "Quick Recovery" section first
 > **Protocol**: [Context Recovery](../../docs/procedures/context-recovery.md)
 
@@ -10,101 +10,107 @@
 
 | Field | Value |
 |-------|-------|
-| **Task** | R2.2 hotfix — Daily Briefing UX improvements bundle (3 items) |
-| **Step** | Starting (no commits yet on R2.2 branch) |
-| **Status** | not-started |
-| **Next Action** | Item 1: TL;DR prompt change in [`DailyBriefingEndpoints.cs`](../../src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs#L398-L460) — convert 5-7 sentences format to 2-3 sentences + key takeaways bullets |
-| **Branch** | `work/spaarke-daily-update-service-r2.2` (forked from `origin/master` @ `3d5c58e4b`) |
-| **PR** | Not yet created — draft PR after first commit (per push-to-github convention) |
-| **Predecessors** | R2 (PR #397, merged) + R2.1 hotfix (PR #400, merged) — both shipped + redeployed to spaarkedev1 |
-| **Successor** | R3 `spaarke-platform-foundations-r3` (PR #404 design.md merged; tasks generation in progress in separate worktree) |
+| **Task** | R2.2 SHIPPED + DEPLOYED. Producer-fix Phase A: Channels 1–5 fetchXml patches LIVE on spaarkedev1. Channels 6+7 deferred (design captured for Ch.7). Moving to Phase B (isread/toasttype + TTL). |
+| **Step** | Phase A complete; Phase B not yet started |
+| **Status** | Phase A done; ready for commit + Phase B kickoff |
+| **Next Action** | (1) Commit new Patch-PlaybookQueryFetchXml.ps1 script + Ch.7 design notes + this checkpoint. (2) Admin-merge PR #413 (known StorageRetryPolicyTests flake). (3) Design Phase B fix for isread/toasttype mismatch + TTL increase. |
+| **Branch** | `work/spaarke-daily-update-service-r2.2-patch-fix` (head: `1282c1335`, +1 uncommitted: new patch script + Ch.7 notes + this update) |
+| **Open PRs** | **PR #413**: scripts/Patch-NotificationPlaybookDueDate.ps1 field-name fix — awaiting admin-merge (Release CI flake on StorageRetryPolicyTests) |
 
-### Scope (3 items)
+### Files Modified This Session (after context-handoff resume)
 
-| # | Item | Effort | Files |
-|---|---|---|---|
-| 1 | TL;DR as 2-3 sentences + key takeaways bullets (was 5-7 sentences) | ~1h | `src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs` (prompt change L398-460) |
-| 2 | Due date rendered per item in `NarrativeBullet` | ~1h | `src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx` |
-| 3 | `AddToTodo` sets sensible default due date + shows confirmation toast | ~2h | `src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useInlineTodoCreate.ts` + UI toast wiring |
+- `scripts/Patch-PlaybookQueryFetchXml.ps1` (NEW) — reusable producer-fix script: patches sprk_configjson.fetchXml + description + optional entityLogicalName + optional ClearParameters. Used to apply Ch.1–5 patches.
+- `projects/spaarke-daily-update-service-r2/notes/channel-7-work-assignments-design.md` (NEW) — captured design for deferred Channel 7 (sprk_workassignment + Option C + createdon OR sprk_responseduedate semantics)
+- `projects/spaarke-daily-update-service-r2/current-task.md` (THIS FILE) — Phase A wrap-up + Phase B kickoff
 
-### Out of scope for R2.2 (deferred to R3)
+### Live Dataverse mutations (after resume) — all on spaarkedev1
 
-- ❌ FetchXML OR interim unblock for `notification-new-documents` / `notification-new-emails` playbooks — **decided 2026-06-20 to wait for R3's `MembershipResolverService`** rather than do throwaway work
-- ❌ `??` Handlebars helper fix (R3 Part 3 H1 — `Spaarke.Scheduling` + platform-level)
-- ❌ Unrendered `{{` runtime warning (R3 Part 3 H1)
+| Node | Channel | What changed |
+|---|---|---|
+| `1cbd78b2-5f2d-…` Query Overdue Tasks | 1 | fetchXml: sprk_todoflag→sprk_eventtype_ref=Task + statuscode=Open + (sprk_duedate OR sprk_finalduedate < today); sort: finalduedate then duedate |
+| `79f77aa5-5f2d-…` Query Tasks Due Soon | 2 | fetchXml: same shape as Ch.1 but BETWEEN today AND {{dueSoonWindowUtc}} (default 7d) |
+| `2b50e587-5f2d-…` Query New Documents | 3 | fetchXml: removed sprk_matterteammember; replaced with outer join on sprk_matter + OR (m.ownerid=me, doc.ownerid=me) |
+| `2d2fdd9e-5f2d-…` Query New Events | 4 | fetchXml: appointment→sprk_event with type IN {Action,Deadline,Meeting,Milestone,Reminder} + sprk_RegardingMatter outer join + Option C OR; entityLogicalName: appointment→sprk_event; cleared stale parameters |
+| `d9468c8e-5f2d-…` Query New Emails | 5 | fetchXml: email→sprk_communication with type=Email (100000000) + sprk_RegardingMatter outer join + Option C OR; entityLogicalName: email→sprk_communication; cleared stale parameters |
 
-### Files Modified This Session
+### Critical Context (must read before continuing)
 
-(none yet — starting fresh on R2.2)
+**1. Phase A done. Producer is now functional.** All 5 active Daily Briefing channels query the right entities with the right filters. Channels 6 + 7 explicitly deferred — Ch.7 design captured for future implementation.
 
-### Critical Context
+**2. Architectural patterns established (apply to any future producer fixes):**
+   - **"My" filter (interim)**: `ownerid eq-userid` (BFF rewrites at runtime per `QueryDataverseNodeExecutor.cs:187-195`). Phase C will design richer "My" resolver (team membership, regarding, etc.).
+   - **Option C (matter-owner OR record-owner)**: when source entity has `sprk_RegardingMatter` lookup (sprk_event, sprk_communication) OR direct matter lookup (sprk_document), use outer-link + `entityname="m"` cross-entity OR pattern.
+   - **Date-range OR**: when a record has multiple date fields (sprk_duedate, sprk_finalduedate, sprk_responseduedate), OR the range conditions together inside the AND filter.
+   - **Two-level sort**: primary by stricter/canonical date, tiebreaker by secondary date.
+   - **entityLogicalName must match `<entity name=>`**: BFF builds entitySet URL from `sprk_configjson.entityLogicalName`. Patching fetchXml without entityLogicalName fix = URL/entity mismatch error.
+   - **Stale parameters block** (`{{timeWindow}}`, `templateParameters.dueWithinDays`, etc.) — BFF only supports `parameters.dueSoonDays` and `parameters.timeWindowHours`. Remove anything else.
 
-R2.2 is a small UX-only hotfix bundle for the Daily Briefing widget + standalone code page. It ships independently of R3 (the large platform-foundations project) and supersedes nothing — the 3 items are real UX gaps surfaced during R2 round-2 UAT (2026-06-19) that don't require platform-level work to fix.
+**3. Test data verification (still pending on user):**
+   - Set sprk_event records' owner to Ralph Schroeder for Ch.1/2/4 testing.
+   - For Ch.5 — emails owned by service principal won't surface unless owner is fixed OR we add `sprk_to` UPN match in Phase C.
+   - For Ch.3 — Ralph already owns most matters + docs, so existing data works.
+   - Verification: wait for next playbook tick (≤1h) OR invoke manually; check appnotification records by category.
 
-All 3 items affect both the SpaarkeAi-embedded widget AND the standalone Daily Briefing code page (`sprk_dailyupdate`) since R2 + R2.1 unified them via Pattern D (`@spaarke/daily-briefing-components`). A single set of changes deploys to both surfaces.
+**4. Architectural bugs still pending (Phase B):**
+   - **isread / toasttype mismatch** in `notificationService.ts:120` — reads `toasttype === 200000000` (which schema says is "Timed", not "Dismissed"). Line 299 writes `webApi.updateRecord('appnotification', id, {isread: true})` — `isread` may not even exist on appnotification schema. Need to verify field names and align read/write paths.
+   - **TTL = 3 days** (`CreateNotificationNodeExecutor.cs:489`, `ttlinseconds = 259200`) may be too short — accidental TTL purge on 2026-06-22 wiped 36 records the user expected. Proposed: 7 or 14 days.
 
-### Deployment notes
+**5. Phase C (out of scope here, tracked):**
+   - R3 (`spaarke-platform-foundations-r3`) provides scheduler robustness + run-now admin endpoints
+   - "My" resolver design (richer than ownerid)
+   - Sync mechanism between repo JSON and deployed playbook configs (repo drift caused the original misdiagnosis)
 
-R2.2 changes affect:
-- **BFF** (item 1): redeploy via `bff-deploy` skill or auto-promotion
-- **Both code pages** (items 2 + 3): rebuild + redeploy `sprk_dailyupdate` (Daily Briefing) + `sprk_spaarkeai` (SpaarkeAi workspace) since both consume `@spaarke/daily-briefing-components`
+### Recovery steps for next session
 
----
-
-## Active Task (Full Details)
-
-| Field | Value |
-|-------|-------|
-| **Task ID** | R2.2 hotfix bundle (no POML — emerged from R2 round-2 UAT findings 2026-06-19) |
-| **Title** | Daily Briefing UX bundle: TL;DR bullet format + per-item due dates + AddToTodo improvements |
-| **Phase** | Post-R2.1 (PR #400 already merged) |
-| **Status** | not-started |
-| **Started** | 2026-06-20 |
-| **Branch** | `work/spaarke-daily-update-service-r2.2` (forked from `origin/master` @ `3d5c58e4b`) |
-| **Rigor Level** | STANDARD — small UX changes, no architectural impact; quality gates skipped per CLAUDE.md §8 |
-
-### Steps
-
-**Item 1 — TL;DR format**
-1. Read current prompt at `DailyBriefingEndpoints.cs:398-460`
-2. Modify prompt to ask for: 2-3 sentence executive summary + key takeaways bullets
-3. Update response parsing (if needed)
-4. Add/update unit test in `Sprk.Bff.Api.Tests`
-5. Commit
-
-**Item 2 — Due dates in NarrativeBullet**
-1. Read `NarrativeBullet.tsx`
-2. Add due-date rendering (data is already in `appnotification.data` payload — `dueDate` field per item)
-3. Style consistent with Fluent v9 + existing card design
-4. Add snapshot test
-5. Commit
-
-**Item 3 — AddToTodo improvements**
-1. Read `useInlineTodoCreate.ts:159-279`
-2. Add default due-date setting (proposed: 3 days from now, or use the bullet's own dueDate if available)
-3. Add Fluent v9 toast on success (via `useToastController`)
-4. Add toast on failure (already has error tooltip, but toast is more discoverable)
-5. Update existing test in `ActivityNotesSection.subList.test.tsx` or add new
-6. Commit
-
-### Step Progress
-- ⏳ Item 1 — not started
-- ⏳ Item 2 — not started
-- ⏳ Item 3 — not started
-
-### Decisions
-
-- **2026-06-20**: Skip FetchXML interim unblock (item 4 from original scope). Reason: R3's `MembershipResolverService` supersedes it; ~3-4h of throwaway work for ≤3 weeks of broken "My Documents" channel doesn't pencil out.
-- **2026-06-20**: Branch named `work/spaarke-daily-update-service-r2.2` (versioned, distinguishes from merged R2.1 hotfix branch).
-
-### Handoff Notes
-
-If session ends mid-flight, the next session can resume by:
-1. Reading this current-task.md Quick Recovery section
-2. Running `git status` to see what's modified
-3. Checking the most recent commit message to know which Item was last touched
-4. Resuming the next un-checked step in the Steps section above
+1. Read this entire Quick Recovery section
+2. Check branch: `git branch --show-current` should show `work/spaarke-daily-update-service-r2.2-patch-fix`
+3. Verify PR #413: `gh pr view 413 --json state,mergedAt` (may have been admin-merged)
+4. Spot-check live state of Ch.1–5 nodes: `mcp__dataverse__read_query SELECT sprk_playbooknodeid, sprk_name, sprk_configjson FROM sprk_playbooknode WHERE sprk_playbooknodeid IN (...)`
+5. Next concrete action: Phase B design (see notes/phase-b-design.md if created)
 
 ---
 
-*Updated 2026-06-20 — R2.2 starting.*
+## Full State (Detailed)
+
+### R2.2 final state (unchanged from prior checkpoint)
+
+| Artifact | State |
+|---|---|
+| PR #405 (R2.2 main) | ✅ MERGED (`ec05765ed`) |
+| PR #410 (R2.2 hotfix) | ✅ MERGED (`e584d296c`) |
+| PR #413 (patch script fix) | 🟡 OPEN — pending admin-merge |
+| BFF deploy | ✅ LIVE (46.07 MB, /healthz green) |
+| `sprk_dailyupdate` code page | ✅ LIVE |
+| `sprk_spaarkeai` code page | ✅ LIVE |
+
+### Phase A live channel state (post-resume)
+
+All 5 channel nodes patched LIVE. Next playbook tick exercises them.
+
+### Decisions Made (this session, after resume)
+
+- **2026-06-22**: Channel-by-channel patches via reusable `Patch-PlaybookQueryFetchXml.ps1` script (extension of the field-fix-only `Patch-NotificationPlaybookDueDate.ps1`). Operates one node at a time so each channel is reviewed + applied independently.
+- **2026-06-22**: For each channel, "My" filter stays as `ownerid eq-userid` (interim) — Phase C will design richer resolver. User confirmed.
+- **2026-06-22**: For sprk_event and sprk_communication, use per-type regarding lookup (`sprk_RegardingMatter`) with outer-link + cross-entity OR pattern (Option C). User clarified that Spaarke has per-entity-type regarding lookups + a unified resolver, NOT a polymorphic regardingobjectid.
+- **2026-06-22**: For sprk_document (Ch.3) — direct sprk_matter lookup is the model (no per-type regarding fields). Option C still applies via outer link + OR.
+- **2026-06-22**: Channel 4 fetchXml type filter set to {Action, Deadline, Meeting, Milestone, Reminder} — user opted for broader event coverage than just Meeting.
+- **2026-06-22**: Channel 5 ownership filter known to miss inbound emails owned by service principal. Documented as interim limitation; Phase C resolves via `sprk_to` UPN match or post-receive ownership-assignment flow.
+- **2026-06-22**: Channels 6+7 deferred. Channel 7 design captured in `notes/channel-7-work-assignments-design.md` for future implementation (requires creating a new sprk_playbooknode record, not just patching).
+
+### MCP visibility limitation (unchanged)
+
+MCP service principal sees only 4 of (presumably 36+) appnotification records. Don't trust MCP appnotification counts as definitive — verify with user-side queries.
+
+### Repo paths
+
+- This file: `projects/spaarke-daily-update-service-r2/current-task.md`
+- Ch.7 design notes: `projects/spaarke-daily-update-service-r2/notes/channel-7-work-assignments-design.md`
+- Producer patch script (NEW): `scripts/Patch-PlaybookQueryFetchXml.ps1`
+- Original due-date patch script: `scripts/Patch-NotificationPlaybookDueDate.ps1` (PR #413)
+- BFF query executor: `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/QueryDataverseNodeExecutor.cs`
+- BFF notification creator: `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs`
+- Client notification service: `src/client/shared/Spaarke.DailyBriefing.Components/src/services/notificationService.ts` (Phase B target)
+
+---
+
+*Updated 2026-06-22 — Phase A complete; ready for commit + Phase B.*

--- a/projects/spaarke-daily-update-service-r2/notes/channel-7-work-assignments-design.md
+++ b/projects/spaarke-daily-update-service-r2/notes/channel-7-work-assignments-design.md
@@ -1,0 +1,77 @@
+# Channel 7 — Work Assignments — Design Notes (DEFERRED)
+
+> **Status**: DEFERRED on 2026-06-22 per user decision after Channels 1–5 producer-fix.
+> **Why**: The deployed "New Work Assignments" playbook has only a "Notify" node (`c10a54bf-…`) with templates referencing undefined `{{task.*}}` variables. No Query node exists. Adding one requires CREATING a `sprk_playbooknode` record (not patching), which is heavier than the channel-patches we've validated; needs inspection of a working playbook's node-graph shape first.
+
+---
+
+## Semantic intent (captured from user)
+
+When Channel 7 IS implemented, the Query node should surface NEW work assignments to a user with the following filter:
+
+- **"Me" filter** (Option C — user's choice): `sprk_assignedto eq-userid` OR `ownerid eq-userid` (cross-entity OR via `entityname=` if needed)
+- **"New" filter** — date must be in window via EITHER field:
+  - `createdon` last-x-hours
+  - `sprk_responseduedate` in window
+  - (Use `<filter type="or">` between the two, mirroring Ch.1/Ch.2 OR-date pattern)
+- **Exclude self-created**: `createdby ne-userid`
+- **Display attributes**: `sprk_name`, `sprk_assignedto`, `sprk_regardingmatter`, plus joined matter name/number
+
+## Confirmed `sprk_workassignment` schema (verified 2026-06-22)
+
+| Field | Status |
+|---|---|
+| `sprk_workassignmentid` | exists |
+| `sprk_name` | exists |
+| `sprk_assignedto` | exists (lookup) |
+| `sprk_regardingmatter` | exists (lookup) |
+| `ownerid` | exists |
+| `createdby` | exists |
+| `createdon` | exists |
+| `sprk_duedate` | DOES NOT EXIST |
+| `sprk_status` | DOES NOT EXIST |
+| `sprk_priority` | DOES NOT EXIST |
+| `sprk_assignedby` | DOES NOT EXIST |
+| `sprk_responseduedate` | TODO: verify exists |
+
+## Draft fetchXml (NOT YET DEPLOYED)
+
+```xml
+<fetch top="50">
+  <entity name="sprk_workassignment">
+    <attribute name="sprk_name"/>
+    <attribute name="createdon"/>
+    <attribute name="sprk_responseduedate"/>
+    <attribute name="sprk_workassignmentid"/>
+    <attribute name="sprk_assignedto"/>
+    <attribute name="sprk_regardingmatter"/>
+    <attribute name="ownerid"/>
+    <link-entity name="sprk_matter" from="sprk_matterid" to="sprk_regardingmatter" link-type="outer" alias="m">
+      <attribute name="sprk_mattername"/>
+      <attribute name="sprk_matternumber"/>
+    </link-entity>
+    <filter type="and">
+      <condition attribute="createdby" operator="ne-userid"/>
+      <filter type="or">
+        <condition attribute="createdon" operator="last-x-hours" value="{{timeWindowHours}}"/>
+        <filter type="and">
+          <condition attribute="sprk_responseduedate" operator="ge" value="{{todayUtc}}"/>
+          <condition attribute="sprk_responseduedate" operator="le" value="{{dueSoonWindowUtc}}"/>
+        </filter>
+      </filter>
+      <filter type="or">
+        <condition attribute="sprk_assignedto" operator="eq-userid"/>
+        <condition attribute="ownerid" operator="eq-userid"/>
+      </filter>
+    </filter>
+    <order attribute="createdon" descending="true"/>
+  </entity>
+</fetch>
+```
+
+## Also needed when Ch.7 is implemented
+
+1. **Verify `sprk_responseduedate` exists** on `sprk_workassignment` before deploying.
+2. **Fix the existing Notify node** (`c10a54bf-…`) — currently references undefined `{{task.subject}}` / `{{task.matterName}}` / `{{task.dueDate}}` / `{{task.id}}`. Should reference iteration-variable bindings like `{{item.sprk_name}}` / `{{item.m.sprk_mattername}}` / `{{item.sprk_responseduedate}}` / `{{item.sprk_workassignmentid}}` once the Query node feeds it.
+3. **Confirm playbook node graph shape** by inspecting a working playbook (e.g., Tasks Overdue) — sprk_playbooknode records linked via sprk_playbookid, sequence ordering, and how the Query node's output feeds the Notify node.
+4. **Create the new Query node** via either: (a) script that creates a sprk_playbooknode record with the right shape, or (b) Maker Designer UI.

--- a/scripts/Patch-NotificationPlaybookDueDate.ps1
+++ b/scripts/Patch-NotificationPlaybookDueDate.ps1
@@ -46,7 +46,12 @@ $Targets = @(
     @{ PlaybookName = 'Tasks Due Soon'; NodeName = 'Create Notification' }
 )
 
-$DueDateTemplate = '{{item.scheduledend}}'  # rendered by CreateNotificationNodeExecutor per R2.2
+# CORRECTED 2026-06-22: was '{{item.scheduledend}}' (OOB task field).
+# The DEPLOYED playbooks query `sprk_event`, which uses `sprk_duedate` for the
+# due date. The earlier patch was based on stale repo JSON that referenced the
+# OOB task entity. Using sprk_duedate makes the template render the actual
+# due-date value into customData.dueDate on each created appnotification.
+$DueDateTemplate = '{{item.sprk_duedate}}'
 
 $ApiBase = "$DataverseUrl/api/data/v9.2"
 

--- a/scripts/Patch-PlaybookQueryFetchXml.ps1
+++ b/scripts/Patch-PlaybookQueryFetchXml.ps1
@@ -1,0 +1,188 @@
+<#
+.SYNOPSIS
+    Producer-fix patch: replaces the fetchXml inside the sprk_configjson
+    of a "Query *" playbook node. Operates one node at a time so each
+    channel can be reviewed + applied independently.
+
+.DESCRIPTION
+    The R1 Daily Briefing producer-layer playbooks were authored against
+    a stale schema (sprk_todoflag, sprk_todostatus). Those fields do not
+    exist on sprk_event in spaarkedev1 today, so the query nodes have
+    been erroring silently for ~80 days, producing zero notifications.
+
+    This script does a targeted PATCH of the fetchXml + description on
+    ONE playbook query node. It does NOT touch the rest of the playbook.
+    No new records. No schema changes.
+
+    Built for Phase A of the producer-fix work (one channel per run).
+
+.PARAMETER DataverseUrl
+    Target Dataverse environment URL.
+
+.PARAMETER NodeName
+    The sprk_name of the playbook node to patch (e.g., 'Query Overdue Tasks').
+
+.PARAMETER PlaybookName
+    The sprk_name of the parent playbook (e.g., 'Tasks Overdue').
+    Used as a safety check so we only update the node attached to the
+    expected playbook.
+
+.PARAMETER FetchXml
+    The new fetchXml string to put inside sprk_configjson.fetchXml.
+
+.PARAMETER Description
+    Optional. New description string to put inside sprk_configjson.description.
+
+.PARAMETER EntityLogicalName
+    Optional. New entityLogicalName to put inside sprk_configjson.entityLogicalName.
+    REQUIRED when the new fetchXml queries a different entity than the old one
+    (e.g., appointment -> sprk_event). The BFF QueryDataverseNodeExecutor uses
+    entityLogicalName to build the entitySetName for the OData URL path; if it
+    doesn't match the fetchXml's <entity name="..."/>, the request fails.
+
+.PARAMETER ClearParameters
+    Optional switch. If set, removes the sprk_configjson.parameters block.
+    Use when the old configjson had stale parameters (e.g., {{timeWindow}} that
+    the BFF no longer supports).
+
+.PARAMETER DryRun
+    Preview the patch (print before/after) without writing.
+
+.EXAMPLE
+    .\Patch-PlaybookQueryFetchXml.ps1 `
+        -DataverseUrl "https://spaarkedev1.crm.dynamics.com" `
+        -PlaybookName 'Tasks Overdue' `
+        -NodeName 'Query Overdue Tasks' `
+        -FetchXml (Get-Content .\overdue-tasks-fetchxml.xml -Raw) `
+        -Description 'Open Task-type sprk_events with due date OR final due date in the past, scoped to current user.' `
+        -DryRun
+#>
+[CmdletBinding()]
+param(
+    [string]$DataverseUrl = $env:DATAVERSE_URL,
+    [Parameter(Mandatory)] [string]$PlaybookName,
+    [Parameter(Mandatory)] [string]$NodeName,
+    [Parameter(Mandatory)] [string]$FetchXml,
+    [string]$Description,
+    [string]$EntityLogicalName,
+    [switch]$ClearParameters,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $DataverseUrl) {
+    Write-Error "DataverseUrl is required. Set DATAVERSE_URL env var or pass -DataverseUrl parameter."
+    exit 1
+}
+
+$ApiBase = "$DataverseUrl/api/data/v9.2"
+
+Write-Host '======================================================'
+Write-Host 'Producer-fix: replace fetchXml on a playbook query node'
+Write-Host '======================================================'
+Write-Host "Environment : $DataverseUrl"
+Write-Host "Playbook    : $PlaybookName"
+Write-Host "Node        : $NodeName"
+Write-Host "Mode        : $(if ($DryRun) { 'DRY RUN' } else { 'LIVE' })"
+Write-Host ''
+
+# 1) Acquire access token
+Write-Host '[1/5] Acquiring access token via Azure CLI...'
+$token = az account get-access-token --resource $DataverseUrl --query accessToken -o tsv
+if ([string]::IsNullOrWhiteSpace($token)) {
+    Write-Error 'Failed to acquire Dataverse access token.'
+    exit 1
+}
+$headers = @{
+    'Authorization'    = "Bearer $token"
+    'Content-Type'     = 'application/json'
+    'OData-MaxVersion' = '4.0'
+    'OData-Version'    = '4.0'
+    'Accept'           = 'application/json'
+}
+Write-Host '       Token acquired.'
+
+# 2) Resolve playbook id
+Write-Host ''
+Write-Host '[2/5] Resolving playbook id...'
+$playbookFilter = "`$filter=sprk_name eq '$($PlaybookName -replace "'", "''")'&`$select=sprk_analysisplaybookid"
+$playbookUrl = "$ApiBase/sprk_analysisplaybooks?$playbookFilter"
+$playbookResp = Invoke-RestMethod -Uri $playbookUrl -Headers $headers -Method Get
+if ($playbookResp.value.Count -eq 0) {
+    Write-Error "Playbook '$PlaybookName' not found."
+    exit 1
+}
+$playbookId = $playbookResp.value[0].sprk_analysisplaybookid
+Write-Host "       Playbook id: $playbookId"
+
+# 3) Resolve node id + read configjson
+Write-Host ''
+Write-Host '[3/5] Resolving node + reading current configjson...'
+$nodeFilter = "`$filter=_sprk_playbookid_value eq '$playbookId' and sprk_name eq '$($NodeName -replace "'", "''")'&`$select=sprk_playbooknodeid,sprk_configjson"
+$nodeUrl = "$ApiBase/sprk_playbooknodes?$nodeFilter"
+$nodeResp = Invoke-RestMethod -Uri $nodeUrl -Headers $headers -Method Get
+if ($nodeResp.value.Count -eq 0) {
+    Write-Error "Node '$NodeName' not found under playbook '$PlaybookName'."
+    exit 1
+}
+$nodeId = $nodeResp.value[0].sprk_playbooknodeid
+$rawConfig = $nodeResp.value[0].sprk_configjson
+Write-Host "       Node id     : $nodeId"
+
+if ([string]::IsNullOrWhiteSpace($rawConfig)) {
+    Write-Error "Node has empty sprk_configjson — cannot patch."
+    exit 1
+}
+
+# 4) Parse, mutate, serialize
+Write-Host ''
+Write-Host '[4/5] Computing patched configjson...'
+$config = $rawConfig | ConvertFrom-Json -AsHashtable -Depth 50
+
+$oldFetch  = $config['fetchXml']
+$oldEntity = $config['entityLogicalName']
+$config['fetchXml'] = $FetchXml
+if ($PSBoundParameters.ContainsKey('Description')) {
+    $config['description'] = $Description
+}
+if ($PSBoundParameters.ContainsKey('EntityLogicalName')) {
+    $config['entityLogicalName'] = $EntityLogicalName
+}
+if ($ClearParameters -and $config.ContainsKey('parameters')) {
+    $config.Remove('parameters') | Out-Null
+}
+$newConfig = $config | ConvertTo-Json -Depth 50 -Compress
+
+Write-Host ''
+if ($PSBoundParameters.ContainsKey('EntityLogicalName')) {
+    Write-Host "EntityLogicalName: $oldEntity -> $EntityLogicalName" -ForegroundColor Yellow
+}
+if ($ClearParameters) {
+    Write-Host 'Parameters block: REMOVED' -ForegroundColor Yellow
+}
+Write-Host '------ OLD fetchXml ------' -ForegroundColor DarkGray
+Write-Host $oldFetch
+Write-Host '------ NEW fetchXml ------' -ForegroundColor Cyan
+Write-Host $FetchXml
+Write-Host '--------------------------'
+
+if ($DryRun) {
+    Write-Host ''
+    Write-Host '[5/5] DRY RUN — no write performed.' -ForegroundColor Cyan
+    exit 0
+}
+
+# 5) PATCH
+Write-Host ''
+Write-Host '[5/5] PATCHing sprk_playbooknodes(...) with new sprk_configjson...'
+$patchUrl = "$ApiBase/sprk_playbooknodes($nodeId)"
+$patchBody = @{ sprk_configjson = $newConfig } | ConvertTo-Json -Depth 10
+Invoke-RestMethod -Uri $patchUrl -Headers $headers -Method Patch -Body $patchBody | Out-Null
+Write-Host '       PATCH succeeded.' -ForegroundColor Green
+
+Write-Host ''
+Write-Host 'Verification hint:'
+Write-Host '  1. Trigger a playbook tick (wait for scheduler or invoke manually).'
+Write-Host '  2. Check sprk_playbookrun rows for the parent playbook — should now succeed.'
+Write-Host '  3. Check appnotification records for new ones with this category.'

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/services/notificationService.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/services/notificationService.ts
@@ -294,9 +294,13 @@ export async function markAllNotificationsRead(
     let succeeded = 0;
     let failed = 0;
 
-    // Use Promise.allSettled for parallel mark-read operations
+    // Use Promise.allSettled for parallel mark-read operations.
+    // Write toasttype=200000000 to match the single-record markNotificationRead path
+    // and the read/filter paths above (line 123, 156). The previous {isread:true} was
+    // either a no-op (isread not on appnotification schema) or wrote to a different
+    // field than the read path checks — bulk dismiss was therefore silently broken.
     const results = await Promise.allSettled(
-      unread.data.map(item => webApi.updateRecord('appnotification', item.id, { isread: true }))
+      unread.data.map(item => webApi.updateRecord('appnotification', item.id, { toasttype: 200000000 }))
     );
 
     for (const r of results) {

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
@@ -493,7 +493,7 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
             ["priority"] = priority,
             ["toasttype"] = toastType,
             ["ownerid@odata.bind"] = $"/systemusers({recipientId})",
-            ["ttlinseconds"] = 259200  // 3 days default TTL
+            ["ttlinseconds"] = 604800  // 7 days default TTL (increased from 3d on 2026-06-22 after UAT showed 36 notifications TTL-purged before user could review them)
         };
 
         // Add category (custom field for idempotency grouping)


### PR DESCRIPTION
## Summary

Daily Briefing producer + consumer hygiene — Phase A (producer-layer fetchXml channel fixes) + Phase B (consumer-side field mismatch + TTL increase).

### Commit 1: `1282c1335` — patch script field name fix
Corrected `{{item.scheduledend}}` (OOB task field) → `{{item.sprk_duedate}}` in the dueDate-plumbing patch script. Already applied live to 2 task notification nodes.

### Commit 2: `383c2b127` — Phase A producer-fix (Channels 1–5)
- **NEW**: `scripts/Patch-PlaybookQueryFetchXml.ps1` — reusable script for any playbook query-node patch (fetchXml + description + optional entityLogicalName + optional ClearParameters).
- **Live patches to spaarkedev1**:
  - Ch.1 Query Overdue Tasks: removed broken `sprk_todoflag` filter; replaced with `sprk_eventtype_ref=Task + statuscode=Open + (sprk_duedate OR sprk_finalduedate < today)`.
  - Ch.2 Query Tasks Due Soon: same shape, BETWEEN today AND `{{dueSoonWindowUtc}}` (7d default).
  - Ch.3 Query New Documents: removed broken `sprk_matterteammember` join (entity DNE); replaced with `sprk_matter` outer-link + Option C OR (matter-owner OR doc-owner).
  - Ch.4 Query New Events: `appointment` → `sprk_event` with type IN {Action, Deadline, Meeting, Milestone, Reminder} + `sprk_RegardingMatter` outer-link + Option C OR; entityLogicalName fix.
  - Ch.5 Query New Emails: `email` → `sprk_communication` (Email=100000000) + `sprk_RegardingMatter` outer-link + Option C OR; entityLogicalName fix.
- **Ch.6 (Matter Activity)** deferred per user.
- **Ch.7 (Work Assignments)** deferred; design captured in `notes/channel-7-work-assignments-design.md` (requires creating a new sprk_playbooknode, not just patching).

### Commit 3: `c55c7a5fe` — Phase B (client field mismatch + server TTL)
- **Fix 1** `notificationService.ts` `markAllNotificationsRead`: wrote `{ isread: true }` but every read/filter/single-mark path uses `{ toasttype: 200000000 }`. Mismatch meant bulk-dismiss was silently broken. Aligned with single-record path.
- **Fix 2** `CreateNotificationNodeExecutor.cs:496`: `ttlinseconds` bumped 3d → 7d (259200 → 604800). 3d was too short for a Friday-issued notification to survive the weekend; ~36 notifications TTL-purged on 2026-06-22 before user could review.

## Why

R2.2 UAT round 3 surfaced "You're all caught up" despite expected items. Root causes:
1. R1 playbook query nodes had been authored against a stale schema (`sprk_todoflag`, `sprk_matterteammember`, OOB `task`/`appointment`/`email`). All silently erroring since 2026-04-03. Producer layer was effectively dark for ~80 days. → **Phase A**
2. Client bulk-dismiss path wrote to a non-canonical field, so "mark all read" didn't persist visibly. → **Phase B Fix 1**
3. 3-day TTL was wiping notifications before user could see them (the "36 notifications gone today" diagnostic). → **Phase B Fix 2**

## Test plan

- [ ] After merge: `/bff-deploy` to push the TTL change live
- [ ] Wait for next scheduled playbook tick (≤1h based on `sprk_lastrundate` cadence) OR invoke manually
- [ ] Check `sprk_playbookrun` rows for each playbook — should succeed (vs. previous silent errors)
- [ ] Check new `appnotification` records by category (Tasks Overdue, Tasks Due Soon, New Documents, New Events, New Emails) with `ttlinseconds=604800`
- [ ] Refresh Daily Briefing in spaarkedev1 — verify items render with proper regarding links
- [ ] Click "mark all as read" — verify all items disappear (bulk-dismiss path)
- [ ] Set test sprk_event records' ownerid to Ralph to verify Ch.1/2/4 scoping

## Out of scope (tracked for Phase C)

- 'My' resolver design (team membership, sprk_to UPN match for inbound emails, etc.)
- R3 (`spaarke-platform-foundations-r3`) scheduler robustness + run-now admin endpoints
- Repo↔Dataverse sync mechanism (so repo JSON doesn't drift from deployed config like it did here)
- Channels 6 + 7 implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)