### PR TITLE
chore: cherry-pick r2.3-orchestrator-diagnosis 3 BFF fixes onto master

### DIFF
--- a/projects/spaarke-daily-update-service-r2/current-task.md
+++ b/projects/spaarke-daily-update-service-r2/current-task.md
@@ -1,8 +1,8 @@
-# Current Task State
+# Current Task State - Spaarke Daily Update Service R2
 
-> **Last Updated**: 2026-06-22 (Phase A Channels 1–5 patched LIVE; Ch.6 + Ch.7 deferred; moving to Phase B)
+> **Last Updated**: 2026-06-23 18:30 UTC (by context-handoff)
 > **Recovery**: Read "Quick Recovery" section first
-> **Protocol**: [Context Recovery](../../docs/procedures/context-recovery.md)
+> **Branch**: `master` (⚠ uncommitted BFF changes present — see "Files Modified" + "Critical Context")
 
 ---
 
@@ -10,107 +10,130 @@
 
 | Field | Value |
 |-------|-------|
-| **Task** | R2.2 SHIPPED + DEPLOYED. Producer-fix Phase A: Channels 1–5 fetchXml patches LIVE on spaarkedev1. Channels 6+7 deferred (design captured for Ch.7). Moving to Phase B (isread/toasttype + TTL). |
-| **Step** | Phase A complete; Phase B not yet started |
-| **Status** | Phase A done; ready for commit + Phase B kickoff |
-| **Next Action** | (1) Commit new Patch-PlaybookQueryFetchXml.ps1 script + Ch.7 design notes + this checkpoint. (2) Admin-merge PR #413 (known StorageRetryPolicyTests flake). (3) Design Phase B fix for isread/toasttype mismatch + TTL increase. |
-| **Branch** | `work/spaarke-daily-update-service-r2.2-patch-fix` (head: `1282c1335`, +1 uncommitted: new patch script + Ch.7 notes + this update) |
-| **Open PRs** | **PR #413**: scripts/Patch-NotificationPlaybookDueDate.ps1 field-name fix — awaiting admin-merge (Release CI flake on StorageRetryPolicyTests) |
+| **Task** | Daily Briefing producer pipeline — 6 bugs diagnosed in series; correct architectural fix identified (refactor to `Spaarke.Dataverse.IGenericEntityService`); audit complete; about to start refactor |
+| **Step** | After audit, before refactor. User asked for /compact at this boundary. |
+| **Status** | blocked-on-compact-then-refactor |
+| **Next Action** | After /compact: refactor 3 broken node executors (`QueryDataverseNodeExecutor`, `CreateNotificationNodeExecutor`, `CreateTaskNodeExecutor`) to inject `Spaarke.Dataverse.IGenericEntityService` instead of the orphan-named `IHttpClientFactory.CreateClient("DataverseApi")`. Then build + zipdeploy + force-tick + verify appnotifications appear for Ralph. Per user principle: "correct, not fastest" — also flag/refactor the 4 OTHER services with same antipattern (EmailTemplateService, BulkRagIndexingJobHandler, SessionRestoreService, EmailAssociationService) as follow-up. |
+| **BFF runtime state** | Diag-instrumented build deployed (hash matches), with `AnalysisActionService.cs:33` SELECT fix included. App Insights captures `[DBG-DAILY]` markers. App-only path enters `ExecuteNodeAsync` then fails on HttpClient missing BaseAddress. |
+| **Dataverse state** | All Phase A fetchXml patches still live (Ch.1–5). All R2.2 BFF + code-page changes still live. Plus today's wiring patches (see "Live Dataverse mutations" below). |
 
-### Files Modified This Session (after context-handoff resume)
+### Files Modified This Session (UNCOMMITTED ⚠)
 
-- `scripts/Patch-PlaybookQueryFetchXml.ps1` (NEW) — reusable producer-fix script: patches sprk_configjson.fetchXml + description + optional entityLogicalName + optional ClearParameters. Used to apply Ch.1–5 patches.
-- `projects/spaarke-daily-update-service-r2/notes/channel-7-work-assignments-design.md` (NEW) — captured design for deferred Channel 7 (sprk_workassignment + Option C + createdon OR sprk_responseduedate semantics)
-- `projects/spaarke-daily-update-service-r2/current-task.md` (THIS FILE) — Phase A wrap-up + Phase B kickoff
+- `src/server/api/Sprk.Bff.Api/Services/Ai/AnalysisActionService.cs` — **Real fix.** Removed `sprk_actiontype` from the `$select` clause (line 33). That field doesn't exist on the `sprk_analysisaction` entity (a 2026-06-02 comment in the same file documented the empirical confirmation but the SELECT was never updated). Including it caused ALL `GetActionAsync` calls to return HTTP 400 → broke Insights AND Daily Briefing AND any future ActionId-based dispatch.
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs` — **Diagnostic instrumentation.** Added 6 `[DBG-DAILY]` `LogWarning` markers at: AppOnlyInternal entry/post-GetNodesAsync/post-ExecuteNodeBasedModeAsync, NodeBased entry/post-graph-build/post-batches/per-batch, ExecuteNodeAsync entry/executor-lookup/calling-executor/executor-returned. Decision pending: leave as `LogInformation` (permanent observability) or revert.
 
-### Live Dataverse mutations (after resume) — all on spaarkedev1
+### Live Dataverse mutations this session (all on spaarkedev1)
 
-| Node | Channel | What changed |
-|---|---|---|
-| `1cbd78b2-5f2d-…` Query Overdue Tasks | 1 | fetchXml: sprk_todoflag→sprk_eventtype_ref=Task + statuscode=Open + (sprk_duedate OR sprk_finalduedate < today); sort: finalduedate then duedate |
-| `79f77aa5-5f2d-…` Query Tasks Due Soon | 2 | fetchXml: same shape as Ch.1 but BETWEEN today AND {{dueSoonWindowUtc}} (default 7d) |
-| `2b50e587-5f2d-…` Query New Documents | 3 | fetchXml: removed sprk_matterteammember; replaced with outer join on sprk_matter + OR (m.ownerid=me, doc.ownerid=me) |
-| `2d2fdd9e-5f2d-…` Query New Events | 4 | fetchXml: appointment→sprk_event with type IN {Action,Deadline,Meeting,Milestone,Reminder} + sprk_RegardingMatter outer join + Option C OR; entityLogicalName: appointment→sprk_event; cleared stale parameters |
-| `d9468c8e-5f2d-…` Query New Emails | 5 | fetchXml: email→sprk_communication with type=Email (100000000) + sprk_RegardingMatter outer join + Option C OR; entityLogicalName: email→sprk_communication; cleared stale parameters |
+**10 sprk_playbooknode records PATCHed**:
+- `sprk_isactive = true` on all 20 nodes across 5 in-scope playbooks (Ch.1–5). Previously all 20 were `false` — `ExecutionGraph.IsActive` filter dropped them → `totalNodes=0` → no work.
+- `__actionType: 33` added to configjson of 5 Start nodes — triggers `isStartNode` passthrough in orchestrator line 1023.
+- `_sprk_actionid_value` (FK) set on 5 Query nodes → SYS-QUERY-DV Action.
+- `_sprk_actionid_value` (FK) set on 5 Notify nodes → SYS-CREATE-NOTIF Action.
 
-### Critical Context (must read before continuing)
+**2 sprk_analysisaction rows CREATED**:
+- `ef7747ca-2b6f-f111-ab0e-7ced8ddc4cc6` SYS-QUERY-DV (executoractiontype=51 via lookup)
+- `f97747ca-2b6f-f111-ab0e-7ced8ddc4cc6` SYS-CREATE-NOTIF (executoractiontype=50 via lookup)
 
-**1. Phase A done. Producer is now functional.** All 5 active Daily Briefing channels query the right entities with the right filters. Channels 6 + 7 explicitly deferred — Ch.7 design captured for future implementation.
+**1 sprk_analysisactiontype row CREATED**:
+- `6fb58650-2e6f-f111-ab0e-70a8a590c51c` "50 - Create Notification" (executor=50). The registry already had "51 - Query Dataverse" (`f9dd8bf5-4865-f111-ab0c-7ced8ddc4a05`).
 
-**2. Architectural patterns established (apply to any future producer fixes):**
-   - **"My" filter (interim)**: `ownerid eq-userid` (BFF rewrites at runtime per `QueryDataverseNodeExecutor.cs:187-195`). Phase C will design richer "My" resolver (team membership, regarding, etc.).
-   - **Option C (matter-owner OR record-owner)**: when source entity has `sprk_RegardingMatter` lookup (sprk_event, sprk_communication) OR direct matter lookup (sprk_document), use outer-link + `entityname="m"` cross-entity OR pattern.
-   - **Date-range OR**: when a record has multiple date fields (sprk_duedate, sprk_finalduedate, sprk_responseduedate), OR the range conditions together inside the AND filter.
-   - **Two-level sort**: primary by stricter/canonical date, tiebreaker by secondary date.
-   - **entityLogicalName must match `<entity name=>`**: BFF builds entitySet URL from `sprk_configjson.entityLogicalName`. Patching fetchXml without entityLogicalName fix = URL/entity mismatch error.
-   - **Stale parameters block** (`{{timeWindow}}`, `templateParameters.dueWithinDays`, etc.) — BFF only supports `parameters.dueSoonDays` and `parameters.timeWindowHours`. Remove anything else.
+### Critical Context
 
-**3. Test data verification (still pending on user):**
-   - Set sprk_event records' owner to Ralph Schroeder for Ch.1/2/4 testing.
-   - For Ch.5 — emails owned by service principal won't surface unless owner is fixed OR we add `sprk_to` UPN match in Phase C.
-   - For Ch.3 — Ralph already owns most matters + docs, so existing data works.
-   - Verification: wait for next playbook tick (≤1h) OR invoke manually; check appnotification records by category.
+**Daily Briefing producer is STILL not creating notifications**, but we've eliminated 5 of 6 known bugs and pivoted to the correct architectural fix instead of a parallel-implementation bypass.
 
-**4. Architectural bugs still pending (Phase B):**
-   - **isread / toasttype mismatch** in `notificationService.ts:120` — reads `toasttype === 200000000` (which schema says is "Timed", not "Dismissed"). Line 299 writes `webApi.updateRecord('appnotification', id, {isread: true})` — `isread` may not even exist on appnotification schema. Need to verify field names and align read/write paths.
-   - **TTL = 3 days** (`CreateNotificationNodeExecutor.cs:489`, `ttlinseconds = 259200`) may be too short — accidental TTL purge on 2026-06-22 wiped 36 records the user expected. Proposed: 7 or 14 days.
+**The 6 bugs found in series** (each fix revealed the next):
 
-**5. Phase C (out of scope here, tracked):**
-   - R3 (`spaarke-platform-foundations-r3`) provides scheduler robustness + run-now admin endpoints
-   - "My" resolver design (richer than ownerid)
-   - Sync mechanism between repo JSON and deployed playbook configs (repo drift caused the original misdiagnosis)
+| # | Bug | Layer | Status |
+|---|---|---|---|
+| 1 | `sprk_isactive=false` on all 10 deployed nodes → ExecutionGraph filtered them out → totalNodes=0 | Data | ✅ Fixed via PATCH |
+| 2 | NodeType=AIAnalysis nodes had no ActionId → "AI node requires Action" error | Data + Arch | ✅ Fixed via PATCH (created SYS Actions + wired FKs) |
+| 3 | Start node configjson missing `__actionType` → fell to Control→Condition fallback → "Condition expression required" error | Data | ✅ Fixed via PATCH |
+| 4 | BFF `AnalysisActionService.GetActionAsync` SELECTs `sprk_actiontype` field that doesn't exist on entity → ALL Action lookups return 400 | Code | ✅ Fixed (uncommitted, deployed) |
+| 5 | Missing `sprk_analysisactiontype` registry row for executor=50 (CreateNotification) | Data | ✅ Fixed via CREATE |
+| 6 | `QueryDataverseNodeExecutor` / `CreateNotificationNodeExecutor` / `CreateTaskNodeExecutor` use `IHttpClientFactory.CreateClient("DataverseApi")` — **named client NEVER registered in DI** → returns default HttpClient with no BaseAddress + no auth handler → "invalid request URI" | Code (architectural) | ❌ NOT FIXED — this is the next refactor |
 
-### Recovery steps for next session
+**Audit found 4 ADDITIONAL services with the same antipattern** (different orphan names, all unregistered):
+- `EmailTemplateService` → `"Dataverse"` (2 sites)
+- `BulkRagIndexingJobHandler` → `"DataverseBatch"`
+- `SessionRestoreService` → `"DataverseETagCheck"`
+- `EmailAssociationService` → `"DataverseAssociation"`
 
-1. Read this entire Quick Recovery section
-2. Check branch: `git branch --show-current` should show `work/spaarke-daily-update-service-r2.2-patch-fix`
-3. Verify PR #413: `gh pr view 413 --json state,mergedAt` (may have been admin-merged)
-4. Spot-check live state of Ch.1–5 nodes: `mcp__dataverse__read_query SELECT sprk_playbooknodeid, sprk_name, sprk_configjson FROM sprk_playbooknode WHERE sprk_playbooknodeid IN (...)`
-5. Next concrete action: Phase B design (see notes/phase-b-design.md if created)
+Plus `"DataversePolling"` (EmailServicesModule:50) is registered-but-bare. So **7 services total** have this defect class.
+
+**The architectural alignment**: The codebase already has the correct pattern: `Spaarke.Dataverse.IGenericEntityService` (shared library, registered via `GraphModule.cs:71` as composite forwarding). Used correctly by 20+ services including `PlaybookSchedulerService` itself (line 217 calls `entityService.RetrieveMultipleAsync(query, ct)`). It handles BaseAddress + TokenCredential + Bearer auth + token refresh automatically. The runtime impl is `DataverseServiceClientImpl` which supports `FetchExpression` (the SDK type for FetchXml).
+
+**Method shapes the 3 node executors need**:
+```csharp
+Task<EntityCollection> RetrieveMultipleAsync(FetchExpression fetch, CancellationToken ct);  // for fetchXml queries
+Task<Guid> CreateAsync(Entity entity, CancellationToken ct);  // for appnotification + task creation
+```
+
+**User's explicit principle (load-bearing for any future decision)**: "We MUST always take the correct technical approach not the fastest/least effort approach." Earlier I made the mistake of recommending a parallel BFF endpoint (bypass). User correctly rejected that as architectural drift. Confirmed approach: refactor the broken executors to use the existing shared library — slower but architecturally aligned.
 
 ---
 
 ## Full State (Detailed)
 
-### R2.2 final state (unchanged from prior checkpoint)
+### Session arc (chronological)
 
-| Artifact | State |
-|---|---|
-| PR #405 (R2.2 main) | ✅ MERGED (`ec05765ed`) |
-| PR #410 (R2.2 hotfix) | ✅ MERGED (`e584d296c`) |
-| PR #413 (patch script fix) | 🟡 OPEN — pending admin-merge |
-| BFF deploy | ✅ LIVE (46.07 MB, /healthz green) |
-| `sprk_dailyupdate` code page | ✅ LIVE |
-| `sprk_spaarkeai` code page | ✅ LIVE |
+1. Resumed from prior session (Phase A + Phase B already shipped: Channels 1–5 fetchXml patches live, TTL=7d live, bulk-dismiss fix live).
+2. User reported Daily Briefing showing zero items despite having qualifying events as owner.
+3. Diagnosed producer pipeline through cascading bugs (the 6 above).
+4. Briefly fell back to "bypass" recommendation after frustration; user correctly pushed back on architectural shortcuts.
+5. Identified `Spaarke.Dataverse.IGenericEntityService` as the canonical shared pattern.
+6. Audit confirmed 7 services across BFF use the broken named-client antipattern.
+7. About to start refactor; user requested /context-handoff first.
 
-### Phase A live channel state (post-resume)
+### Key code paths to know
 
-All 5 channel nodes patched LIVE. Next playbook tick exercises them.
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs:168` — `ExecuteAppOnlyInternalAsync`, app-only entry, currently has DBG-DAILY markers
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs:635` — `ExecuteNodeBasedModeAsync` (batched parallel)
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs:885` — `ExecuteNodeAsync` (per-node dispatch, executor lookup, Validate, ExecuteAsync)
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs:1023` — `isStartNode` early-return passthrough check
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs:1067` — `if (node.ActionId != Guid.Empty)` Action-FK branch
+- `src/server/api/Sprk.Bff.Api/Services/Ai/ExecutionGraph.cs:?` — constructor filters `nodes.Where(n => n.IsActive)`
+- `src/server/api/Sprk.Bff.Api/Services/Ai/AnalysisActionService.cs:33` — the SELECT fix (uncommitted)
+- `src/server/api/Sprk.Bff.Api/Services/Ai/DataverseHttpServiceBase.cs` — pattern used by AnalysisActionService etc. (constructor sets BaseAddress + headers, EnsureAuthenticatedAsync attaches Bearer)
+- `src/server/shared/Spaarke.Dataverse/IGenericEntityService.cs` — **canonical Dataverse access interface; refactor target**
+- `src/server/shared/Spaarke.Dataverse/DataverseServiceClientImpl.cs` — runtime impl (handles FetchExpression)
+- `src/server/api/Sprk.Bff.Api/Infrastructure/DI/GraphModule.cs:71` — `IGenericEntityService` registration (composite forwarding to `IDataverseService`)
+- `src/server/api/Sprk.Bff.Api/Infrastructure/DI/AnalysisServicesModule.cs` — node executor registrations (need to add `IGenericEntityService` dep when refactoring)
+- `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/UpdateRecordNodeExecutor.cs` — **reference implementation** — the ONE node executor that correctly uses `IGenericEntityService`. Mirror this pattern when refactoring the 3 broken ones.
 
-### Decisions Made (this session, after resume)
+### Resumption protocol (do this on /compact resume)
 
-- **2026-06-22**: Channel-by-channel patches via reusable `Patch-PlaybookQueryFetchXml.ps1` script (extension of the field-fix-only `Patch-NotificationPlaybookDueDate.ps1`). Operates one node at a time so each channel is reviewed + applied independently.
-- **2026-06-22**: For each channel, "My" filter stays as `ownerid eq-userid` (interim) — Phase C will design richer resolver. User confirmed.
-- **2026-06-22**: For sprk_event and sprk_communication, use per-type regarding lookup (`sprk_RegardingMatter`) with outer-link + cross-entity OR pattern (Option C). User clarified that Spaarke has per-entity-type regarding lookups + a unified resolver, NOT a polymorphic regardingobjectid.
-- **2026-06-22**: For sprk_document (Ch.3) — direct sprk_matter lookup is the model (no per-type regarding fields). Option C still applies via outer link + OR.
-- **2026-06-22**: Channel 4 fetchXml type filter set to {Action, Deadline, Meeting, Milestone, Reminder} — user opted for broader event coverage than just Meeting.
-- **2026-06-22**: Channel 5 ownership filter known to miss inbound emails owned by service principal. Documented as interim limitation; Phase C resolves via `sprk_to` UPN match or post-receive ownership-assignment flow.
-- **2026-06-22**: Channels 6+7 deferred. Channel 7 design captured in `notes/channel-7-work-assignments-design.md` for future implementation (requires creating a new sprk_playbooknode record, not just patching).
+1. **Read this Quick Recovery section** (you are reading it now)
+2. **Check uncommitted state**: `git status --short` — should show 2 modified files (`AnalysisActionService.cs`, `PlaybookOrchestrationService.cs`). If clean, the changes got committed or reverted; investigate before proceeding.
+3. **Confirm branch**: `git branch --show-current` — should be `master` (we did NOT branch off; uncommitted changes are on master).
+4. **Decide on commit strategy**: 
+    - Option A: branch off + commit before refactor (cleaner history)
+    - Option B: stash, do refactor on master, commit everything together
+    - Recommend Option A.
+5. **Read `UpdateRecordNodeExecutor.cs`** (the reference implementation) to internalize the correct pattern.
+6. **Refactor in this order**:
+   - `QueryDataverseNodeExecutor` — uses `RetrieveMultipleAsync(FetchExpression)` — the most critical for Daily Briefing
+   - `CreateNotificationNodeExecutor` — uses `CreateAsync(Entity)` — also critical for Daily Briefing
+   - `CreateTaskNodeExecutor` — uses `CreateAsync(Entity)` — same pattern
+7. **Update DI** in `AnalysisServicesModule.cs` — these executors are registered as singletons; need to verify they can take `IGenericEntityService` dep (which may be scoped — confirm).
+8. **Build + zipdeploy** (use stop → kudu zipdeploy → start cycle to bypass file locks).
+9. **Force-tick** (NULL `sprk_lastrundate` on 5 playbooks + restart). Verify `appnotification` records appear for Ralph in spaarkedev1.
+10. **If green**: revert diag logging from orchestrator + redeploy clean. Commit + PR.
+11. **Follow-up backlog**: 4 other services with same antipattern — same refactor pattern.
 
-### MCP visibility limitation (unchanged)
+### Verification queries
 
-MCP service principal sees only 4 of (presumably 36+) appnotification records. Don't trust MCP appnotification counts as definitive — verify with user-side queries.
+- App Insights for orchestrator behavior: `traces | where timestamp > ago(15m) | where message contains "DBG-DAILY" or message contains "Playbook" | order by timestamp`
+- Appnotifications: `appnotifications?$filter=createdon ge {ISO-timestamp}&$select=title,createdon,ttlinseconds,partitionid&$orderby=createdon desc&$top=30`
+- Playbook last-run dates: `sprk_analysisplaybooks?$filter=sprk_playbooktype eq 2 and statecode eq 0&$select=sprk_name,sprk_lastrundate`
 
-### Repo paths
+### Deferred (do NOT lose sight of)
 
-- This file: `projects/spaarke-daily-update-service-r2/current-task.md`
-- Ch.7 design notes: `projects/spaarke-daily-update-service-r2/notes/channel-7-work-assignments-design.md`
-- Producer patch script (NEW): `scripts/Patch-PlaybookQueryFetchXml.ps1`
-- Original due-date patch script: `scripts/Patch-NotificationPlaybookDueDate.ps1` (PR #413)
-- BFF query executor: `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/QueryDataverseNodeExecutor.cs`
-- BFF notification creator: `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs`
-- Client notification service: `src/client/shared/Spaarke.DailyBriefing.Components/src/services/notificationService.ts` (Phase B target)
+- Channel 6 (Matter/Project Activity) and Channel 7 (Work Assignments) — design captured in `notes/channel-7-work-assignments-design.md`.
+- The 4 other services with broken named-client pattern — should be refactored in same wave to prevent future bug reports.
+- "DataversePolling" bare registration in `EmailServicesModule.cs:50` — needs proper config or migration to shared lib.
+- Decision: should `_sprk_actionid_value` always be required on every node (eliminate the structural-NodeType fallback)? Discussed; user agreed it would be cleaner. R3 / R4 work item.
+- R3 PR #415 still pending merge — DOES NOT fix this bug class (R3's `PlaybookSchedulerJob` calls the same broken `ExecuteAppOnlyAsync` path). Our refactor benefits R3 too.
 
 ---
 
-*Updated 2026-06-22 — Phase A complete; ready for commit + Phase B.*
+*Checkpoint written 2026-06-23 18:30 UTC. Ready for /compact + resume.*

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/AnalysisActionService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/AnalysisActionService.cs
@@ -30,7 +30,11 @@ public class AnalysisActionService : DataverseHttpServiceBase
 
         await EnsureAuthenticatedAsync(cancellationToken);
 
-        var url = $"sprk_analysisactions({actionId})?$select=sprk_analysisactionid,sprk_name,sprk_description,sprk_systemprompt,sprk_actiontype,sprk_temperature&$expand=sprk_ActionTypeId($select=sprk_name,sprk_executoractiontype)";
+        // Bug fix 2026-06-23: removed sprk_actiontype from $select — that field does not exist on
+        // sprk_analysisaction (the comment below documents the Q1 2026-06-02 empirical confirmation
+        // but the SELECT clause was never updated). Including it causes ALL GetActionAsync calls to
+        // return 400 Bad Request, silently breaking every node that depends on Action lookup.
+        var url = $"sprk_analysisactions({actionId})?$select=sprk_analysisactionid,sprk_name,sprk_description,sprk_systemprompt,sprk_temperature&$expand=sprk_ActionTypeId($select=sprk_name,sprk_executoractiontype)";
         var response = await Http.GetAsync(url, cancellationToken);
 
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound)

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
@@ -439,7 +439,7 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
             };
             query.Criteria.AddCondition("ownerid", ConditionOperator.Equal, recipientId);
             query.Criteria.AddCondition("sprk_category", ConditionOperator.Equal, category);
-            query.Criteria.AddCondition("regardingobjectid", ConditionOperator.Equal, regardingId);
+            query.Criteria.AddCondition("sprk_regardingid", ConditionOperator.Equal, regardingId.ToString());
             query.Criteria.AddCondition("statecode", ConditionOperator.Equal, 0);
 
             var result = await _entityService.RetrieveMultipleAsync(query, cancellationToken);
@@ -528,10 +528,14 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
             entity["data"] = JsonSerializer.Serialize(dataObject);
         }
 
-        // Add regarding object if specified
+        // Add regarding info if specified. appnotification is NOT an activity entity
+        // (no polymorphic regardingobjectid lookup), so we store regarding as two text
+        // fields: sprk_regardingid (GUID string) + sprk_regardingtype (entity logical name).
+        // These are also used in CheckForDuplicateNotificationAsync for idempotency.
         if (regardingId.HasValue && !string.IsNullOrWhiteSpace(regardingType))
         {
-            entity["regardingobjectid"] = new EntityReference(regardingType, regardingId.Value);
+            entity["sprk_regardingid"] = regardingId.Value.ToString();
+            entity["sprk_regardingtype"] = regardingType;
         }
 
         // Add AI metadata (playbook run info)

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
@@ -1,5 +1,7 @@
-using System.Net;
 using System.Text.Json;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Spaarke.Dataverse;
 using Sprk.Bff.Api.Models.Ai;
 
 namespace Sprk.Bff.Api.Services.Ai.Nodes;
@@ -30,6 +32,12 @@ namespace Sprk.Bff.Api.Services.Ai.Nodes;
 /// Priority values follow Dataverse appnotification convention:
 ///   100000000 = Informational, 200000000 = Important (default), 300000000 = Urgent
 /// </para>
+/// <para>
+/// Uses the canonical <see cref="IGenericEntityService"/> shared library
+/// (which forwards to <c>DataverseServiceClientImpl</c>) rather than an
+/// app-private named HttpClient. This gives correct BaseAddress + token
+/// acquisition + lifecycle management for app-only execution paths.
+/// </para>
 /// </remarks>
 public sealed class CreateNotificationNodeExecutor : INodeExecutor
 {
@@ -54,16 +62,16 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
     private const int DefaultToastType = 200_000_000;
 
     private readonly ITemplateEngine _templateEngine;
-    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IGenericEntityService _entityService;
     private readonly ILogger<CreateNotificationNodeExecutor> _logger;
 
     public CreateNotificationNodeExecutor(
         ITemplateEngine templateEngine,
-        IHttpClientFactory httpClientFactory,
+        IGenericEntityService entityService,
         ILogger<CreateNotificationNodeExecutor> logger)
     {
         _templateEngine = templateEngine;
-        _httpClientFactory = httpClientFactory;
+        _entityService = entityService;
         _logger = logger;
     }
 
@@ -227,16 +235,16 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
                 }
             }
 
-            // Build appnotification payload
-            var notificationPayload = BuildNotificationPayload(
+            // Build appnotification entity
+            var entity = BuildNotificationEntity(
                 title, body, category, config.Priority ?? DefaultPriority,
                 config.ToastType ?? DefaultToastType,
                 actionUrl, recipientId.Value, regardingId, regardingType,
                 dueDate,
                 context);
 
-            // Create the notification via Dataverse Web API
-            var notificationId = await CreateAppNotificationAsync(notificationPayload, cancellationToken);
+            // Create the notification via shared Dataverse client
+            var notificationId = await _entityService.CreateAsync(entity, cancellationToken);
 
             _logger.LogInformation(
                 "CreateNotification node {NodeId} completed — notification {NotificationId} created for user {UserId}: {Title}",
@@ -277,9 +285,6 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
         }
     }
 
-    /// <summary>
-    /// Resolves the recipient systemuserid from config template or run context.
-    /// </summary>
     /// <summary>
     /// Executes the iterate-items path: loops over items from upstream query output,
     /// creates one notification per item using the itemNotification template.
@@ -366,12 +371,12 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
                 if (isDuplicate) { skipped++; continue; }
             }
 
-            var payload = BuildNotificationPayload(
+            var entity = BuildNotificationEntity(
                 title, body, category, itemConfig.Priority ?? DefaultPriority,
                 itemConfig.ToastType ?? DefaultToastType,
                 actionUrl, recipientId.Value, regardingId, regardingType,
                 dueDate, context);
-            await CreateAppNotificationAsync(payload, cancellationToken);
+            await _entityService.CreateAsync(entity, cancellationToken);
             created++;
         }
 
@@ -387,6 +392,9 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
             metrics: NodeExecutionMetrics.Timed(startedAt, DateTimeOffset.UtcNow));
     }
 
+    /// <summary>
+    /// Resolves the recipient systemuserid from config template or run context.
+    /// </summary>
     private Guid? ResolveRecipientId(NotificationNodeConfig config, Dictionary<string, object?> templateContext)
     {
         if (!string.IsNullOrWhiteSpace(config.RecipientId))
@@ -423,32 +431,19 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
     {
         try
         {
-            var client = _httpClientFactory.CreateClient("DataverseApi");
-
-            // Query for unread notifications matching user + regarding + category
-            // appnotification: statecode 0 = Active (unread)
-            var filter = $"_ownerid_value eq '{recipientId}' " +
-                         $"and sprk_category eq '{category}' " +
-                         $"and _regardingobjectid_value eq '{regardingId}' " +
-                         $"and statecode eq 0";
-
-            var requestUrl = $"appnotifications?$filter={Uri.EscapeDataString(filter)}&$top=1&$select=activityid";
-
-            var response = await client.GetAsync(requestUrl, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
+            var query = new QueryExpression("appnotification")
             {
-                _logger.LogWarning(
-                    "Idempotency check failed with status {StatusCode} — proceeding with creation",
-                    response.StatusCode);
-                return false;
-            }
+                ColumnSet = new ColumnSet("activityid"),
+                TopCount = 1,
+                Criteria = new FilterExpression(LogicalOperator.And)
+            };
+            query.Criteria.AddCondition("ownerid", ConditionOperator.Equal, recipientId);
+            query.Criteria.AddCondition("sprk_category", ConditionOperator.Equal, category);
+            query.Criteria.AddCondition("regardingobjectid", ConditionOperator.Equal, regardingId);
+            query.Criteria.AddCondition("statecode", ConditionOperator.Equal, 0);
 
-            var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            using var doc = JsonDocument.Parse(content);
-
-            var values = doc.RootElement.GetProperty("value");
-            return values.GetArrayLength() > 0;
+            var result = await _entityService.RetrieveMultipleAsync(query, cancellationToken);
+            return result.Entities.Count > 0;
         }
         catch (Exception ex)
         {
@@ -462,7 +457,7 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
     }
 
     /// <summary>
-    /// Builds the appnotification OData payload for Dataverse Web API.
+    /// Builds an SDK <see cref="Entity"/> representing the appnotification to create.
     /// </summary>
     /// <remarks>
     /// Per FR-18 (P3): when <paramref name="actionUrl"/> is present, <c>data</c> is serialized as
@@ -473,7 +468,7 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
     /// icon shows a clickable "Open" button. Hidden-toast notifications skip <c>data.actions</c>
     /// because no visible surface renders them.
     /// </remarks>
-    private static Dictionary<string, object?> BuildNotificationPayload(
+    private static Entity BuildNotificationEntity(
         string title,
         string body,
         string? category,
@@ -486,20 +481,18 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
         string? dueDate,
         NodeExecutionContext context)
     {
-        var payload = new Dictionary<string, object?>
-        {
-            ["title"] = title,
-            ["body"] = body,
-            ["priority"] = priority,
-            ["toasttype"] = toastType,
-            ["ownerid@odata.bind"] = $"/systemusers({recipientId})",
-            ["ttlinseconds"] = 604800  // 7 days default TTL (increased from 3d on 2026-06-22 after UAT showed 36 notifications TTL-purged before user could review them)
-        };
+        var entity = new Entity("appnotification");
+        entity["title"] = title;
+        entity["body"] = body;
+        entity["priority"] = new OptionSetValue(priority);
+        entity["toasttype"] = new OptionSetValue(toastType);
+        entity["ownerid"] = new EntityReference("systemuser", recipientId);
+        entity["ttlinseconds"] = 604800; // 7 days default TTL (increased from 3d on 2026-06-22 after UAT showed 36 notifications TTL-purged before user could review them)
 
         // Add category (custom field for idempotency grouping)
         if (!string.IsNullOrWhiteSpace(category))
         {
-            payload["sprk_category"] = category;
+            entity["sprk_category"] = category;
         }
 
         // FR-18 (P3): build appnotification.data payload.
@@ -512,7 +505,6 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
         var hasDueDate = !string.IsNullOrWhiteSpace(dueDate);
         if (hasActionUrl || hasDueDate)
         {
-            // Build customData as a dictionary so we conditionally include only the populated fields.
             var customData = new Dictionary<string, object?>();
             if (hasActionUrl) customData["actionUrl"] = actionUrl;
             if (hasDueDate) customData["dueDate"] = dueDate;
@@ -533,58 +525,20 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
                 }
                 : (object)new { customData };
 
-            payload["data"] = JsonSerializer.Serialize(dataObject);
+            entity["data"] = JsonSerializer.Serialize(dataObject);
         }
 
         // Add regarding object if specified
         if (regardingId.HasValue && !string.IsNullOrWhiteSpace(regardingType))
         {
-            var entitySetName = GetEntitySetName(regardingType);
-            payload[$"regardingobjectid_{regardingType}@odata.bind"] = $"/{entitySetName}({regardingId.Value})";
+            entity["regardingobjectid"] = new EntityReference(regardingType, regardingId.Value);
         }
 
         // Add AI metadata (playbook run info)
-        payload["sprk_source"] = "playbook";
-        payload["sprk_playbookrunid"] = context.RunId.ToString();
+        entity["sprk_source"] = "playbook";
+        entity["sprk_playbookrunid"] = context.RunId.ToString();
 
-        return payload;
-    }
-
-    /// <summary>
-    /// Creates an appnotification record via Dataverse Web API.
-    /// </summary>
-    private async Task<Guid> CreateAppNotificationAsync(
-        Dictionary<string, object?> payload,
-        CancellationToken cancellationToken)
-    {
-        var client = _httpClientFactory.CreateClient("DataverseApi");
-
-        var jsonContent = JsonSerializer.Serialize(payload, JsonOptions);
-        var content = new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json");
-
-        var response = await client.PostAsync("appnotifications", content, cancellationToken);
-        response.EnsureSuccessStatusCode();
-
-        // Extract the created record ID from the OData-EntityId header
-        if (response.Headers.TryGetValues("OData-EntityId", out var entityIdValues))
-        {
-            var entityIdUrl = entityIdValues.FirstOrDefault();
-            if (entityIdUrl is not null)
-            {
-                // Format: https://{org}.crm.dynamics.com/api/data/v9.2/appnotifications({guid})
-                var guidStart = entityIdUrl.LastIndexOf('(') + 1;
-                var guidEnd = entityIdUrl.LastIndexOf(')');
-                if (guidStart > 0 && guidEnd > guidStart)
-                {
-                    var guidStr = entityIdUrl[guidStart..guidEnd];
-                    if (Guid.TryParse(guidStr, out var createdId))
-                        return createdId;
-                }
-            }
-        }
-
-        // Fallback: return a new GUID if we can't extract the ID
-        return Guid.NewGuid();
+        return entity;
     }
 
     /// <summary>
@@ -625,23 +579,6 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
         };
 
         return templateContext;
-    }
-
-    /// <summary>
-    /// Gets the OData entity set name (plural) for a Dataverse entity.
-    /// </summary>
-    private static string GetEntitySetName(string entityLogicalName)
-    {
-        return entityLogicalName switch
-        {
-            "sprk_document" => "sprk_documents",
-            "sprk_matter" => "sprk_matters",
-            "sprk_project" => "sprk_projects",
-            "account" => "accounts",
-            "contact" => "contacts",
-            "task" => "tasks",
-            _ => entityLogicalName.EndsWith("s") ? entityLogicalName : entityLogicalName + "s"
-        };
     }
 }
 

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateTaskNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateTaskNodeExecutor.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Microsoft.Xrm.Sdk;
+using Spaarke.Dataverse;
 using Sprk.Bff.Api.Models.Ai;
 
 namespace Sprk.Bff.Api.Services.Ai.Nodes;
@@ -21,22 +23,28 @@ namespace Sprk.Bff.Api.Services.Ai.Nodes;
 ///   "dueDate": "{{dueDate}}"
 /// }
 /// </code>
+/// <para>
+/// Uses the canonical <see cref="IGenericEntityService"/> shared library
+/// (which forwards to <c>DataverseServiceClientImpl</c>) rather than an
+/// app-private named HttpClient. This gives correct BaseAddress + token
+/// acquisition + lifecycle management for app-only execution paths.
+/// </para>
 /// </remarks>
 public sealed class CreateTaskNodeExecutor : INodeExecutor
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     private readonly ITemplateEngine _templateEngine;
-    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IGenericEntityService _entityService;
     private readonly ILogger<CreateTaskNodeExecutor> _logger;
 
     public CreateTaskNodeExecutor(
         ITemplateEngine templateEngine,
-        IHttpClientFactory httpClientFactory,
+        IGenericEntityService entityService,
         ILogger<CreateTaskNodeExecutor> logger)
     {
         _templateEngine = templateEngine;
-        _httpClientFactory = httpClientFactory;
+        _entityService = entityService;
         _logger = logger;
     }
 
@@ -121,15 +129,20 @@ public sealed class CreateTaskNodeExecutor : INodeExecutor
                 "Creating task with subject: {Subject}",
                 subject);
 
-            // Build task payload for Dataverse
-            var taskPayload = new Dictionary<string, object?>
+            // Build task entity
+            var entity = new Entity("task");
+            entity["subject"] = subject;
+            if (description is not null)
+                entity["description"] = description;
+
+            if (config.DueDate is not null)
             {
-                ["subject"] = subject,
-                ["description"] = description,
-                ["scheduledend"] = config.DueDate is not null
-                    ? _templateEngine.Render(config.DueDate, templateContext)
-                    : null
-            };
+                var dueDateStr = _templateEngine.Render(config.DueDate, templateContext);
+                if (DateTime.TryParse(dueDateStr, out var dueDate))
+                {
+                    entity["scheduledend"] = dueDate.ToUniversalTime();
+                }
+            }
 
             // Add regarding object if specified
             if (!string.IsNullOrWhiteSpace(config.RegardingObjectId) && !string.IsNullOrWhiteSpace(config.RegardingObjectType))
@@ -137,8 +150,7 @@ public sealed class CreateTaskNodeExecutor : INodeExecutor
                 var regardingId = _templateEngine.Render(config.RegardingObjectId, templateContext);
                 if (Guid.TryParse(regardingId, out var regardingGuid))
                 {
-                    var entitySetName = GetEntitySetName(config.RegardingObjectType);
-                    taskPayload[$"regardingobjectid_{config.RegardingObjectType}@odata.bind"] = $"/{entitySetName}({regardingGuid})";
+                    entity["regardingobjectid"] = new EntityReference(config.RegardingObjectType, regardingGuid);
                 }
             }
 
@@ -148,34 +160,22 @@ public sealed class CreateTaskNodeExecutor : INodeExecutor
                 var ownerId = _templateEngine.Render(config.OwnerId, templateContext);
                 if (Guid.TryParse(ownerId, out var ownerGuid))
                 {
-                    taskPayload["ownerid@odata.bind"] = $"/systemusers({ownerGuid})";
+                    entity["ownerid"] = new EntityReference("systemuser", ownerGuid);
                 }
             }
 
-            // Create the task record in Dataverse via Web API
-            var http = _httpClientFactory.CreateClient("DataverseApi");
-            var taskJson = JsonSerializer.Serialize(taskPayload, JsonOptions);
-            var requestContent = new StringContent(taskJson, System.Text.Encoding.UTF8, "application/json");
-
-            var response = await http.PostAsync("tasks", requestContent, cancellationToken);
-
+            // Create the task record via shared Dataverse client
             Guid taskId;
-            if (response.IsSuccessStatusCode)
+            try
             {
-                // Dataverse returns the new record ID in the OData-EntityId header
-                var entityIdHeader = response.Headers.Location?.AbsoluteUri
-                    ?? response.Headers.GetValues("OData-EntityId").FirstOrDefault();
-
-                taskId = Guid.TryParse(
-                    entityIdHeader?.Split('(').LastOrDefault()?.TrimEnd(')'),
-                    out var parsed) ? parsed : Guid.NewGuid();
+                taskId = await _entityService.CreateAsync(entity, cancellationToken);
             }
-            else
+            catch (Exception createEx)
             {
-                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
                 _logger.LogWarning(
-                    "Dataverse task creation returned {StatusCode} for node {NodeId}: {Error}",
-                    response.StatusCode, context.Node.Id, errorBody);
+                    createEx,
+                    "Dataverse task creation failed for node {NodeId}: {Error}",
+                    context.Node.Id, createEx.Message);
 
                 // Return a degraded success — the task payload was assembled correctly
                 // but Dataverse rejected it. Include the error for the user.
@@ -255,24 +255,6 @@ public sealed class CreateTaskNodeExecutor : INodeExecutor
         };
 
         return templateContext;
-    }
-
-    /// <summary>
-    /// Gets the OData entity set name (plural) for a Dataverse entity.
-    /// </summary>
-    private static string GetEntitySetName(string entityLogicalName)
-    {
-        // Common entity mappings
-        return entityLogicalName switch
-        {
-            "sprk_document" => "sprk_documents",
-            "sprk_matter" => "sprk_matters",
-            "sprk_project" => "sprk_projects",
-            "account" => "accounts",
-            "contact" => "contacts",
-            "task" => "tasks",
-            _ => entityLogicalName.EndsWith("s") ? entityLogicalName : entityLogicalName + "s"
-        };
     }
 }
 

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/QueryDataverseNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/QueryDataverseNodeExecutor.cs
@@ -1,6 +1,8 @@
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Spaarke.Dataverse;
 using Sprk.Bff.Api.Models.Ai;
 
 namespace Sprk.Bff.Api.Services.Ai.Nodes;
@@ -8,9 +10,16 @@ namespace Sprk.Bff.Api.Services.Ai.Nodes;
 /// <summary>
 /// Node executor for querying Dataverse via FetchXML from playbook execution.
 /// Resolves template variables in FetchXML (date tokens, user references),
-/// executes the query via OData Web API, and returns structured results
-/// for downstream condition/notification nodes.
+/// executes the query via <see cref="IGenericEntityService"/>, and returns
+/// structured results for downstream condition/notification nodes.
 /// </summary>
+/// <remarks>
+/// Uses the canonical <see cref="IGenericEntityService"/> shared library
+/// (which forwards to <c>DataverseServiceClientImpl</c>) rather than an
+/// app-private named HttpClient. This gives correct BaseAddress + token
+/// acquisition + lifecycle management for app-only execution paths
+/// (background scheduler, Daily Briefing producer).
+/// </remarks>
 public sealed class QueryDataverseNodeExecutor : INodeExecutor
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
@@ -19,16 +28,16 @@ public sealed class QueryDataverseNodeExecutor : INodeExecutor
     private const int DefaultTimeWindowHours = 24;
 
     private readonly ITemplateEngine _templateEngine;
-    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IGenericEntityService _entityService;
     private readonly ILogger<QueryDataverseNodeExecutor> _logger;
 
     public QueryDataverseNodeExecutor(
         ITemplateEngine templateEngine,
-        IHttpClientFactory httpClientFactory,
+        IGenericEntityService entityService,
         ILogger<QueryDataverseNodeExecutor> logger)
     {
         _templateEngine = templateEngine;
-        _httpClientFactory = httpClientFactory;
+        _entityService = entityService;
         _logger = logger;
     }
 
@@ -110,10 +119,7 @@ public sealed class QueryDataverseNodeExecutor : INodeExecutor
                 config.EntityLogicalName,
                 resolvedFetchXml.Length);
 
-            var results = await ExecuteFetchXmlAsync(
-                config.EntityLogicalName!,
-                resolvedFetchXml,
-                cancellationToken);
+            var results = await ExecuteFetchXmlAsync(resolvedFetchXml, cancellationToken);
 
             _logger.LogInformation(
                 "QueryDataverse node {NodeId} completed -- entity: {Entity}, results: {ResultCount}",
@@ -195,78 +201,44 @@ public sealed class QueryDataverseNodeExecutor : INodeExecutor
     }
 
     private async Task<List<Dictionary<string, object?>>> ExecuteFetchXmlAsync(
-        string entityLogicalName,
         string fetchXml,
         CancellationToken cancellationToken)
     {
-        var client = _httpClientFactory.CreateClient("DataverseApi");
-        var entitySetName = GetEntitySetName(entityLogicalName);
-        var encodedFetchXml = Uri.EscapeDataString(fetchXml);
-        var requestUrl = $"{entitySetName}?fetchXml={encodedFetchXml}";
+        var entityCollection = await _entityService.RetrieveMultipleAsync(
+            new FetchExpression(fetchXml), cancellationToken);
 
-        _logger.LogDebug("Executing FetchXML query against {EntitySet}", entitySetName);
-
-        var response = await client.GetAsync(requestUrl, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
+        var results = new List<Dictionary<string, object?>>(entityCollection.Entities.Count);
+        foreach (var entity in entityCollection.Entities)
         {
-            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            _logger.LogError(
-                "FetchXML query failed with status {StatusCode}: {ErrorContent}",
-                response.StatusCode,
-                errorContent.Length > 500 ? errorContent[..500] : errorContent);
-
-            throw new HttpRequestException(
-                $"Dataverse FetchXML query failed with status {(int)response.StatusCode}: {response.ReasonPhrase}");
-        }
-
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        using var doc = JsonDocument.Parse(content);
-        var results = new List<Dictionary<string, object?>>();
-
-        if (doc.RootElement.TryGetProperty("value", out var valueArray))
-        {
-            foreach (var item in valueArray.EnumerateArray())
+            var record = new Dictionary<string, object?>(entity.Attributes.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (var (key, value) in entity.Attributes)
             {
-                var record = new Dictionary<string, object?>();
-                foreach (var prop in item.EnumerateObject())
-                {
-                    if (prop.Name.StartsWith("@odata.") || prop.Name.StartsWith("@Microsoft."))
-                        continue;
-
-                    record[prop.Name] = prop.Value.ValueKind switch
-                    {
-                        JsonValueKind.String => prop.Value.GetString(),
-                        JsonValueKind.Number => prop.Value.TryGetInt64(out var l) ? l : prop.Value.GetDouble(),
-                        JsonValueKind.True => true,
-                        JsonValueKind.False => false,
-                        JsonValueKind.Null => null,
-                        _ => prop.Value.GetRawText()
-                    };
-                }
-                results.Add(record);
+                record[key] = ConvertAttributeValue(value);
             }
+            results.Add(record);
         }
-
         return results;
     }
 
-    private static string GetEntitySetName(string entityLogicalName)
+    /// <summary>
+    /// Converts an SDK <see cref="Entity"/> attribute value into a primitive shape
+    /// suitable for downstream template substitution. Mirrors the scalar values
+    /// the Web API previously returned (e.g. lookups → GUID string, option sets → int).
+    /// </summary>
+    private static object? ConvertAttributeValue(object? value)
     {
-        return entityLogicalName switch
+        return value switch
         {
-            "sprk_event" => "sprk_events",
-            "sprk_document" => "sprk_documents",
-            "sprk_matter" => "sprk_matters",
-            "sprk_project" => "sprk_projects",
-            "sprk_todoitem" => "sprk_todoitems",
-            "account" => "accounts",
-            "contact" => "contacts",
-            "task" => "tasks",
-            "email" => "emails",
-            "appointment" => "appointments",
-            "appnotification" => "appnotifications",
-            _ => entityLogicalName.EndsWith("s") ? entityLogicalName : entityLogicalName + "s"
+            null => null,
+            AliasedValue av => ConvertAttributeValue(av.Value),
+            EntityReference er => er.Id.ToString(),
+            OptionSetValue osv => osv.Value,
+            OptionSetValueCollection osvc => osvc.Select(x => x.Value).ToArray(),
+            Money m => m.Value,
+            Guid g => g.ToString(),
+            DateTime dt => dt.ToString("o"),
+            DateTimeOffset dto => dto.ToString("o"),
+            _ => value
         };
     }
 }

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs
@@ -171,9 +171,11 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         ChannelWriter<PlaybookStreamEvent> writer,
         CancellationToken cancellationToken)
     {
+        _logger.LogWarning("[DBG-DAILY] AppOnlyInternal ENTRY runId={RunId} playbookId={PlaybookId}", context.RunId, request.PlaybookId);
         try
         {
             var nodes = await _nodeService.GetNodesAsync(request.PlaybookId, cancellationToken);
+            _logger.LogWarning("[DBG-DAILY] AppOnlyInternal GetNodesAsync returned count={Count} for playbook={PlaybookId}", nodes.Length, request.PlaybookId);
 
             if (nodes.Length == 0)
             {
@@ -192,8 +194,11 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
             _logger.LogInformation(
                 "App-only mode: Playbook {PlaybookId} has {NodeCount} nodes — using node-based execution",
                 request.PlaybookId, nodes.Length);
+            _logger.LogWarning("[DBG-DAILY] AppOnlyInternal nodes=[{Names}] entering NodeBasedMode for playbook={PlaybookId}",
+                string.Join(",", nodes.Select(n => $"{n.Name}(nt={n.NodeType})")), request.PlaybookId);
 
             await ExecuteNodeBasedModeAsync(context, nodes, writer, cancellationToken);
+            _logger.LogWarning("[DBG-DAILY] AppOnlyInternal ExecuteNodeBasedModeAsync returned for playbook={PlaybookId}", request.PlaybookId);
         }
         catch (OperationCanceledException)
         {
@@ -638,11 +643,13 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         ChannelWriter<PlaybookStreamEvent> writer,
         CancellationToken cancellationToken)
     {
+        _logger.LogWarning("[DBG-DAILY] NodeBased ENTRY runId={RunId} playbookId={PlaybookId} nodeCount={Count}", context.RunId, context.PlaybookId, nodes.Length);
         context.MarkRunning();
 
         // Build execution graph
         var graph = new ExecutionGraph(nodes);
         var totalNodes = graph.NodeCount;
+        _logger.LogWarning("[DBG-DAILY] NodeBased graph built totalNodes={TotalNodes} for playbook={PlaybookId}", totalNodes, context.PlaybookId);
 
         _logger.LogDebug(
             "Built execution graph for playbook {PlaybookId}: {NodeCount} active nodes",
@@ -654,6 +661,7 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
 
         // Get execution batches for parallel processing
         var batches = graph.GetExecutionBatches();
+        _logger.LogWarning("[DBG-DAILY] NodeBased batches={BatchCount} for playbook={PlaybookId}", batches.Count, context.PlaybookId);
 
         _logger.LogDebug(
             "Execution batches for playbook {PlaybookId}: {BatchCount} batches",
@@ -667,6 +675,8 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         foreach (var batch in batches)
         {
             batchNumber++;
+            _logger.LogWarning("[DBG-DAILY] NodeBased batch={N}/{Total} nodes=[{Names}] playbook={PlaybookId}",
+                batchNumber, batches.Count, string.Join(",", batch.Select(n => n.Name)), context.PlaybookId);
 
             if (context.CancellationToken.IsCancellationRequested)
             {
@@ -879,6 +889,8 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         ChannelWriter<PlaybookStreamEvent> writer,
         CancellationToken cancellationToken)
     {
+        _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync ENTRY node={Name} nodeType={Type} runId={RunId} playbookId={PlaybookId}",
+            node.Name, node.NodeType, runContext.RunId, runContext.PlaybookId);
         _logger.LogDebug("Executing node {NodeId}: {NodeName}", node.Id, node.Name);
 
         // Write start event
@@ -1116,6 +1128,8 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
 
             // Get executor for action type
             var executor = _executorRegistry.GetExecutor(actionType);
+            _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync EXECUTOR LOOKUP node={Name} actionType={ActionType} found={Found}",
+                node.Name, actionType, executor != null);
             if (executor == null)
             {
                 var errorMsg = $"No executor registered for action type '{actionType}'";
@@ -1216,8 +1230,11 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
             }
 
             // Execute the node
+            _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync CALLING executor for node={Name} actionType={ActionType}", node.Name, actionType);
             _logger.LogDebug("Calling executor for node {NodeName}", node.Name);
             var output = await executor.ExecuteAsync(nodeContext, runContext.CancellationToken);
+            _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync EXECUTOR RETURNED node={Name} success={Success} hasError={HasError}",
+                node.Name, output.Success, !string.IsNullOrEmpty(output.ErrorMessage));
 
             // Store output for downstream nodes
             runContext.StoreNodeOutput(output);

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/PlaybookOrchestrationService.cs
@@ -171,11 +171,9 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         ChannelWriter<PlaybookStreamEvent> writer,
         CancellationToken cancellationToken)
     {
-        _logger.LogWarning("[DBG-DAILY] AppOnlyInternal ENTRY runId={RunId} playbookId={PlaybookId}", context.RunId, request.PlaybookId);
         try
         {
             var nodes = await _nodeService.GetNodesAsync(request.PlaybookId, cancellationToken);
-            _logger.LogWarning("[DBG-DAILY] AppOnlyInternal GetNodesAsync returned count={Count} for playbook={PlaybookId}", nodes.Length, request.PlaybookId);
 
             if (nodes.Length == 0)
             {
@@ -194,11 +192,8 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
             _logger.LogInformation(
                 "App-only mode: Playbook {PlaybookId} has {NodeCount} nodes — using node-based execution",
                 request.PlaybookId, nodes.Length);
-            _logger.LogWarning("[DBG-DAILY] AppOnlyInternal nodes=[{Names}] entering NodeBasedMode for playbook={PlaybookId}",
-                string.Join(",", nodes.Select(n => $"{n.Name}(nt={n.NodeType})")), request.PlaybookId);
 
             await ExecuteNodeBasedModeAsync(context, nodes, writer, cancellationToken);
-            _logger.LogWarning("[DBG-DAILY] AppOnlyInternal ExecuteNodeBasedModeAsync returned for playbook={PlaybookId}", request.PlaybookId);
         }
         catch (OperationCanceledException)
         {
@@ -643,13 +638,11 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         ChannelWriter<PlaybookStreamEvent> writer,
         CancellationToken cancellationToken)
     {
-        _logger.LogWarning("[DBG-DAILY] NodeBased ENTRY runId={RunId} playbookId={PlaybookId} nodeCount={Count}", context.RunId, context.PlaybookId, nodes.Length);
         context.MarkRunning();
 
         // Build execution graph
         var graph = new ExecutionGraph(nodes);
         var totalNodes = graph.NodeCount;
-        _logger.LogWarning("[DBG-DAILY] NodeBased graph built totalNodes={TotalNodes} for playbook={PlaybookId}", totalNodes, context.PlaybookId);
 
         _logger.LogDebug(
             "Built execution graph for playbook {PlaybookId}: {NodeCount} active nodes",
@@ -661,7 +654,6 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
 
         // Get execution batches for parallel processing
         var batches = graph.GetExecutionBatches();
-        _logger.LogWarning("[DBG-DAILY] NodeBased batches={BatchCount} for playbook={PlaybookId}", batches.Count, context.PlaybookId);
 
         _logger.LogDebug(
             "Execution batches for playbook {PlaybookId}: {BatchCount} batches",
@@ -675,8 +667,6 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         foreach (var batch in batches)
         {
             batchNumber++;
-            _logger.LogWarning("[DBG-DAILY] NodeBased batch={N}/{Total} nodes=[{Names}] playbook={PlaybookId}",
-                batchNumber, batches.Count, string.Join(",", batch.Select(n => n.Name)), context.PlaybookId);
 
             if (context.CancellationToken.IsCancellationRequested)
             {
@@ -889,8 +879,6 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
         ChannelWriter<PlaybookStreamEvent> writer,
         CancellationToken cancellationToken)
     {
-        _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync ENTRY node={Name} nodeType={Type} runId={RunId} playbookId={PlaybookId}",
-            node.Name, node.NodeType, runContext.RunId, runContext.PlaybookId);
         _logger.LogDebug("Executing node {NodeId}: {NodeName}", node.Id, node.Name);
 
         // Write start event
@@ -1128,8 +1116,6 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
 
             // Get executor for action type
             var executor = _executorRegistry.GetExecutor(actionType);
-            _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync EXECUTOR LOOKUP node={Name} actionType={ActionType} found={Found}",
-                node.Name, actionType, executor != null);
             if (executor == null)
             {
                 var errorMsg = $"No executor registered for action type '{actionType}'";
@@ -1230,11 +1216,8 @@ public class PlaybookOrchestrationService : IPlaybookOrchestrationService
             }
 
             // Execute the node
-            _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync CALLING executor for node={Name} actionType={ActionType}", node.Name, actionType);
             _logger.LogDebug("Calling executor for node {NodeName}", node.Name);
             var output = await executor.ExecuteAsync(nodeContext, runContext.CancellationToken);
-            _logger.LogWarning("[DBG-DAILY] ExecuteNodeAsync EXECUTOR RETURNED node={Name} success={Success} hasError={HasError}",
-                node.Name, output.Success, !string.IsNullOrEmpty(output.ErrorMessage));
 
             // Store output for downstream nodes
             runContext.StoreNodeOutput(output);


### PR DESCRIPTION
## Summary

Cherry-picks 3 unmerged BFF commits from `work/spaarke-daily-update-service-r2.3-orchestrator-diagnosis` onto master so that a pending bff-dev redeploy can include both this work AND the chat-routing-redesign-r1 work that just landed via PR #409.

**Context**: Discovered during PR #409 BFF deploy (2026-06-23) that `work/spaarke-daily-update-service-r2.3-orchestrator-diagnosis` had 3 BFF commits ahead of master that had been deployed to bff-dev. Without this cherry-pick, redeploying from master would have rolled back those fixes. This PR brings them into master so the redeploy is safe.

## Commits cherry-picked

| Original SHA | New SHA | Title |
|---|---|---|
| `46f03e630` | `5266ea779` | fix(daily-briefing): orchestrator-path bug diagnosis + AnalysisActionService SELECT fix |
| `3d617f0a6` | `c0683feaf` | fix(daily-briefing): refactor 3 node executors to use IGenericEntityService |
| `460e19d8d` | `9694b9d8a` | fix(daily-briefing): appnotification schema-compat — sprk_regardingid + sprk_regardingtype |

## Files touched

- `src/server/api/Sprk.Bff.Api/Services/Ai/AnalysisActionService.cs`
- `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs`
- `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateTaskNodeExecutor.cs`
- `src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/QueryDataverseNodeExecutor.cs`

## Verification

- ✅ Clean cherry-pick (no conflicts — PR #409 touched none of these 4 files)
- ✅ Local Release build: `dotnet build src/server/api/Sprk.Bff.Api/ -c Release` — 0 errors, 17 warnings (baseline)

## Why a separate cherry-pick branch instead of merging the original branch

The original branch `work/spaarke-daily-update-service-r2.3-orchestrator-diagnosis` is owned by a parallel project and has additional in-flight context. This PR isolates JUST the 3 already-deployed BFF fixes so master is safe to redeploy from immediately, while leaving the original project branch's other state untouched for its owner to handle separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)