### PR TITLE
fix(daily-briefing): bug #10 — template context navigates JsonElement

### DIFF
--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/ConditionNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/ConditionNodeExecutor.cs
@@ -466,10 +466,16 @@ public sealed class ConditionNodeExecutor : INodeExecutor
 
         foreach (var (varName, output) in context.PreviousOutputs)
         {
+            // 2026-06-24 (bug #10 fix): use TemplateEngine.ConvertJsonElement to recursively
+            // convert JsonElement → Dictionary<string,object?> so Handlebars can navigate
+            // nested paths like {{varName.output.count}}. The prior JsonSerializer.Deserialize<object>
+            // returned a JsonElement whose properties were invisible to Handlebars reflection,
+            // causing all such template expressions to render as empty strings and downstream
+            // numeric comparisons to throw "Cannot compare non-numeric value:".
             templateContext[varName] = new
             {
                 output = output.StructuredData.HasValue
-                    ? JsonSerializer.Deserialize<object>(output.StructuredData.Value.GetRawText())
+                    ? TemplateEngine.ConvertJsonElement(output.StructuredData.Value)
                     : null,
                 text = output.TextContent,
                 success = output.Success,

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateNotificationNodeExecutor.cs
@@ -554,10 +554,13 @@ public sealed class CreateNotificationNodeExecutor : INodeExecutor
 
         foreach (var (varName, output) in context.PreviousOutputs)
         {
+            // 2026-06-24 (bug #10 fix): use TemplateEngine.ConvertJsonElement so Handlebars
+            // can navigate nested paths like {{varName.output.count}}. See full rationale on
+            // the matching change in ConditionNodeExecutor.BuildTemplateContext.
             templateContext[varName] = new
             {
                 output = output.StructuredData.HasValue
-                    ? JsonSerializer.Deserialize<object>(output.StructuredData.Value.GetRawText())
+                    ? TemplateEngine.ConvertJsonElement(output.StructuredData.Value)
                     : null,
                 text = output.TextContent,
                 success = output.Success

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateTaskNodeExecutor.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Nodes/CreateTaskNodeExecutor.cs
@@ -227,10 +227,13 @@ public sealed class CreateTaskNodeExecutor : INodeExecutor
 
         foreach (var (varName, output) in context.PreviousOutputs)
         {
+            // 2026-06-24 (bug #10 fix): use TemplateEngine.ConvertJsonElement so Handlebars
+            // can navigate nested paths like {{varName.output.field}}. See full rationale on
+            // the matching change in ConditionNodeExecutor.BuildTemplateContext.
             templateContext[varName] = new
             {
                 output = output.StructuredData.HasValue
-                    ? JsonSerializer.Deserialize<object>(output.StructuredData.Value.GetRawText())
+                    ? TemplateEngine.ConvertJsonElement(output.StructuredData.Value)
                     : null,
                 text = output.TextContent,
                 success = output.Success


### PR DESCRIPTION
Final fix in the Daily Briefing 10-bug cascade. ConditionNodeExecutor + CreateNotificationNodeExecutor + CreateTaskNodeExecutor BuildTemplateContext used JsonSerializer.Deserialize<object> which returns JsonElement (invisible to Handlebars reflection). Replaced with TemplateEngine.ConvertJsonElement (canonical helper, already used by UpdateRecordNodeExecutor).

Master CI is informational-only since PR #449 — admin-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)