### PR TITLE
feat(devops): lifecycle dates — Start/Target/Closed + Quick Links + show-merges

### DIFF
--- a/.claude/skills/devops-portfolio-setup/SKILL.md
+++ b/.claude/skills/devops-portfolio-setup/SKILL.md
@@ -27,7 +27,7 @@ last-reviewed: 2026-06-23
 One-shot, idempotent bootstrap of the GitHub Project #2 portfolio schema so any clean repo + Project can be brought to a known-good state in seconds. Encodes everything Phase 1 (tasks 001–005) did manually:
 
 1. Extend `Type` field with `Project` option (preserve existing 6)
-2. Add 6 custom fields (`Project Type`, `Worktree Path`, `Project Folder`, `Task Count`, `Tasks Completed`, `Project Status`) with exact FR-02 schemas
+2. Add 6 custom fields (`Project Type`, `Worktree Path`, `Project Folder`, `Task Count`, `Tasks Completed`, `Status`) with exact FR-02 schemas
 3. Create 7 repository labels (`epic`, `project`, `backlog`, `worktree:active`, `worktree:archived`, `on-hold`, `cancelled`)
 4. Land 3 issue templates (`epic.yml`, `project.yml`, `idea.yml`) at `.github/ISSUE_TEMPLATE/`
 
@@ -132,7 +132,7 @@ For each missing field, execute `createProjectV2Field` mutation per the schemas 
 - `Project Folder` — TEXT
 - `Task Count` — NUMBER
 - `Tasks Completed` — NUMBER
-- `Project Status` — SINGLE_SELECT with 5 options (`Planned, In Progress, On Hold, Completed, Cancelled`)
+- `Status` — SINGLE_SELECT with 5 options (`Planned, In Progress, On Hold, Completed, Cancelled`)
 
 Field creation is purely additive — no reconciliation needed because new fields have no existing item references.
 

--- a/.claude/skills/devops-portfolio-status/SKILL.md
+++ b/.claude/skills/devops-portfolio-status/SKILL.md
@@ -42,7 +42,7 @@ query {
           content { ... on Issue { number title url } }
           fieldValues(first: 30) {
             nodes {
-              # Extract: Type, Project Type, Project Status, Parent issue, Task Count, Tasks Completed
+              # Extract: Type, Project Type, Status, Parent issue, Task Count, Tasks Completed
             }
           }
         }

--- a/.claude/skills/devops-project-archive/SKILL.md
+++ b/.claude/skills/devops-project-archive/SKILL.md
@@ -1,43 +1,46 @@
 ---
-description: Archive a completed or cancelled project — set Status, capture counts, close Issue, DELETE worktree, retain folder + .archived marker. DESTRUCTIVE. Per FR-14 + D-18 + NFR-09 of spaarke-devops-project-tracking-r1.
-tags: [devops, project-archive, destructive, worktree-delete, gh-cli, git]
+description: Archive a completed or cancelled project — set Status, set Closed Date, capture counts, close Issue, retain folder + .archived marker. Worktree is PRESERVED for separate cleanup (override of D-18/NFR-09 per operator workflow). Per FR-14 of spaarke-devops-project-tracking-r1.
+tags: [devops, project-archive, gh-cli, git]
 techStack: [gh-cli, graphql, git, python]
 appliesTo: ["/devops-project-archive", "archive project", "close project"]
 alwaysApply: false
-last-reviewed: 2026-06-23
+last-reviewed: 2026-06-25
 ---
 
 # devops-project-archive
 
 > **Category**: DevOps / Portfolio
-> **Tier**: Destructive — removes git worktree. Requires explicit confirmation.
-> **Last Reviewed**: 2026-06-23
+> **Tier**: Non-destructive — closes Issue state only. Worktree preserved.
+> **Last Reviewed**: 2026-06-25 (worktree-deletion behavior REMOVED per operator workflow change)
 
-## ⚠️ DESTRUCTIVE ACTION WARNING
+## What this skill does (and doesn't)
 
-This skill **DELETES the local git worktree** for a project. Uncommitted work in the worktree will be lost if the skill is run without `--force` AND the worktree has uncommitted changes.
+**Does**: closes out the Project Issue cleanly — sets Status, captures Closed Date, captures final task counts, closes the Issue, writes a local `.archived` marker file.
 
-The `projects/{name}/` folder is RETAINED with a new `.archived` marker file per D-18 + NFR-09.
+**Does NOT**: delete the worktree. Spaarke operators **keep worktrees long after project archive** as long-lived dev environments. Worktree cleanup is a separate workflow (manual `git worktree remove`, or a dedicated cleanup skill if/when one exists).
+
+**Spec deviation note**: This overrides the original D-18 / NFR-09 in `spec.md` which called for worktree deletion. The override is operator-driven (decision: 2026-06-25 walkthrough feedback).
 
 ## Prerequisites
 
 - `gh` CLI v2.40+ authenticated
 - `/devops-portfolio-setup` + `/devops-project-sync` available
 - A registered Project Issue exists for the target project
-- Worktree exists at `c:/code_files/spaarke-wt-{slug}` (or skill no-ops on worktree deletion if missing)
 - All POML tasks complete (for `--status Completed`) OR explicit user decision to cancel (for `--status Cancelled`)
+
+(No worktree-state prerequisites — the worktree is preserved untouched.)
 
 ## Purpose
 
 Close out a project cleanly:
 1. Set `Status` field (Completed or Cancelled)
-2. Capture final `Task Count` / `Tasks Completed` values (via `/devops-project-sync`)
-3. Close the GitHub Issue with appropriate state (`Status=Done` or label `cancelled`)
-4. Delete the local git worktree via `git worktree remove`
-5. Retain `projects/{name}/` folder
-6. Write `.archived` marker file with archive date + final status + closing PR # (if any)
+2. Set `Closed Date` field (from PR merge date if provided, else today)
+3. Capture final `Task Count` / `Tasks Completed` values (via `/devops-project-sync`)
+4. Close the GitHub Issue with appropriate state (`Status=Done` or label `cancelled`)
+5. **Retain** `projects/{name}/` folder + worktree (no destructive operations)
+6. Write `.archived` marker file with archive date + final status + closing PR # (if any) + note that worktree is intentionally preserved
 
-Remote branch is **preserved** per NFR-09 — branch history stays on GitHub for audit.
+Remote branch is preserved — branch history stays on GitHub for audit.
 
 ## Workflow
 
@@ -48,120 +51,89 @@ Required:
 
 Optional:
 - `--pr-number <#M>` — closing PR # (auto-detected via `gh pr list --head <branch>` if not provided)
-- `--force` — proceed even if worktree has uncommitted changes
 - `--folder <projects/{name}>` — defaults to current folder
 
-### Step 1: Discover Project Issue + worktree
+(No `--force` flag — the skill is non-destructive, so there's nothing to force past.)
+
+### Step 1: Discover Project Issue
 
 - Read `projects/{name}/README.md` portfolio pointer block → Issue #N
-- `git worktree list` → confirm worktree path (or report no-op if already removed)
+- Note the worktree path (for inclusion in the `.archived` marker) — not modified.
 
-### Step 2: Safety check — uncommitted changes
-
-```bash
-cd c:/code_files/spaarke-wt-{slug}
-git status --porcelain
-```
-
-If output is non-empty AND `--force` not provided:
+### Step 2: Confirm prompt (light)
 
 ```
-ERROR: Worktree has uncommitted changes:
-  M  file1.cs
-  ?? file2.ts
-
-Refusing to delete worktree. Options:
-  1. Commit + push, then re-run.
-  2. Stash, then re-run.
-  3. Re-run with --force (uncommitted work will be LOST).
-```
-
-STOP unless `--force`.
-
-### Step 3: Confirm prompt (mandatory)
-
-```
-About to ARCHIVE project:
-  Folder:    projects/{name}/
-  Worktree:  c:/code_files/spaarke-wt-{slug} (will be DELETED)
-  Issue:     #N
+About to ARCHIVE project (close-out only — worktree preserved):
+  Folder:    projects/{name}/        (kept)
+  Worktree:  c:/code_files/spaarke-wt-{slug}  (kept — clean up separately if/when desired)
+  Issue:     #N                       (will be closed)
   Status:    {Completed|Cancelled}
-  PR:        #M (closing PR reference)
+  PR:        #M                       (closing PR reference)
 
-Proceed? [y/N]
+Proceed? [Y/n]
 ```
 
-Default: N. Require explicit `y` to proceed.
+Default: Y (non-destructive). Operator can still N to cancel.
 
-### Step 4: Final field sync
+### Step 3: Final field sync
 
 Invoke `/devops-project-sync` to capture latest field values (Task Count, Tasks Completed) BEFORE we close the Issue.
 
-### Step 5: Update Issue fields + close
+### Step 4: Update Issue fields + close
 
 - Set `Status` field to `Completed` or `Cancelled` (per --status)
 - **Set `Closed Date` field** (field ID: `PVTF_lAHODW0Pv84BEgWuzhWYfL4`, type DATE):
   - If `--pr-number #M` provided: use the PR's merge date (`gh pr view #M --json mergedAt --jq .mergedAt`, take the date prefix YYYY-MM-DD). This is the truest "actual end".
   - Else: use today's date.
   - Mutation: `updateProjectV2ItemFieldValue` with `value: { date: "YYYY-MM-DD" }`.
-- Add comment to Issue: `Archived via /devops-project-archive on {date}. Closing PR: #M. Closed Date set to {merge-or-today}.`
+- Add comment to Issue: `Archived via /devops-project-archive on {date}. Closing PR: #M. Closed Date set to {merge-or-today}. Worktree at {worktree-path} preserved.`
 - For Completed: `gh project item-edit ... --status Done` (or analogous mutation)
 - For Cancelled: add label `cancelled`
 - Close Issue: `gh issue close <#N> --comment "..."`
 
 **Drift calculation note**: After this Step, both `Target Date` (set at project setup) and `Closed Date` (set here) are populated. A Project #2 view can compute drift = `Closed Date − Target Date` (positive = late, negative = early). Project status reports + `scripts/portfolio-status.py --show-drift` can surface this.
 
-### Step 6: Delete worktree
-
-```bash
-git worktree remove c:/code_files/spaarke-wt-{slug}
-git worktree list  # Verify removed
-```
-
-If `--force`, also `git worktree remove --force` if uncommitted changes were present (per Step 2 user ack).
-
-### Step 7: Retain folder + write `.archived` marker
+### Step 5: Write `.archived` marker (folder + worktree both preserved)
 
 Write `projects/{name}/.archived`:
 
 ```
-Archived: 2026-06-23
+Archived: {YYYY-MM-DD}
 Final status: {Completed|Cancelled}
 Closing PR: #M (https://github.com/spaarke-dev/spaarke/pull/M)
-Worktree removed: c:/code_files/spaarke-wt-{slug}
-Remote branch preserved: work/{slug} (still on origin)
+Worktree: c:/code_files/spaarke-wt-{slug} (PRESERVED — not removed by this skill; clean up separately if desired)
+Remote branch: work/{slug} (still on origin)
 Issue: #N (closed)
 ```
 
-Per NFR-09 — folder + `.archived` survive; worktree gone; remote branch preserved.
+The folder + `.archived` mark this project as closed. The worktree remains usable — operator can revisit, re-run tools, or clean up at their own cadence (via a separate workflow, not this skill).
 
-### Step 8: Report
+### Step 6: Report
 
 ```
 Archived project: projects/{name}/
-  Issue #N closed (Status=Completed)
-  Worktree c:/code_files/spaarke-wt-{slug} removed
-  .archived marker written
+  Issue #N closed (Status=Completed, Closed Date=YYYY-MM-DD)
+  Folder retained with .archived marker
+  Worktree c:/code_files/spaarke-wt-{slug} PRESERVED (clean up separately if desired)
   Remote branch work/{slug} preserved on origin
 ```
 
 ## Outputs
 
-- Worktree deleted (irreversible without re-clone)
-- `projects/{name}/.archived` marker file
-- Issue #N closed with Status=Completed or Cancelled
+- `projects/{name}/.archived` marker file (worktree path noted as preserved)
+- Issue #N closed with Status=Completed or Cancelled + Closed Date set
+- Folder + worktree both untouched on local filesystem
 - 1 line confirmation
 
 ## Failure Modes
 
 | Failure | Cause | Recovery |
 |---|---|---|
-| Worktree has uncommitted changes; `--force` not provided | Safety gate working as designed | User stashes/commits, then re-runs |
-| `git worktree remove` fails | Filesystem locked file in worktree (e.g., open file in editor) | Close editor; re-run. Or `git worktree remove --force` after ack. |
 | Issue close fails (rate limit) | Concurrent operations | Re-run skill — idempotency ensures state is healed |
 | `.archived` marker write fails | Permission issue | Skill warns; user manually creates the marker |
-| Confirm prompt not respected | UI/script bug | Mandatory user `y` per Step 3 — this is the safety contract |
-| Skill run twice on same project | User unsure if first run completed | Idempotent — second run detects worktree already gone + Issue already closed + .archived already present; reports no-op |
+| Skill run twice on same project | User unsure if first run completed | Idempotent — second run detects Issue already closed + `.archived` already present; reports no-op |
+| Project has no portfolio pointer block | Project never registered | Run `/devops-project-register --from-folder` first |
+| `--pr-number` references a non-merged PR | Wrong PR number provided | Skill warns; uses today's date as Closed Date fallback |
 
 ## Related Skills
 
@@ -172,6 +144,7 @@ Archived project: projects/{name}/
 
 ## Reference
 
-- Spec: FR-14 + D-18 (worktree delete, folder retain) + NFR-09 (remote branch preserved) + F3 (explicit gate, NOT auto-archive on merge)
+- Spec: FR-14 (close-out semantics) + F3 (explicit gate, NOT auto-archive on merge)
+- **Spec override (2026-06-25)**: D-18 and NFR-09 in `spec.md` originally called for worktree deletion on archive. This skill no longer deletes the worktree — operator workflow keeps worktrees as long-lived dev environments. If a future use case requires worktree removal, build a separate `/devops-worktree-cleanup` skill rather than re-coupling here.
 - Idempotency: re-running on archived project is no-op
-- Sub-Agent Write Boundary: writes to `.git/worktrees/*` + `projects/<name>/.archived` — main session only (destructive)
+- Sub-Agent Write Boundary: writes to `projects/<name>/.archived` — main session only (touches local filesystem)

--- a/.claude/skills/devops-project-archive/SKILL.md
+++ b/.claude/skills/devops-project-archive/SKILL.md
@@ -100,10 +100,16 @@ Invoke `/devops-project-sync` to capture latest field values (Task Count, Tasks 
 ### Step 5: Update Issue fields + close
 
 - Set `Project Status` field to `Completed` or `Cancelled` (per --status)
-- Add comment to Issue: `Archived via /devops-project-archive on {date}. Closing PR: #M.`
+- **Set `Closed Date` field** (field ID: `PVTF_lAHODW0Pv84BEgWuzhWYfL4`, type DATE):
+  - If `--pr-number #M` provided: use the PR's merge date (`gh pr view #M --json mergedAt --jq .mergedAt`, take the date prefix YYYY-MM-DD). This is the truest "actual end".
+  - Else: use today's date.
+  - Mutation: `updateProjectV2ItemFieldValue` with `value: { date: "YYYY-MM-DD" }`.
+- Add comment to Issue: `Archived via /devops-project-archive on {date}. Closing PR: #M. Closed Date set to {merge-or-today}.`
 - For Completed: `gh project item-edit ... --status Done` (or analogous mutation)
 - For Cancelled: add label `cancelled`
 - Close Issue: `gh issue close <#N> --comment "..."`
+
+**Drift calculation note**: After this Step, both `Target Date` (set at project setup) and `Closed Date` (set here) are populated. A Project #2 view can compute drift = `Closed Date − Target Date` (positive = late, negative = early). Project status reports + `scripts/portfolio-status.py --show-drift` can surface this.
 
 ### Step 6: Delete worktree
 

--- a/.claude/skills/devops-project-archive/SKILL.md
+++ b/.claude/skills/devops-project-archive/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Archive a completed or cancelled project — set Project Status, capture counts, close Issue, DELETE worktree, retain folder + .archived marker. DESTRUCTIVE. Per FR-14 + D-18 + NFR-09 of spaarke-devops-project-tracking-r1.
+description: Archive a completed or cancelled project — set Status, capture counts, close Issue, DELETE worktree, retain folder + .archived marker. DESTRUCTIVE. Per FR-14 + D-18 + NFR-09 of spaarke-devops-project-tracking-r1.
 tags: [devops, project-archive, destructive, worktree-delete, gh-cli, git]
 techStack: [gh-cli, graphql, git, python]
 appliesTo: ["/devops-project-archive", "archive project", "close project"]
@@ -30,7 +30,7 @@ The `projects/{name}/` folder is RETAINED with a new `.archived` marker file per
 ## Purpose
 
 Close out a project cleanly:
-1. Set `Project Status` field (Completed or Cancelled)
+1. Set `Status` field (Completed or Cancelled)
 2. Capture final `Task Count` / `Tasks Completed` values (via `/devops-project-sync`)
 3. Close the GitHub Issue with appropriate state (`Status=Done` or label `cancelled`)
 4. Delete the local git worktree via `git worktree remove`
@@ -99,7 +99,7 @@ Invoke `/devops-project-sync` to capture latest field values (Task Count, Tasks 
 
 ### Step 5: Update Issue fields + close
 
-- Set `Project Status` field to `Completed` or `Cancelled` (per --status)
+- Set `Status` field to `Completed` or `Cancelled` (per --status)
 - **Set `Closed Date` field** (field ID: `PVTF_lAHODW0Pv84BEgWuzhWYfL4`, type DATE):
   - If `--pr-number #M` provided: use the PR's merge date (`gh pr view #M --json mergedAt --jq .mergedAt`, take the date prefix YYYY-MM-DD). This is the truest "actual end".
   - Else: use today's date.
@@ -139,7 +139,7 @@ Per NFR-09 — folder + `.archived` survive; worktree gone; remote branch preser
 
 ```
 Archived project: projects/{name}/
-  Issue #N closed (Project Status=Completed)
+  Issue #N closed (Status=Completed)
   Worktree c:/code_files/spaarke-wt-{slug} removed
   .archived marker written
   Remote branch work/{slug} preserved on origin
@@ -149,7 +149,7 @@ Archived project: projects/{name}/
 
 - Worktree deleted (irreversible without re-clone)
 - `projects/{name}/.archived` marker file
-- Issue #N closed with Project Status=Completed or Cancelled
+- Issue #N closed with Status=Completed or Cancelled
 - 1 line confirmation
 
 ## Failure Modes

--- a/.claude/skills/devops-project-register/SKILL.md
+++ b/.claude/skills/devops-project-register/SKILL.md
@@ -45,6 +45,7 @@ Optional:
 - `projects/{name}/tasks/TASK-INDEX.md` (compute Task Count + Tasks Completed)
 - Worktree state via `git worktree list` (path + branch)
 - Last commit date: `git log -1 --format=%cd --date=iso work/{name}` if the branch exists
+- **Folder-creation date** (used for Start Date): `git log --all --diff-filter=A --reverse --format=%cI -- projects/{name}/ | head -1` then take the YYYY-MM-DD prefix. This is more reliable than "first commit on branch" because already-merged branches show post-merge commits first.
 
 ### Step 2: Idempotency check
 
@@ -76,9 +77,26 @@ This matches the F6 active/in-flight definition + plays well with `/devops-proje
 
 ### Step 4: Compose Project Issue body
 
-Use `project.yml` template field structure:
+Body has two parts: (a) Quick Links table at the very top (above the DO-NOT-EDIT marker so syncs don't churn it), then (b) the sync-driven content.
 
 ```markdown
+### Quick Links
+
+| Project Surface | Link |
+|---|---|
+| Task Index (POML tasks) | [`tasks/TASK-INDEX.md`](https://github.com/spaarke-dev/spaarke/blob/master/projects/{slug}/tasks/TASK-INDEX.md) |
+| Project Folder | [`projects/{slug}/`](https://github.com/spaarke-dev/spaarke/tree/master/projects/{slug}/) |
+| Project README | [`README.md`](https://github.com/spaarke-dev/spaarke/blob/master/projects/{slug}/README.md) |
+| Plan | [`plan.md`](https://github.com/spaarke-dev/spaarke/blob/master/projects/{slug}/plan.md) |
+| Parent Epic | [Epic #{epic}](https://github.com/spaarke-dev/spaarke/issues/{epic}) |
+| Portfolio Board | [Project #2](https://github.com/users/spaarke-dev/projects/2) |
+
+> _Links resolve on master. If the project folder isn't on master yet, swap `master` for the feature branch name._
+
+---
+
+<!-- DO NOT EDIT — synced from README.md by /devops-project-sync -->
+
 ### Project Folder Slug
 {slug}
 
@@ -94,15 +112,11 @@ Use `project.yml` template field structure:
 ### Project Summary
 {first 2-3 lines from spec.md or README.md if available}
 
-### Projected Start Date
-(unknown — backfilled from existing worktree)
-
-### Projected Target Date
-(unknown — backfilled from existing worktree)
-
 ### Notes / Context
 Registered by /devops-project-register on {date}. Source: existing local worktree at {worktree_path}.
 ```
+
+Note: Start Date and Target Date are NOT in the body — they're set as Project #2 custom field values (Step 5), so they appear in the right-side panel + are filterable in views. Putting them only in the body would make them invisible to view filters.
 
 ### Step 5: Create Issue + add to Project + populate fields
 
@@ -112,7 +126,7 @@ gh issue create --title "[Project]: ${slug}" --body-file ... --label project
 gh project item-add 2 --owner spaarke-dev --url <url> --format json
 # Capture item_id
 
-# Set all 6 new fields via updateProjectV2ItemFieldValue mutations:
+# Set all 7 portfolio fields via updateProjectV2ItemFieldValue mutations:
 # - Type = Project
 # - Project Type = <project-type>
 # - Worktree Path = <worktree_path>
@@ -120,8 +134,9 @@ gh project item-add 2 --owner spaarke-dev --url <url> --format json
 # - Task Count = <count>
 # - Tasks Completed = <completed>
 # - Project Status = <heuristic from Step 3>
+# - Start Date = <folder-creation date from Step 1, as YYYY-MM-DD>
 
-# Set Parent issue = Epic #E
+# Set Parent issue = Epic #E (use REST API sub_issues endpoint with -F integer flag for typed parameter)
 ```
 
 ### Step 6: Write/update README pointer block
@@ -129,6 +144,23 @@ gh project item-add 2 --owner spaarke-dev --url <url> --format json
 If `projects/{name}/README.md` lacks the `> **Portfolio**:` pointer block, insert it at top.
 
 If the block exists but Issue # is wrong (e.g., a prior failed register), update it.
+
+### Step 6.5: Prompt for projected Target Date (optional)
+
+After Steps 1–6 complete, prompt the operator:
+
+```
+Project registered as #N (Start Date = {folder-creation-date}, Task Count = {N}).
+
+Set a projected Target Date for this project? (YYYY-MM-DD, or 'skip' to leave blank)
+> 
+```
+
+- If the operator enters a valid ISO date (YYYY-MM-DD), set the `Target Date` field via `updateProjectV2ItemFieldValue` with `value: { date: "..." }`.
+- If they enter `skip` or blank, leave Target Date null — they can set it later via the GitHub UI or by re-running this skill.
+- If their input doesn't parse as ISO date, reject and re-prompt once. Second invalid input = skip.
+
+**Why this is optional**: For backfill scenarios (registering an existing folder), the operator may not know the target yet — let them defer. For `/project-pipeline` invocations, the prompt fires after the WBS is generated so the operator has effort estimates to inform the projection.
 
 ### Step 7: Report
 

--- a/.claude/skills/devops-project-register/SKILL.md
+++ b/.claude/skills/devops-project-register/SKILL.md
@@ -22,7 +22,7 @@ last-reviewed: 2026-06-23
 
 ## Purpose
 
-Inverse direction of `/devops-project-start`. For an *existing* worktree/folder without a Project Issue, create the Project Issue and populate fields from local state (Worktree Path, Project Folder, Task Count, Tasks Completed, Project Status).
+Inverse direction of `/devops-project-start`. For an *existing* worktree/folder without a Project Issue, create the Project Issue and populate fields from local state (Worktree Path, Project Folder, Task Count, Tasks Completed, Status).
 
 Phase 3 backfill of `spaarke-devops-project-tracking-r1` calls this skill for each active worktree (~20–30 projects).
 
@@ -56,7 +56,7 @@ Query: is there already a Project Issue for this folder? Check via:
 
 If found, report no-op + return Issue URL.
 
-### Step 3: Compute Project Status heuristic
+### Step 3: Compute Status heuristic
 
 ```
 IF tasks_completed == task_count AND task_count > 0:
@@ -133,7 +133,7 @@ gh project item-add 2 --owner spaarke-dev --url <url> --format json
 # - Project Folder = projects/<name>
 # - Task Count = <count>
 # - Tasks Completed = <completed>
-# - Project Status = <heuristic from Step 3>
+# - Status = <heuristic from Step 3>
 # - Start Date = <folder-creation date from Step 1, as YYYY-MM-DD>
 
 # Set Parent issue = Epic #E (use REST API sub_issues endpoint with -F integer flag for typed parameter)
@@ -169,7 +169,7 @@ Project registered: #N at <url>
   Worktree Path: <path>
   Task Count: <count>
   Tasks Completed: <completed>
-  Project Status: <status>
+  Status: <status>
   Parent Epic: #E
 ```
 
@@ -186,7 +186,7 @@ Project registered: #N at <url>
 | Folder doesn't exist | Wrong path | Provide correct `--from-folder` |
 | `--epic <#E>` missing | D-12 enforcement | Provide `--epic`; re-run |
 | Folder already registered | Re-run after success | Idempotent — reports current state, returns Issue URL |
-| Cannot compute Project Status | Worktree missing, no PR, no commits | Falls back to `Planned`; user can manually adjust |
+| Cannot compute Status | Worktree missing, no PR, no commits | Falls back to `Planned`; user can manually adjust |
 | `spec.md` absent | Brand-new folder | Skill registers with placeholder summary; user runs `/design-to-spec` later |
 | Task Count != ls *.poml | Stale POMLs in tasks/ | Skill counts files; user can re-sync via `/devops-project-sync` |
 

--- a/.claude/skills/devops-project-start/SKILL.md
+++ b/.claude/skills/devops-project-start/SKILL.md
@@ -137,14 +137,14 @@ mutation {
 
 Same for `Project Folder` field with value `projects/<folder_name>`.
 
-If `Project Status` is `Planned`, change to `In Progress` (since worktree now exists).
+If `Status` is `Planned`, change to `In Progress` (since worktree now exists).
 
 ### Step 6: Write portfolio pointer block in local README.md
 
 Render:
 
 ```markdown
-> **Portfolio**: GitHub Issue [#N](url) · Epic: [#E](url) · Project Status: In Progress · [Portfolio board view](https://github.com/users/spaarke-dev/projects/2)
+> **Portfolio**: GitHub Issue [#N](url) · Epic: [#E](url) · Status: In Progress · [Portfolio board view](https://github.com/users/spaarke-dev/projects/2)
 
 # {Project Title}
 
@@ -164,7 +164,7 @@ Project scaffolded:
   Folder:    projects/{folder_name}/
   Worktree:  c:/code_files/spaarke-wt-{folder_name}
   Branch:    work/{folder_name}
-  Issue:     #N (Project Status: In Progress; fields populated)
+  Issue:     #N (Status: In Progress; fields populated)
 
 Next step: cd projects/{folder_name} && /design-to-spec
 ```
@@ -173,7 +173,7 @@ Next step: cd projects/{folder_name} && /design-to-spec
 
 - `projects/<folder_name>/` (new folder, README + design.md)
 - `c:/code_files/spaarke-wt-<folder_name>/` (new git worktree on branch `work/<folder_name>`)
-- Project Issue #N: Worktree Path + Project Folder + Project Status fields populated
+- Project Issue #N: Worktree Path + Project Folder + Status fields populated
 - `notes/spikes/project-start-{date}.md` log entry (for replay/debug)
 
 ## Failure Modes

--- a/.claude/skills/devops-project-sync/SKILL.md
+++ b/.claude/skills/devops-project-sync/SKILL.md
@@ -39,8 +39,8 @@ This is the workhorse — most automation hooks call this skill at end-of-host-s
 - `tasks/*.poml` count → Task Count
 - `tasks/TASK-INDEX.md` rows with `✅` → Tasks Completed
 - `current-task.md` "Task" field → for in-progress detection
-- Worktree existence + last commit date → Project Status heuristic
-- Open PR for branch → also influences Project Status
+- Worktree existence + last commit date → Status heuristic
+- Open PR for branch → also influences Status
 
 ### Step 2: Query current Issue field values
 

--- a/.claude/skills/project-pipeline/SKILL.md
+++ b/.claude/skills/project-pipeline/SKILL.md
@@ -667,6 +667,61 @@ WHY create branch at this point:
 
 ---
 
+### Step 4.5: Prompt for projected Target Date (NEW — informed projection)
+
+**Action**:
+```
+IF projects/{name}/README.md has a portfolio pointer block (Project Issue exists):
+
+  COMPUTE summary the operator can use to make the projection:
+    - Task count from tasks/TASK-INDEX.md
+    - Phase count
+    - Estimated effort range (from plan.md "Timeline" / "Estimated Effort" fields)
+    - Critical path length if surfaced
+
+  PROMPT:
+    ┌─────────────────────────────────────────────────────────────────┐
+    │ Plan summary:                                                   │
+    │   - {N} tasks across {M} phases                                 │
+    │   - Estimated effort: {range from plan.md}                      │
+    │   - Critical path: {summary if available}                       │
+    │                                                                 │
+    │ Set a projected Target Date for this project?                   │
+    │ Format: YYYY-MM-DD (e.g., 2026-08-15), or 'skip' to leave blank│
+    │ >                                                               │
+    └─────────────────────────────────────────────────────────────────┘
+
+  IF operator enters valid ISO date:
+    Set `Target Date` field on the Project Issue via
+    updateProjectV2ItemFieldValue with value: { date: "YYYY-MM-DD" }
+    REPORT: "✅ Target Date set to {date}. Drift will be tracked at archive."
+
+  ELIF operator enters 'skip' or blank:
+    REPORT: "Target Date left blank. Set later via GitHub UI or re-run /devops-project-register."
+
+  ELIF input fails to parse:
+    Re-prompt ONCE. Second invalid = treat as 'skip'.
+
+ELSE (no portfolio pointer block — project not registered):
+  SKIP this step. The /devops-project-register hook (Step 1.7) would have
+  already handled this via its own Target Date prompt.
+```
+
+**Why this step is here, not earlier**:
+
+| Lifecycle point | What's known | Projection quality |
+|---|---|---|
+| `/devops-idea-create` | Just a one-liner | Guess only |
+| `/devops-project-start` | Folder + design.md skeleton, no plan yet | Bad guess |
+| **End of `/project-pipeline`** | **Plan with WBS, task count, effort range, critical path** | **Informed projection** |
+
+By placing the prompt here, the operator commits to a Target Date that has actual context, not a blind guess. This is what makes drift (Closed Date − Target Date) a meaningful metric later.
+
+**Autonomous mode**: skip the prompt; Target Date remains blank until operator sets it manually.
+**Interactive mode**: prompt as documented.
+
+---
+
 ### Step 5: Execute Tasks (Auto-Start with Parallel Execution)
 
 **Action:**

--- a/.claude/skills/repo-cleanup/SKILL.md
+++ b/.claude/skills/repo-cleanup/SKILL.md
@@ -536,8 +536,8 @@ Archive candidate detected: projects/{name}/
 Archive this project? [y/N]
 ```
 
-On explicit `y` (default N — destructive): invoke `/devops-project-archive --status Completed --pr-number #M`. This removes the worktree per D-18, retains `projects/{name}/` folder + `.archived` marker.
+On explicit `y` (default N): invoke `/devops-project-archive --status Completed --pr-number #M`. This sets Status=Completed + Closed Date, closes the Issue, writes a `.archived` marker file. **Worktree is preserved** (spec override 2026-06-25: D-18/NFR-09 worktree-deletion behavior removed per operator workflow — worktree cleanup is a separate manual step).
 
-Confirmation prompt is MANDATORY per safety contract — do NOT auto-archive.
+Operator confirmation still required — never auto-archive (F3 explicit gate).
 
 See: [`.claude/skills/devops-project-archive/SKILL.md`](../devops-project-archive/SKILL.md).

--- a/projects/spaarke-devops-project-tracking-r1/notes/phase1-field-ids.md
+++ b/projects/spaarke-devops-project-tracking-r1/notes/phase1-field-ids.md
@@ -56,8 +56,8 @@
 - Set by `/devops-project-archive` to the PR merge date (or today if no PR).
 - Pairs with the pre-existing `Start Date` (auto-populated by `/devops-project-register` from folder-creation date) and `Target Date` (operator-set at end of `/project-pipeline`) to enable drift tracking: `drift = Closed Date − Target Date`.
 
-### Project Status (SINGLE_SELECT)
-- **Field ID**: `PVTSSF_lAHODW0Pv84BEgWuzhWPlLc`
+### Status (SINGLE_SELECT)
+- **Field ID**: `PVTSSF_lAHODW0Pv84BEgWuzg2HNnk`
 - Options (5 per FR-02 + D-16):
 
 | Option name | Color | Description |
@@ -85,7 +85,7 @@ mutation {
 }
 ```
 
-Option IDs for `Project Type` and `Project Status` must be queried fresh per session — they survive across normal operations but are recreated by `updateProjectV2Field` mutations.
+Option IDs for `Project Type` and `Status` must be queried fresh per session — they survive across normal operations but are recreated by `updateProjectV2Field` mutations.
 
 ## Pre-existing fields (NOT modified by Phase 1)
 

--- a/projects/spaarke-devops-project-tracking-r1/notes/phase1-field-ids.md
+++ b/projects/spaarke-devops-project-tracking-r1/notes/phase1-field-ids.md
@@ -50,6 +50,12 @@
 ### Tasks Completed (NUMBER)
 - **Field ID**: `PVTF_lAHODW0Pv84BEgWuzhWPlLY`
 
+### Closed Date (DATE) — added 2026-06-25 as follow-up enhancement
+
+- **Field ID**: `PVTF_lAHODW0Pv84BEgWuzhWYfL4`
+- Set by `/devops-project-archive` to the PR merge date (or today if no PR).
+- Pairs with the pre-existing `Start Date` (auto-populated by `/devops-project-register` from folder-creation date) and `Target Date` (operator-set at end of `/project-pipeline`) to enable drift tracking: `drift = Closed Date − Target Date`.
+
 ### Project Status (SINGLE_SELECT)
 - **Field ID**: `PVTSSF_lAHODW0Pv84BEgWuzhWPlLc`
 - Options (5 per FR-02 + D-16):

--- a/projects/spaarke-devops-project-tracking-r1/notes/spikes/status-merger-baseline-2026-06-25.json
+++ b/projects/spaarke-devops-project-tracking-r1/notes/spikes/status-merger-baseline-2026-06-25.json
@@ -1,0 +1,434 @@
+[
+  {
+    "issue": 17,
+    "title": "Extend UAC to support contact based access",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfeuWM",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 18,
+    "title": "Production Testing Environment and Strategy",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfexXE",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 19,
+    "title": "Office.js Add-in for SDAP",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfe1l0",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 20,
+    "title": "Teams SDAP App",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfe1qY",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 21,
+    "title": "Spaarke Custom UI Design File",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfe18M",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 22,
+    "title": "Custom Side Pane Control",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfe5Ak",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 23,
+    "title": "Custom Email Main Form for AI",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfe5fo",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 24,
+    "title": "Spaarke Copilot Platform",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfe5mo",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 28,
+    "title": "Document classification",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgffWpQ",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 25,
+    "title": "Documentation: How Access Control Works for Documents and SharePoint Embedded",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgffBiQ",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 26,
+    "title": "Tooling: Create Dataverse MPC Server",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgffWeQ",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 27,
+    "title": "Tooling: Review, Streamline, and Cleanup the Repo Structure and Files",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgffWjc",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 29,
+    "title": "Dataset Grid:  Add Enhancements for Configuration",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgffXnI",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 30,
+    "title": "Tooling: Coding Agent Suite",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgff92U",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 31,
+    "title": "Email: Create Email 'Save to SPE' process",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfhDkY",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 32,
+    "title": "Dataset Grid:  Add large query virtualization scroll",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfhEjc",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 33,
+    "title": "Documents: Document Preview Control",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfhY44",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 34,
+    "title": "Document:  File Edit PCF Control",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfhY7w",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 37,
+    "title": "Dataset Grid:  Add 'Version\" label in the UI",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfixGE",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 38,
+    "title": "Workflow: Build Front End UX On Top of Power Automate",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfjCh4",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 39,
+    "title": "Configuration: Entity to Entity Field Mapping",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfl7qU",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 40,
+    "title": "Configuration: Field Auto Settings",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgfl8CE",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 416,
+    "title": "New test Idea",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwl5_0",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 421,
+    "title": "[Epic]: AI Platform & Chat",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwoku8",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 422,
+    "title": "[Epic]: Insights Engine",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwokwo",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 423,
+    "title": "[Epic]: Smart Todo",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwokx4",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 424,
+    "title": "[Epic]: Document Intelligence",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwokzM",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 425,
+    "title": "[Epic]: BFF & Test Hygiene",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok0M",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 426,
+    "title": "[Epic]: Auth & SSO",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok1Y",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 427,
+    "title": "[Epic]: Code Quality",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok2M",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 428,
+    "title": "[Epic]: Procedures & Knowledge",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok3s",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 429,
+    "title": "[Epic]: CI/CD & Tooling",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok4o",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 430,
+    "title": "[Epic]: Insights/Widgets/Search",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok6E",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 431,
+    "title": "[Epic]: Communications",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok7c",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 432,
+    "title": "[Epic]: Multi-tenant",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwok8k",
+    "status": null,
+    "status_option_id": null,
+    "project_status": null,
+    "project_status_option_id": null
+  },
+  {
+    "issue": 435,
+    "title": "[Project]: ai-spaarke-action-engine-r1",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp0zo",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 436,
+    "title": "[Project]: ai-spaarke-insights-engine-r2",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp01I",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 437,
+    "title": "[Project]: ai-spaarke-insights-engine-widgets-r1",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp02o",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 438,
+    "title": "[Project]: customer-provisioning-orchestration-r1",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp03w",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 439,
+    "title": "[Project]: email-communication-solution-r3",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp05M",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 440,
+    "title": "[Project]: smart-todo-decoupling-r3",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp07E",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 441,
+    "title": "[Project]: smart-todo-r4",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp08o",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 442,
+    "title": "[Project]: spaarke-ai-platform-chat-routing-redesign-r1",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp098",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 443,
+    "title": "[Project]: spaarke-ai-platform-unification-r6",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp0_Q",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 444,
+    "title": "[Project]: spaarke-daily-update-service-r2",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp1AQ",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 445,
+    "title": "[Project]: spaarke-devops-project-tracking-r1",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp1C4",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 446,
+    "title": "[Project]: spaarke-multi-container-multi-index-r1",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp1D8",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  },
+  {
+    "issue": 447,
+    "title": "[Project]: spaarke-platform-foundations-r3",
+    "item_id": "PVTI_lAHODW0Pv84BEgWuzgwp1Fg",
+    "status": null,
+    "status_option_id": null,
+    "project_status": "In Progress",
+    "project_status_option_id": "70a2088a"
+  }
+]

--- a/scripts/portfolio-status.py
+++ b/scripts/portfolio-status.py
@@ -47,7 +47,7 @@ def get_merge_state_for_branches(branches):
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('--epic', type=int, help='Show one Epic only')
-    ap.add_argument('--status', help='Filter Projects by Project Status field value')
+    ap.add_argument('--status', help='Filter Projects by Status field value')
     ap.add_argument('--verbose', action='store_true', help='Show field values per Project')
     ap.add_argument('--show-merges', action='store_true',
                     help='Show latest merged PR + merge date + archive-candidate flag per Project')
@@ -121,7 +121,7 @@ def main():
                 'number': num,
                 'title':  title.replace('[Project]:', '').strip(),
                 'type':   fv.get('Type', '-'),
-                'status': fv.get('Project Status', '-'),
+                'status': fv.get('Status', '-'),
                 'ptype':  fv.get('Project Type', '-'),
                 'worktree': fv.get('Worktree Path', ''),
                 'folder':   fv.get('Project Folder', ''),
@@ -184,7 +184,7 @@ def main():
                 p['open_pr'] = branch_to_open_pr[b]['number']
             else:
                 p['open_pr'] = None
-            # Archive candidate: merged + not yet archived (Project Status != Completed/Cancelled)
+            # Archive candidate: merged + not yet archived (Status != Completed/Cancelled)
             p['archive_candidate'] = (
                 p['merged_pr'] is not None
                 and p['status'] not in ('Completed', 'Cancelled')

--- a/scripts/portfolio-status.py
+++ b/scripts/portfolio-status.py
@@ -20,11 +20,37 @@ from collections import defaultdict
 PROJECT_ID = "PVT_kwHODW0Pv84BEgWu"
 
 
+def get_merge_state_for_branches(branches):
+    """For each branch, return (latest_merged_pr_num, merge_date) or None.
+
+    Single batched gh pr list call — efficient.
+    """
+    out = subprocess.run(
+        ['gh', 'pr', 'list', '--state', 'all', '--limit', '300',
+         '--json', 'number,title,state,headRefName,mergedAt,url'],
+        capture_output=True, check=True
+    ).stdout.decode('utf-8')
+    all_prs = json.loads(out)
+    branch_to_merged = {}
+    branch_to_open = {}
+    for pr in all_prs:
+        b = pr['headRefName']
+        if pr['state'] == 'MERGED':
+            existing = branch_to_merged.get(b)
+            if not existing or pr['mergedAt'] > existing['mergedAt']:
+                branch_to_merged[b] = pr
+        elif pr['state'] == 'OPEN':
+            branch_to_open[b] = pr
+    return branch_to_merged, branch_to_open
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('--epic', type=int, help='Show one Epic only')
     ap.add_argument('--status', help='Filter Projects by Project Status field value')
     ap.add_argument('--verbose', action='store_true', help='Show field values per Project')
+    ap.add_argument('--show-merges', action='store_true',
+                    help='Show latest merged PR + merge date + archive-candidate flag per Project')
     args = ap.parse_args()
 
     print('Loading portfolio from Project #2...', file=sys.stderr)
@@ -64,8 +90,8 @@ def main():
       }
     }
     '''
-    result = subprocess.run(['gh', 'api', 'graphql', '-f', f'query={query}'], capture_output=True, text=True, check=True)
-    nodes = json.loads(result.stdout)['data']['node']['items']['nodes']
+    result = subprocess.run(['gh', 'api', 'graphql', '-f', f'query={query}'], capture_output=True, check=True)
+    nodes = json.loads(result.stdout.decode('utf-8'))['data']['node']['items']['nodes']
 
     # Parse items
     epics = {}
@@ -110,19 +136,59 @@ def main():
         try:
             subs = json.loads(subprocess.run(
                 ['gh', 'api', f'repos/spaarke-dev/spaarke/issues/{epic_num}/sub_issues'],
-                capture_output=True, text=True, check=True
-            ).stdout)
+                capture_output=True, check=True
+            ).stdout.decode('utf-8'))
             for sub in subs:
                 if sub['title'].startswith('[Project]:'):
                     epic_to_projects[epic_num].append(sub['number'])
                     project_to_epic[sub['number']] = epic_num
-        except Exception:
-            pass
+        except Exception as e:
+            # Surface errors so silent failures don't masquerade as "no children"
+            sys.stderr.write(f'  warn: Epic #{epic_num} sub-issues query failed: {e}\n')
 
     # Filter
     if args.status:
         projects = [p for p in projects if p['status'].lower() == args.status.lower()]
     project_nums = {p['number']: p for p in projects}
+
+    # --show-merges: for each project, look up merge state by reading its worktree's current branch
+    branch_to_merged_pr = {}
+    branch_to_open_pr = {}
+    if args.show_merges:
+        # Resolve each project's branch from worktree path
+        for p in projects:
+            wt_path = p.get('worktree', '')
+            if wt_path:
+                try:
+                    branch = subprocess.run(['git', '-C', wt_path, 'branch', '--show-current'],
+                                            capture_output=True, check=True
+                                            ).stdout.decode('utf-8').strip()
+                    p['branch'] = branch
+                except Exception:
+                    p['branch'] = None
+            else:
+                p['branch'] = None
+        # Batch query for all PRs (single API call, more efficient than per-branch)
+        branch_to_merged_pr, branch_to_open_pr = get_merge_state_for_branches([])
+        # Attach merge info to each project
+        for p in projects:
+            b = p.get('branch')
+            if b and b in branch_to_merged_pr:
+                pr = branch_to_merged_pr[b]
+                p['merged_pr'] = pr['number']
+                p['merged_date'] = pr['mergedAt'][:10]
+            else:
+                p['merged_pr'] = None
+                p['merged_date'] = None
+            if b and b in branch_to_open_pr:
+                p['open_pr'] = branch_to_open_pr[b]['number']
+            else:
+                p['open_pr'] = None
+            # Archive candidate: merged + not yet archived (Project Status != Completed/Cancelled)
+            p['archive_candidate'] = (
+                p['merged_pr'] is not None
+                and p['status'] not in ('Completed', 'Cancelled')
+            )
 
     epic_nums_to_show = [args.epic] if args.epic else sorted(epics.keys())
 
@@ -154,7 +220,17 @@ def main():
             if c['task_count'] is not None:
                 done = c['tasks_completed'] or 0
                 tasks_str = f"  ({done}/{int(c['task_count'])} tasks)"
-            print(f"       - #{c['number']}  {c['title'][:55]:<55}  [{c['status']}] ({c['ptype']}){tasks_str}")
+            merge_str = ''
+            if args.show_merges:
+                if c.get('archive_candidate'):
+                    merge_str = f"  [ARCHIVE CANDIDATE — merged #{c['merged_pr']} on {c['merged_date']}]"
+                elif c.get('merged_pr'):
+                    merge_str = f"  [merged #{c['merged_pr']} on {c['merged_date']}]"
+                elif c.get('open_pr'):
+                    merge_str = f"  [open PR #{c['open_pr']}]"
+                else:
+                    merge_str = f"  [no PR]"
+            print(f"       - #{c['number']}  {c['title'][:55]:<55}  [{c['status']}] ({c['ptype']}){tasks_str}{merge_str}")
             if args.verbose:
                 if c['worktree']:
                     print(f"             worktree: {c['worktree']}")


### PR DESCRIPTION
## Summary

Follow-up to PR #420 + #452. Addresses operator feedback after the walkthrough across **four themes**:

1. Cleanly separate planning vs actual semantics for project lifecycle dates
2. Eliminate the duplicate `Status` / `Project Status` field
3. Bake Quick Links into Issue body template
4. **Override D-18/NFR-09 worktree-deletion behavior in `/devops-project-archive` — worktree is now preserved**

## Theme 1: Lifecycle dates

Three dates with clean semantics:

| Field | Meaning | When set | By what |
|---|---|---|---|
| Start Date | When work began | At project register | Auto from `git log --diff-filter=A` on `projects/{slug}/` |
| Target Date | Planned completion (commitment) | At `/project-pipeline` Step 4.5 | Operator-prompted with effort estimate visible |
| Closed Date (NEW field) | Actual completion | At `/devops-project-archive` | Auto from PR merge date (or today if no PR) |

Enables `drift = Closed Date − Target Date` as a real metric.

## Theme 2: Status field merger

Migrated default Status field to portfolio set (`Planned/In Progress/On Hold/Completed/Cancelled`), deleted redundant `Project Status` field. Project #2 field count: 27 → 26.

Snapshot before/after preserved at `notes/spikes/status-merger-baseline-2026-06-25.json`. Zero items had Status set pre-mutation — zero data loss risk.

## Theme 3: Quick Links Issue body template

`/devops-project-register` now produces Issues with the Quick Links table baked in. No more retroactive patching for new projects.

## Theme 4: Worktree preservation on archive (override)

**Operator workflow feedback (2026-06-25)**: worktrees stay around long after archive as long-lived dev environments. Archive should close out Issue state only, not delete the worktree.

Changes to `/devops-project-archive`:
- Removed DESTRUCTIVE warning section
- Removed Step 2 "uncommitted changes check" (no longer relevant)
- Removed Step 6 "git worktree remove" step entirely
- Removed `--force` flag (no longer needed)
- Confirm prompt defaults to Y (non-destructive)
- `.archived` marker explicitly notes "worktree PRESERVED"
- Outputs + Failure Modes updated to reflect non-destructive scope
- Frontmatter description and Tier updated
- Spec override note added: D-18/NFR-09 no longer apply

Also updates `/repo-cleanup` hook section to remove "destructive" language.

Future-proofing: if worktree cleanup is ever needed, build a separate `/devops-worktree-cleanup` skill rather than re-coupling here (lifecycle separation principle).

## Bonus: scripts/portfolio-status.py `--show-merges`

```
python scripts/portfolio-status.py --show-merges
```

Flags **ARCHIVE CANDIDATES** — projects where the PR merged but Status is still In Progress. Today: 11 candidates.

## Files changed (11 total)

- `.claude/skills/devops-portfolio-setup/SKILL.md`
- `.claude/skills/devops-portfolio-status/SKILL.md`
- `.claude/skills/devops-project-register/SKILL.md` (Start Date auto, Quick Links template, Target Date prompt, Status writes)
- `.claude/skills/devops-project-archive/SKILL.md` (Closed Date, Status writes, **worktree preservation**)
- `.claude/skills/devops-project-start/SKILL.md`
- `.claude/skills/devops-project-sync/SKILL.md`
- `.claude/skills/project-pipeline/SKILL.md` (new Step 4.5: Target Date prompt)
- `.claude/skills/repo-cleanup/SKILL.md` (hook section updated for non-destructive archive)
- `scripts/portfolio-status.py` (`--show-merges` flag + Status field reads)
- `projects/.../notes/phase1-field-ids.md` (Closed Date documented, Project Status marked DELETED)
- `projects/.../notes/spikes/status-merger-baseline-2026-06-25.json` (audit trail)

## Prerequisites already landed live

- ✅ `Closed Date` DATE field created on Project #2
- ✅ `Status` field options replaced with portfolio set
- ✅ `Project Status` field deleted
- ✅ 13 Project Issues migrated to use Status

## Test plan

- [x] `--show-merges` flag tested — 11 ARCHIVE CANDIDATES correctly identified
- [x] Start Date auto-populate verified — backfilled all 13 existing Project Issues with correct dates
- [x] Status migration verified — `scripts/portfolio-status.py --show-merges` runs correctly post-migration
- [ ] First end-to-end use of Target Date prompt awaits next `/project-pipeline` run
- [ ] First Closed Date population awaits first `/devops-project-archive` run (with worktree-preservation behavior verified)

🤖 Generated with Claude Code