### PR TITLE
hotfix(bff)(di): route IFieldMappingDataverseService to DataverseWebApiService

### DIFF
--- a/src/server/api/Sprk.Bff.Api/Infrastructure/DI/GraphModule.cs
+++ b/src/server/api/Sprk.Bff.Api/Infrastructure/DI/GraphModule.cs
@@ -71,7 +71,11 @@ public static class GraphModule
         services.AddSingleton<IProcessingJobService>(sp => sp.GetRequiredService<IDataverseService>());
         // Events use DataverseWebApiService (real implementation) instead of DataverseServiceClientImpl (stub).
         services.AddSingleton<IEventDataverseService>(sp => sp.GetRequiredService<DataverseWebApiService>());
-        services.AddSingleton<IFieldMappingDataverseService>(sp => sp.GetRequiredService<IDataverseService>());
+        // Fix: IFieldMappingDataverseService routes to DataverseWebApiService (real impl)
+        // because QueryChildRecordIdsAsync is implemented there, not in DataverseServiceClientImpl (stub).
+        // Mirrors line 73's IEventDataverseService pattern. Asymmetric-registration anti-pattern fix
+        // (CLAUDE.md §10 F.1). Bug came in via daily-update-service-r4 master merge.
+        services.AddSingleton<IFieldMappingDataverseService>(sp => sp.GetRequiredService<DataverseWebApiService>());
         services.AddSingleton<IKpiDataverseService>(sp => sp.GetRequiredService<IDataverseService>());
         services.AddSingleton<ICommunicationDataverseService>(sp => sp.GetRequiredService<IDataverseService>());
         services.AddSingleton<IDataverseHealthService>(sp => sp.GetRequiredService<IDataverseService>());


### PR DESCRIPTION
## Summary
- Production hotfix: cherry-pick of `3119c11ef` from `work/spaarke-ai-platform-chat-routing-redesign-r1` to land the DI fix on master ahead of the larger chat-routing PR.
- Routes `IFieldMappingDataverseService` to `DataverseWebApiService` (real impl) instead of `DataverseServiceClientImpl` (stub) — matches the line 73 pattern for `IEventDataverseService`.

## Why now
- `POST /api/ai/chat/sessions/{id}/documents` returns HTTP 500 (`NotImplementedException`) in dev — chat-routing UAT (2026-06-26).
- Bug landed via daily-update-service-r4 master merge. Surfaces in the document-upload pipeline (`ChatDataverseRepository.QueryChildRecordIdsAsync`).
- Per CLAUDE.md §10 F.1: asymmetric-registration anti-pattern fix.

## Test plan
- [ ] CI build green on `src/server/api/Sprk.Bff.Api/`
- [ ] BFF publish-size ≤60 MB (no dependency change; sub-5MB delta expected)
- [ ] Smoke: `POST /api/ai/chat/sessions/{id}/documents` no longer 500s in dev after deploy
- [ ] After merge: rebase/merge master into `work/spaarke-ai-platform-chat-routing-redesign-r1`; dup commit will drop out
- [ ] After merge: delete `hotfix/dataverse-fieldmapping-di-registration` branch + temp worktree (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)