### PR TITLE
fix(tests): RecallSessionFileHandlerResolvableTests uses ITenantCache (PR #482 follow-up)

### DIFF
--- a/tests/integration/Sprk.Bff.Api.IntegrationTests/Services/Ai/Handlers/RecallSessionFileHandlerResolvableTests.cs
+++ b/tests/integration/Sprk.Bff.Api.IntegrationTests/Services/Ai/Handlers/RecallSessionFileHandlerResolvableTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
-using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Sprk.Bff.Api.Infrastructure.Cache;
 using Sprk.Bff.Api.Services.Ai.Handlers;
 using Sprk.Bff.Api.Services.Ai.Memory;
 using Xunit;
@@ -73,7 +73,7 @@ public sealed class RecallSessionFileHandlerResolvableTests
         services.AddSingleton(Moq.Mock.Of<Sprk.Bff.Api.Services.Ai.IRagService>());
         services.AddScoped<Sprk.Bff.Api.Services.Ai.Chat.ChatSessionManager>(sp =>
             new Sprk.Bff.Api.Services.Ai.Chat.ChatSessionManager(
-                cache: sp.GetRequiredService<IDistributedCache>(),
+                cache: sp.GetRequiredService<ITenantCache>(),
                 dataverseRepository: Moq.Mock.Of<Sprk.Bff.Api.Services.Ai.Chat.IChatDataverseRepository>(),
                 logger: sp.GetRequiredService<ILogger<Sprk.Bff.Api.Services.Ai.Chat.ChatSessionManager>>(),
                 persistence: null,


### PR DESCRIPTION
## Summary
Completes PR #482's test-fixture fix. PR #482 updated 5 files in `tests/integration/Spe.Integration.Tests/` but missed `tests/integration/Sprk.Bff.Api.IntegrationTests/Services/Ai/Handlers/RecallSessionFileHandlerResolvableTests.cs` (different test project — same broken pattern).

Unblocks the master CI build that was breaking the SDAP CI Tier 1 Build & Test on every sweep PR.

## Test plan
- [x] BFF integration test project builds (0 errors) verified locally
- [ ] CI Tier 1 Build & Test (Debug) green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)