### PR TITLE
fix(shared): Spaarke.DailyBriefing.Components — restore standalone build

### DIFF
--- a/scripts/Build-AllClientComponents.ps1
+++ b/scripts/Build-AllClientComponents.ps1
@@ -4,9 +4,7 @@
 
 .DESCRIPTION
     Orchestrates the build of all Spaarke client components in the required order:
-    1. Shared libraries (8 packages in src/client/shared/ — Auth, SdapClient, AI.Context, AI.Outputs, Events.Components, SmartTodo.Components, UI.Components, AI.Widgets)
-       NOTE: Spaarke.DailyBriefing.Components is intentionally excluded — it's a source-only lib
-       (tsc --noEmit) with @spaarke peerDependencies; type-check happens via the consumer's tsc pass.
+    1. Shared libraries (9 packages in src/client/shared/ — Auth, SdapClient, AI.Context, AI.Outputs, Events.Components, SmartTodo.Components, UI.Components, AI.Widgets, DailyBriefing.Components)
     2. Vite solutions (19 projects in src/solutions/)
     3. Webpack code pages (4 projects in src/client/code-pages/)
     4. PCF controls (src/client/pcf/)
@@ -61,21 +59,16 @@ if ($Component) {
 $RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
 
 # Shared libraries (build order matters — downstream deps must come after their dependencies)
-#
-# Spaarke.DailyBriefing.Components is intentionally EXCLUDED from this list. Its build script is
-# `tsc --noEmit` and its `@spaarke/*` deps are listed as peerDependencies (not regular deps),
-# so it cannot type-check standalone — the type-check is performed by each consumer's tsc pass
-# (SpaarkeAi, DailyBriefing). Tried adding it 2026-06-28 → orchestrator failed on TS2307
-# "Cannot find module '@spaarke/ui-components'" etc. Excluded by design.
 $SharedLibs = @(
-    @{ Name = "Spaarke.Auth";                 Path = "$RepoRoot\src\client\shared\Spaarke.Auth" }
-    @{ Name = "Spaarke.SdapClient";           Path = "$RepoRoot\src\client\shared\Spaarke.SdapClient" }
-    @{ Name = "Spaarke.AI.Context";           Path = "$RepoRoot\src\client\shared\Spaarke.AI.Context" }           # depends on Auth
-    @{ Name = "Spaarke.AI.Outputs";           Path = "$RepoRoot\src\client\shared\Spaarke.AI.Outputs" }
-    @{ Name = "Spaarke.Events.Components";    Path = "$RepoRoot\src\client\shared\Spaarke.Events.Components" }
-    @{ Name = "Spaarke.SmartTodo.Components"; Path = "$RepoRoot\src\client\shared\Spaarke.SmartTodo.Components" }
-    @{ Name = "Spaarke.UI.Components";        Path = "$RepoRoot\src\client\shared\Spaarke.UI.Components" }        # depends on Auth, SdapClient
-    @{ Name = "Spaarke.AI.Widgets";           Path = "$RepoRoot\src\client\shared\Spaarke.AI.Widgets" }           # depends on UI.Components, AI.Outputs
+    @{ Name = "Spaarke.Auth";                    Path = "$RepoRoot\src\client\shared\Spaarke.Auth" }
+    @{ Name = "Spaarke.SdapClient";              Path = "$RepoRoot\src\client\shared\Spaarke.SdapClient" }
+    @{ Name = "Spaarke.AI.Context";              Path = "$RepoRoot\src\client\shared\Spaarke.AI.Context" }              # depends on Auth
+    @{ Name = "Spaarke.AI.Outputs";              Path = "$RepoRoot\src\client\shared\Spaarke.AI.Outputs" }
+    @{ Name = "Spaarke.Events.Components";       Path = "$RepoRoot\src\client\shared\Spaarke.Events.Components" }
+    @{ Name = "Spaarke.SmartTodo.Components";    Path = "$RepoRoot\src\client\shared\Spaarke.SmartTodo.Components" }
+    @{ Name = "Spaarke.UI.Components";           Path = "$RepoRoot\src\client\shared\Spaarke.UI.Components" }           # depends on Auth, SdapClient
+    @{ Name = "Spaarke.AI.Widgets";              Path = "$RepoRoot\src\client\shared\Spaarke.AI.Widgets" }              # depends on UI.Components, AI.Outputs
+    @{ Name = "Spaarke.DailyBriefing.Components"; Path = "$RepoRoot\src\client\shared\Spaarke.DailyBriefing.Components" } # depends on Auth, UI.Components
 )
 
 # Expand the "SharedLibs" special shortcut into the actual lib names so the filter at line ~113 matches.

--- a/src/client/shared/Spaarke.DailyBriefing.Components/package-lock.json
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "@spaarke/daily-briefing-components",
       "version": "0.1.0",
+      "dependencies": {
+        "@spaarke/auth": "file:../Spaarke.Auth",
+        "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+      },
       "devDependencies": {
         "@fluentui/react-components": "^9.46.2",
         "@fluentui/react-icons": "^2.0.200",
@@ -28,8 +32,102 @@
         "@fluentui/react-components": "^9.0.0",
         "@fluentui/react-icons": "^2.0.0",
         "@spaarke/auth": "^2.0.0",
+        "@spaarke/ui-components": "*",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "../Spaarke.Auth": {
+      "name": "@spaarke/auth",
+      "version": "2.0.0",
+      "license": "UNLICENSED",
+      "devDependencies": {
+        "@azure/msal-browser": "^3.27.0",
+        "@types/jest": "^30.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^8.57.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "ts-jest": "^29.4.4",
+        "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.0.0"
+      }
+    },
+    "../Spaarke.UI.Components": {
+      "name": "@spaarke/ui-components",
+      "version": "2.3.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@microsoft/applicationinsights-web": "^3.3.0",
+        "@spaarke/sdap-client": "file:../Spaarke.SdapClient",
+        "d3-force": "^3.0.0",
+        "diff": "^8.0.3",
+        "dompurify": "^3.4.0",
+        "mammoth": "^1.12.0",
+        "marked": "^17.0.4",
+        "pdfjs-dist": "^5.7.284",
+        "react-window": "^1.8.11"
+      },
+      "devDependencies": {
+        "@fluentui/react-components": "^9.73.2",
+        "@fluentui/react-icons": "^2.0.320",
+        "@hello-pangea/dnd": "^18.0.1",
+        "@lexical/html": "^0.41.0",
+        "@lexical/list": "^0.41.0",
+        "@lexical/react": "^0.41.0",
+        "@lexical/rich-text": "^0.41.0",
+        "@lexical/selection": "^0.41.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/d3-force": "^3.0.10",
+        "@types/diff": "^7.0.0",
+        "@types/dompurify": "^3.0.5",
+        "@types/jest": "^30.0.0",
+        "@types/powerapps-component-framework": "^1.3.4",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@types/react-window": "^1.8.8",
+        "eslint": "^9.17.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react-hooks": "^5.0.0",
+        "globals": "^15.14.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "lexical": "^0.41.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "ts-jest": "^29.4.4",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "^8.20.0"
+      },
+      "peerDependencies": {
+        "@fluentui/react-button": "^9.6.7",
+        "@fluentui/react-dialog": "^9.15.3",
+        "@fluentui/react-icons": "^2.0.311",
+        "@fluentui/react-input": "^9.6.6",
+        "@fluentui/react-label": "^9.3.6",
+        "@fluentui/react-message-bar": "^9.6.8",
+        "@fluentui/react-progress": "^9.4.6",
+        "@fluentui/react-provider": "^9.22.6",
+        "@fluentui/react-spinner": "^9.7.6",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.6",
+        "@hello-pangea/dnd": "^17.0.0 || ^18.0.0",
+        "@lexical/html": "^0.17.0",
+        "@lexical/list": "^0.17.0",
+        "@lexical/react": "^0.17.0",
+        "@lexical/rich-text": "^0.17.0",
+        "@lexical/selection": "^0.17.0",
+        "lexical": "^0.17.0",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2957,6 +3055,14 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@spaarke/auth": {
+      "resolved": "../Spaarke.Auth",
+      "link": true
+    },
+    "node_modules/@spaarke/ui-components": {
+      "resolved": "../Spaarke.UI.Components",
+      "link": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",

--- a/src/client/shared/Spaarke.DailyBriefing.Components/package.json
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/package.json
@@ -23,10 +23,15 @@
     "test:coverage": "jest --coverage",
     "test:ci": "jest --ci --coverage --maxWorkers=2"
   },
+  "dependencies": {
+    "@spaarke/auth": "file:../Spaarke.Auth",
+    "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+  },
   "peerDependencies": {
     "@fluentui/react-components": "^9.0.0",
     "@fluentui/react-icons": "^2.0.0",
     "@spaarke/auth": "^2.0.0",
+    "@spaarke/ui-components": "*",
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/src/client/shared/Spaarke.DailyBriefing.Components/tsconfig.json
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/tsconfig.json
@@ -14,7 +14,16 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@spaarke/auth": ["../Spaarke.Auth/dist/index.d.ts"],
+      "@spaarke/auth/*": ["../Spaarke.Auth/dist/*"],
+      "@spaarke/ui-components": ["../Spaarke.UI.Components/dist/index.d.ts"],
+      "@spaarke/ui-components/*": ["../Spaarke.UI.Components/dist/*"],
+      "@fluentui/react-icons": ["./node_modules/@fluentui/react-icons"],
+      "@fluentui/react-icons/*": ["./node_modules/@fluentui/react-icons/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Master build feedback flagged `src/client/shared/Spaarke.DailyBriefing.Components` failing `tsc --noEmit` standalone with TS2307 module errors. Root cause: cross-lib `@spaarke/*` deps were declared only as `peerDependencies`, so `npm install` created no symlinks in `node_modules/@spaarke/` and tsc could not resolve the imports.

The lib still worked in production — consumers (`src/solutions/DailyBriefing/` + `src/solutions/SpaarkeAi/`) resolve everything via their own `node_modules`. Only standalone build + CI gate were broken.

The fix mirrors `src/client/shared/Spaarke.AI.Widgets/` (the only sibling lib with the same `file:..` cross-lib pattern that builds clean).

## Changes

| File | Change |
|---|---|
| `src/client/shared/Spaarke.DailyBriefing.Components/package.json` | Add `dependencies` block with `file:..` refs for `@spaarke/auth` + `@spaarke/ui-components`; add `@spaarke/ui-components` to `peerDependencies` (was imported but never declared as peer — latent contract gap) |
| `src/client/shared/Spaarke.DailyBriefing.Components/tsconfig.json` | Add `baseUrl` + `paths` — same shape as AI.Widgets sibling — for subpath import resolution (`@spaarke/ui-components/services`) + FluentIcon dedup |
| `src/client/shared/Spaarke.DailyBriefing.Components/package-lock.json` | Regenerated from new dependencies |
| `scripts/Build-AllClientComponents.ps1` | Un-exclude the lib: add to `$SharedLibs` after AI.Widgets (depends on Auth + UI.Components); remove `intentionally EXCLUDED` block; docstring `8 packages` → `9 packages` |

## Constraints honored (per task brief)

- ✅ Public `exports` field unchanged (`./components`, `./widgets`, `./hooks`, `./services`, `./types`, `./utils`)
- ✅ `main` / `types` unchanged — still point at `./src/index.ts` (source-only lib; no compilation step)
- ✅ `peerDependencies` not weakened — added `@spaarke/ui-components` to close a latent contract gap
- ✅ `file:` refs match sibling AI.Widgets relative-path convention

## Why tsconfig `paths` was needed

Three reasons, in order of importance:

1. **Subpath imports** — `useInlineTodoCreate.ts` imports from `@spaarke/ui-components/services`. UI.Components has no `exports` field; subpath resolution under `moduleResolution: bundler` falls back to TS path mapping. AI.Widgets already has these `/*` paths for the same reason.

2. **FluentIcon dual-install** — `npm install` puts `@fluentui/react-icons` in this lib's `node_modules`; UI.Components has its own copy. Two physical installs → TS sees two unrelated `FluentIcon` types → assignment error at `dailyBriefing.registration.ts:177` (`icon: SparkleRegular` → `SectionRegistration.icon: FluentIcon`). The path mapping forces tsc to resolve through a single physical location.

3. **Sibling consistency** — same pattern AI.Widgets uses.

## Test plan

- [x] `cd src/client/shared/Spaarke.DailyBriefing.Components && npm install --legacy-peer-deps --no-audit --no-fund` — installs cleanly, creates `node_modules/@spaarke/auth` + `node_modules/@spaarke/ui-components` symlinks
- [x] `ls node_modules/@spaarke/` — shows symlinks for every `@spaarke/*` import found in `src/`
- [x] `npm run build` — exit 0, 0 TS errors
- [x] `pwsh scripts/Build-AllClientComponents.ps1 -Component Spaarke.DailyBriefing.Components` — SUCCESS 15.1s (verified via the orchestrator path)
- [ ] CI build green
- [ ] Reviewer: verify consumer solutions (DailyBriefing + SpaarkeAi) still build unchanged (this PR only adds tracked deps — does not remove any)

## Out of scope (pre-existing issues observed)

While running `pwsh scripts/Build-AllClientComponents.ps1 -Component SharedLibs` end-to-end, Spaarke.Events.Components + Spaarke.SmartTodo.Components fail with `../Spaarke.UI.Components/src/...` typecheck errors. These libs do NOT import `@spaarke/*` (verified via grep) — their tsconfig appears to be including UI.Components source via some path. These failures pre-exist on master and are unrelated to this fix. Filed mentally for a follow-on PR; this PR scope is limited to the Spaarke.DailyBriefing.Components standalone build per task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)