### PR TITLE
fix(shared): Events.Components + SmartTodo.Components — package boundary + orchestrator order

### DIFF
--- a/scripts/Build-AllClientComponents.ps1
+++ b/scripts/Build-AllClientComponents.ps1
@@ -72,9 +72,9 @@ $SharedLibs = @(
     @{ Name = "Spaarke.SdapClient";           Path = "$RepoRoot\src\client\shared\Spaarke.SdapClient" }
     @{ Name = "Spaarke.AI.Context";           Path = "$RepoRoot\src\client\shared\Spaarke.AI.Context" }           # depends on Auth
     @{ Name = "Spaarke.AI.Outputs";           Path = "$RepoRoot\src\client\shared\Spaarke.AI.Outputs" }
-    @{ Name = "Spaarke.Events.Components";    Path = "$RepoRoot\src\client\shared\Spaarke.Events.Components" }
-    @{ Name = "Spaarke.SmartTodo.Components"; Path = "$RepoRoot\src\client\shared\Spaarke.SmartTodo.Components" }
     @{ Name = "Spaarke.UI.Components";        Path = "$RepoRoot\src\client\shared\Spaarke.UI.Components" }        # depends on Auth, SdapClient
+    @{ Name = "Spaarke.Events.Components";    Path = "$RepoRoot\src\client\shared\Spaarke.Events.Components" }    # depends on UI.Components (DataGrid, XrmDataverseClient)
+    @{ Name = "Spaarke.SmartTodo.Components"; Path = "$RepoRoot\src\client\shared\Spaarke.SmartTodo.Components" } # depends on UI.Components (Kanban, OrientationToggle, MicrosoftToDoIcon)
     @{ Name = "Spaarke.AI.Widgets";           Path = "$RepoRoot\src\client\shared\Spaarke.AI.Widgets" }           # depends on UI.Components, AI.Outputs
 )
 

--- a/src/client/shared/Spaarke.Events.Components/package-lock.json
+++ b/src/client/shared/Spaarke.Events.Components/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@spaarke/events-components",
       "version": "0.1.0",
+      "dependencies": {
+        "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+      },
       "devDependencies": {
         "@fluentui/react-components": "^9.46.2",
         "@fluentui/react-icons": "^2.0.200",
@@ -20,8 +23,83 @@
       "peerDependencies": {
         "@fluentui/react-components": "^9.0.0",
         "@fluentui/react-icons": "^2.0.0",
+        "@spaarke/ui-components": "*",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "../Spaarke.UI.Components": {
+      "name": "@spaarke/ui-components",
+      "version": "2.3.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@microsoft/applicationinsights-web": "^3.3.0",
+        "@spaarke/sdap-client": "file:../Spaarke.SdapClient",
+        "d3-force": "^3.0.0",
+        "diff": "^8.0.3",
+        "dompurify": "^3.4.0",
+        "mammoth": "^1.12.0",
+        "marked": "^17.0.4",
+        "pdfjs-dist": "^5.7.284",
+        "react-window": "^1.8.11"
+      },
+      "devDependencies": {
+        "@fluentui/react-components": "^9.73.2",
+        "@fluentui/react-icons": "^2.0.320",
+        "@hello-pangea/dnd": "^18.0.1",
+        "@lexical/html": "^0.41.0",
+        "@lexical/list": "^0.41.0",
+        "@lexical/react": "^0.41.0",
+        "@lexical/rich-text": "^0.41.0",
+        "@lexical/selection": "^0.41.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/d3-force": "^3.0.10",
+        "@types/diff": "^7.0.0",
+        "@types/dompurify": "^3.0.5",
+        "@types/jest": "^30.0.0",
+        "@types/powerapps-component-framework": "^1.3.4",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@types/react-window": "^1.8.8",
+        "eslint": "^9.17.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react-hooks": "^5.0.0",
+        "globals": "^15.14.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "lexical": "^0.41.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "ts-jest": "^29.4.4",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "^8.20.0"
+      },
+      "peerDependencies": {
+        "@fluentui/react-button": "^9.6.7",
+        "@fluentui/react-dialog": "^9.15.3",
+        "@fluentui/react-icons": "^2.0.311",
+        "@fluentui/react-input": "^9.6.6",
+        "@fluentui/react-label": "^9.3.6",
+        "@fluentui/react-message-bar": "^9.6.8",
+        "@fluentui/react-progress": "^9.4.6",
+        "@fluentui/react-provider": "^9.22.6",
+        "@fluentui/react-spinner": "^9.7.6",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.6",
+        "@hello-pangea/dnd": "^17.0.0 || ^18.0.0",
+        "@lexical/html": "^0.17.0",
+        "@lexical/list": "^0.17.0",
+        "@lexical/react": "^0.17.0",
+        "@lexical/rich-text": "^0.17.0",
+        "@lexical/selection": "^0.17.0",
+        "lexical": "^0.17.0",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1741,6 +1819,10 @@
       "dependencies": {
         "csstype": "^3.2.3"
       }
+    },
+    "node_modules/@spaarke/ui-components": {
+      "resolved": "../Spaarke.UI.Components",
+      "link": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.21",

--- a/src/client/shared/Spaarke.Events.Components/package.json
+++ b/src/client/shared/Spaarke.Events.Components/package.json
@@ -20,9 +20,13 @@
     "build": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },
+  "dependencies": {
+    "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+  },
   "peerDependencies": {
     "@fluentui/react-components": "^9.0.0",
     "@fluentui/react-icons": "^2.0.0",
+    "@spaarke/ui-components": "*",
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/src/client/shared/Spaarke.Events.Components/src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx
+++ b/src/client/shared/Spaarke.Events.Components/src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx
@@ -124,8 +124,8 @@ import { addMonths, startOfMonth } from '../../utils/dateMath';
 // (UniversalDatasetGrid, useDatasetMode, SprkChat, etc.) into events-components's
 // tsc check — events-components has no ComponentFramework types installed.
 // See task 033b deviations doc for rationale.
-import { DataGrid, type HostFilterCondition } from '../../../../Spaarke.UI.Components/src/components/DataGrid';
-import { XrmDataverseClient } from '../../../../Spaarke.UI.Components/src/services/XrmDataverseClient';
+import { DataGrid, type HostFilterCondition } from '@spaarke/ui-components/components/DataGrid';
+import { XrmDataverseClient } from '@spaarke/ui-components/services/XrmDataverseClient';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Configuration — the sprk_gridconfiguration record id that drives the grid.

--- a/src/client/shared/Spaarke.Events.Components/tsconfig.json
+++ b/src/client/shared/Spaarke.Events.Components/tsconfig.json
@@ -18,7 +18,14 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@spaarke/ui-components": ["../Spaarke.UI.Components/dist/index.d.ts"],
+      "@spaarke/ui-components/*": ["../Spaarke.UI.Components/dist/*"],
+      "@fluentui/react-icons": ["./node_modules/@fluentui/react-icons"],
+      "@fluentui/react-icons/*": ["./node_modules/@fluentui/react-icons/*"]
+    }
   },
   "include": ["src"]
 }

--- a/src/client/shared/Spaarke.SmartTodo.Components/package-lock.json
+++ b/src/client/shared/Spaarke.SmartTodo.Components/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@spaarke/smart-todo-components",
       "version": "0.1.0",
+      "dependencies": {
+        "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+      },
       "devDependencies": {
         "@fluentui/react-components": "^9.46.2",
         "@fluentui/react-icons": "^2.0.200",
@@ -22,8 +25,83 @@
         "@fluentui/react-components": "^9.0.0",
         "@fluentui/react-icons": "^2.0.0",
         "@hello-pangea/dnd": "^17.0.0 || ^18.0.0",
+        "@spaarke/ui-components": "*",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "../Spaarke.UI.Components": {
+      "name": "@spaarke/ui-components",
+      "version": "2.3.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@microsoft/applicationinsights-web": "^3.3.0",
+        "@spaarke/sdap-client": "file:../Spaarke.SdapClient",
+        "d3-force": "^3.0.0",
+        "diff": "^8.0.3",
+        "dompurify": "^3.4.0",
+        "mammoth": "^1.12.0",
+        "marked": "^17.0.4",
+        "pdfjs-dist": "^5.7.284",
+        "react-window": "^1.8.11"
+      },
+      "devDependencies": {
+        "@fluentui/react-components": "^9.73.2",
+        "@fluentui/react-icons": "^2.0.320",
+        "@hello-pangea/dnd": "^18.0.1",
+        "@lexical/html": "^0.41.0",
+        "@lexical/list": "^0.41.0",
+        "@lexical/react": "^0.41.0",
+        "@lexical/rich-text": "^0.41.0",
+        "@lexical/selection": "^0.41.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/d3-force": "^3.0.10",
+        "@types/diff": "^7.0.0",
+        "@types/dompurify": "^3.0.5",
+        "@types/jest": "^30.0.0",
+        "@types/powerapps-component-framework": "^1.3.4",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@types/react-window": "^1.8.8",
+        "eslint": "^9.17.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react-hooks": "^5.0.0",
+        "globals": "^15.14.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "lexical": "^0.41.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "ts-jest": "^29.4.4",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "^8.20.0"
+      },
+      "peerDependencies": {
+        "@fluentui/react-button": "^9.6.7",
+        "@fluentui/react-dialog": "^9.15.3",
+        "@fluentui/react-icons": "^2.0.311",
+        "@fluentui/react-input": "^9.6.6",
+        "@fluentui/react-label": "^9.3.6",
+        "@fluentui/react-message-bar": "^9.6.8",
+        "@fluentui/react-progress": "^9.4.6",
+        "@fluentui/react-provider": "^9.22.6",
+        "@fluentui/react-spinner": "^9.7.6",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.6",
+        "@hello-pangea/dnd": "^17.0.0 || ^18.0.0",
+        "@lexical/html": "^0.17.0",
+        "@lexical/list": "^0.17.0",
+        "@lexical/react": "^0.17.0",
+        "@lexical/rich-text": "^0.17.0",
+        "@lexical/selection": "^0.17.0",
+        "lexical": "^0.17.0",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1762,6 +1840,10 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@spaarke/ui-components": {
+      "resolved": "../Spaarke.UI.Components",
+      "link": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",

--- a/src/client/shared/Spaarke.SmartTodo.Components/package.json
+++ b/src/client/shared/Spaarke.SmartTodo.Components/package.json
@@ -17,10 +17,14 @@
     "build": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },
+  "dependencies": {
+    "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+  },
   "peerDependencies": {
     "@fluentui/react-components": "^9.0.0",
     "@fluentui/react-icons": "^2.0.0",
     "@hello-pangea/dnd": "^17.0.0 || ^18.0.0",
+    "@spaarke/ui-components": "*",
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/components/SmartTodoKanban/SmartTodoKanban.tsx
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/components/SmartTodoKanban/SmartTodoKanban.tsx
@@ -52,7 +52,7 @@
 import * as React from 'react';
 import type { DropResult } from '@hello-pangea/dnd';
 
-import { KanbanBoard } from '../../../../Spaarke.UI.Components/src/components/Kanban/KanbanBoard';
+import { KanbanBoard } from '@spaarke/ui-components/components/Kanban/KanbanBoard';
 import { useKanbanColumns } from '../../hooks/useKanbanColumns';
 import { KanbanCard } from '../KanbanCard';
 import { DEFAULT_TODAY_THRESHOLD, DEFAULT_TOMORROW_THRESHOLD } from '../../hooks/useKanbanColumns';

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/types/kanban.ts
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/types/kanban.ts
@@ -79,7 +79,7 @@ export interface IKanbanCardTodo extends IKanbanTodoLike {
  * import the UI primitive library directly. Source-path import keeps the
  * dependency narrow (same pattern as `PaneHeader` in `SmartTodoWidget.tsx`).
  */
-export type { IKanbanColumn, KanbanOrientation } from '../../../Spaarke.UI.Components/src/components/Kanban/types';
+export type { IKanbanColumn, KanbanOrientation } from '@spaarke/ui-components/components/Kanban/types';
 
 /**
  * Minimal Dataverse service surface the hoisted hook requires to persist

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
@@ -108,8 +108,8 @@ import { ArrowClockwiseRegular, Add20Regular, Open20Regular, Search20Regular } f
 import {
   OrientationToggle,
   type Orientation,
-} from '../../../../Spaarke.UI.Components/src/components/OrientationToggle';
-import { MicrosoftToDoIcon } from '../../../../Spaarke.UI.Components/src/icons/MicrosoftToDoIcon';
+} from '@spaarke/ui-components/components/OrientationToggle';
+import { MicrosoftToDoIcon } from '@spaarke/ui-components/icons/MicrosoftToDoIcon';
 
 import { useSmartTodoWidgetStyles } from './SmartTodoWidget.styles';
 import type { IFeedSyncBridge, IRegardingContext, ITodoRecord, IWebApi } from '../../types/todo';

--- a/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
+++ b/src/client/shared/Spaarke.SmartTodo.Components/src/widgets/SmartTodoWidget/SmartTodoWidget.tsx
@@ -105,10 +105,7 @@ import {
   type InputOnChangeData,
 } from '@fluentui/react-components';
 import { ArrowClockwiseRegular, Add20Regular, Open20Regular, Search20Regular } from '@fluentui/react-icons';
-import {
-  OrientationToggle,
-  type Orientation,
-} from '@spaarke/ui-components/components/OrientationToggle';
+import { OrientationToggle, type Orientation } from '@spaarke/ui-components/components/OrientationToggle';
 import { MicrosoftToDoIcon } from '@spaarke/ui-components/icons/MicrosoftToDoIcon';
 
 import { useSmartTodoWidgetStyles } from './SmartTodoWidget.styles';

--- a/src/client/shared/Spaarke.SmartTodo.Components/tsconfig.json
+++ b/src/client/shared/Spaarke.SmartTodo.Components/tsconfig.json
@@ -14,7 +14,14 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@spaarke/ui-components": ["../Spaarke.UI.Components/dist/index.d.ts"],
+      "@spaarke/ui-components/*": ["../Spaarke.UI.Components/dist/*"],
+      "@fluentui/react-icons": ["./node_modules/@fluentui/react-icons"],
+      "@fluentui/react-icons/*": ["./node_modules/@fluentui/react-icons/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Both `Spaarke.Events.Components` and `Spaarke.SmartTodo.Components` bypassed the `@spaarke/ui-components` package boundary by importing from UI.Components' `src/` via relative-path traversal (`../../../../Spaarke.UI.Components/src/...`). Effect on the orchestrator: each lib's `tsc --noEmit` walked UI.Components' source tree and surfaced its (otherwise-private) source-level type errors. The failure surfaced as `JSX element implicitly has type 'any'` etc. — but the root cause was the boundary bypass, not the UI.Components code.

This PR restores the package boundary using the same pattern as `Spaarke.AI.Widgets` and `Spaarke.DailyBriefing.Components` (PR #506).

## Imports rewritten (6 total)

### `Spaarke.Events.Components` — 1 file, 2 imports
- `src/widgets/CalendarWorkspaceWidget/CalendarWorkspaceWidget.tsx`:
  - `'.../Spaarke.UI.Components/src/components/DataGrid'` → `'@spaarke/ui-components/components/DataGrid'`
  - `'.../Spaarke.UI.Components/src/services/XrmDataverseClient'` → `'@spaarke/ui-components/services/XrmDataverseClient'`

### `Spaarke.SmartTodo.Components` — 3 files, 4 imports
- `src/types/kanban.ts`:
  - `'.../Spaarke.UI.Components/src/components/Kanban/types'` → `'@spaarke/ui-components/components/Kanban/types'`
- `src/widgets/SmartTodoWidget/SmartTodoWidget.tsx`:
  - `'.../Spaarke.UI.Components/src/components/OrientationToggle'` → `'@spaarke/ui-components/components/OrientationToggle'`
  - `'.../Spaarke.UI.Components/src/icons/MicrosoftToDoIcon'` → `'@spaarke/ui-components/icons/MicrosoftToDoIcon'`
- `src/components/SmartTodoKanban/SmartTodoKanban.tsx`:
  - `'.../Spaarke.UI.Components/src/components/Kanban/KanbanBoard'` → `'@spaarke/ui-components/components/Kanban/KanbanBoard'`

Runtime semantics unchanged — the new path resolves to the same compiled dist files via the file: symlink + tsconfig paths.

## Configuration changes (per lib)

### `package.json`
- Add `dependencies: { \"@spaarke/ui-components\": \"file:../Spaarke.UI.Components\" }`
- Add `\"@spaarke/ui-components\": \"*\"` to `peerDependencies` (consumer contract)
- `@fluentui/*` peerDeps + devDeps unchanged. `exports`, `main`, `types` unchanged.

### `tsconfig.json`
- Add `baseUrl: \".\"` + `paths` matching the AI.Widgets pattern:
  - `@spaarke/ui-components` and `@spaarke/ui-components/*` → `../Spaarke.UI.Components/dist/*`
  - `@fluentui/react-icons` and `@fluentui/react-icons/*` → `./node_modules/@fluentui/react-icons/*` (prevents dual-install FluentIcon-type duplication)

### `scripts/Build-AllClientComponents.ps1`
Reorder `$SharedLibs` array: move `Spaarke.UI.Components` from position 7 to position 5, BEFORE Events + SmartTodo (which now declare it as a dep). Sibling comments updated to state the dep explicitly.

Before: `Auth → SdapClient → AI.Context → AI.Outputs → Events → SmartTodo → UI.Components → AI.Widgets`
After:  `Auth → SdapClient → AI.Context → AI.Outputs → UI.Components → Events → SmartTodo → AI.Widgets`

## Verification

\`\`\`
pwsh scripts/Build-AllClientComponents.ps1 -Component SharedLibs

  Component                     Category        Status    Duration
  --------------------------------------------------------------
  Spaarke.Auth                  Shared Library  SUCCESS   1.6s
  Spaarke.SdapClient            Shared Library  SUCCESS   1.1s
  Spaarke.AI.Context            Shared Library  SUCCESS   34.9s
  Spaarke.AI.Outputs            Shared Library  SUCCESS   37.2s
  Spaarke.UI.Components         Shared Library  SUCCESS   8.2s
  Spaarke.Events.Components     Shared Library  SUCCESS   2.8s
  Spaarke.SmartTodo.Components  Shared Library  SUCCESS   2.4s
  Spaarke.AI.Widgets            Shared Library  SUCCESS   43.1s
  Total: 8 components | 8 succeeded | 131.4s total
\`\`\`

## Constraints honored

- ✅ Public `exports` field unchanged in both libs
- ✅ `main` / `types` unchanged (source-only libs)
- ✅ `peerDependencies` not weakened — added one entry to express previously-missing contract
- ✅ `file:` refs match sibling AI.Widgets relative-path convention
- ✅ Runtime semantics unchanged — only build-time module resolution differs

## Relationship to PR #506

Both PRs modify `scripts/Build-AllClientComponents.ps1`. The conflict is mechanical (both touch `$SharedLibs` array) and trivially resolvable:

- If **#506 lands first**: rebase + apply this PR's reorder (move UI.Components from position 7 → position 5)
- If **this PR lands first**: #506 picks up the new order, just adds DailyBriefing.Components at the end

Either order works; the libs themselves are independent fixes.

## Test plan

- [x] `pwsh scripts/Build-AllClientComponents.ps1 -Component SharedLibs` — all 8 libs SUCCESS (verified locally)
- [ ] CI build green
- [ ] Reviewer: confirm downstream consumer solutions (LegalWorkspace, SmartTodo, EventsPage, SpaarkeAi Calendar widget) still build — this PR only changes import paths to resolve to the same compiled artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)