### PR TITLE
fix(ci): satisfy actionlint type-check for ci-tier2-advisory run-* string inputs

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -205,16 +205,23 @@ jobs:
       # Map router classification → tier2's `run-*` toggles per its workflow_call contract.
       # docs_only diffs never reach here (see `if:` above). For everything else, default-on.
       # Skip client-side lint when no client files changed (no spaarke_ai/bff client paths).
-      # All run-* are tier2's string-typed inputs (CICD-086). Literals are quoted
-      # to satisfy actionlint's stricter-than-runtime type check; expressions are
-      # already string-returning per `== 'true'` comparison.
-      run-lint: ${{ needs.classify.outputs.spaarke_ai == 'true' || needs.classify.outputs.bff == 'true' }}
-      run-format: 'true'
-      run-unit-tests: ${{ needs.classify.outputs.bff == 'true' }}
-      run-adr-compliance: 'true'
-      run-markdown: 'true'
-      run-last-reviewed: 'true'
-      run-plugin-size: ${{ needs.classify.outputs.bff == 'true' }}
+      #
+      # All run-* are tier2's string-typed inputs (CICD-086 rationale: avoids
+      # cross-workflow_call coercion surprises that produced startup_failure).
+      # Values MUST be explicit string-returning expressions to satisfy actionlint's
+      # static type check (which treats unwrapped `'true'` literals AND `${{ ==
+      # 'true' }}` boolean comparisons as bool — neither pattern previously worked
+      # despite the now-removed comment claiming otherwise).
+      # Pattern: conditional → `${{ (cond) && 'true' || 'false' }}` (ternary
+      # returns string literal). Always-on → `${{ 'true' }}` (explicit string
+      # expression).
+      run-lint: ${{ (needs.classify.outputs.spaarke_ai == 'true' || needs.classify.outputs.bff == 'true') && 'true' || 'false' }}
+      run-format: ${{ 'true' }}
+      run-unit-tests: ${{ needs.classify.outputs.bff == 'true' && 'true' || 'false' }}
+      run-adr-compliance: ${{ 'true' }}
+      run-markdown: ${{ 'true' }}
+      run-last-reviewed: ${{ 'true' }}
+      run-plugin-size: ${{ needs.classify.outputs.bff == 'true' && 'true' || 'false' }}
 
   # ==========================================================================
   # JOB 4 — Router: THE single required status check (`CI / Router`)


### PR DESCRIPTION
## Summary

Fixes a continuous actionlint failure on master that surfaced during R2 hotfix PR #512 verification:

```
.github/workflows/ci-router.yml:211:17: input \"run-lint\" is typed as string
  by reusable workflow \"./.github/workflows/ci-tier2-advisory.yml\".
  bool value cannot be assigned [expression]
```

The failure repeated for `run-lint`, `run-format`, `run-unit-tests`, `run-adr-compliance`, `run-markdown`, `run-last-reviewed`, `run-plugin-size` — every single \`run-*\` toggle. Present in master independent of any specific PR; would block every future PR from getting a green actionlint check.

## Root cause

[CICD-086 (2026-06-26)](https://github.com/search?q=CICD-086+repo%3Aspaarke-dev%2Fspaarke&type=commits) declared `ci-tier2-advisory.yml`'s `run-*` inputs as `type: string` to avoid cross-workflow_call coercion that previously produced \`startup_failure\` with `type: boolean`. The fix-attempt in ci-router.yml quoted literals as `'true'` and used `${{ x == 'true' }}` boolean comparisons, on the assumption that the quoting would satisfy actionlint's static type check.

It didn't. actionlint:
- Treats quoted YAML scalar `'true'` as bool (matches bool-literal heuristic).
- Treats `${{ x == 'true' }}` as bool (`==` returns bool in GitHub expression language).

Both patterns get inferred as `bool`, which actionlint then rejects against the `type: string` declaration.

## Fix

Convert ALL `run-*` values to explicit string-returning expressions:

- **Conditional**: `${{ (cond) && 'true' || 'false' }}` — ternary always returns a string literal.
- **Always-on**: `${{ 'true' }}` — single-quoted literal inside expression context = string.

Both forms are statically typed as `string` by actionlint, matching the reusable workflow's input declaration. Runtime semantics unchanged (guards in ci-tier2-advisory.yml compare against the string `'false'`).

Updated the inline comment to reflect what actually works.

## Test plan

- [ ] actionlint job in CI passes on this PR (was failing on master + every recent PR)
- [ ] All other Tier 1 + Tier 2 checks still pass (no semantic change to run-* values)
- [ ] Verify Tier 2 jobs still fire for bff/spaarke-ai diffs (run-lint, run-unit-tests, run-plugin-size conditional remained semantically equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)