### PR TITLE
chore(bff-api)(redis-r2): add appsettings.Testing.json with AllowInMemoryFallback default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,12 @@ docs/CONFIGURATION_REQUIREMENTS.md
 **/appsettings.*.json
 !**/appsettings.Development.json.template
 !**/appsettings.Production.json.template
+# appsettings.Testing.json is allow-listed because it contains ONLY CI-safe defaults
+# (no secrets, no connection strings) — see src/server/api/Sprk.Bff.Api/appsettings.Testing.json.
+# ASP.NET Core loads it ONLY when ASPNETCORE_ENVIRONMENT=Testing (never Production, never
+# Development), so anything in it cannot reach a deployed environment. PRs touching this
+# file must keep that invariant (no real conn strings, no real Azure AD tenant IDs, etc.).
+!**/appsettings.Testing.json
 
 # Secrets and keys
 *.secret

--- a/src/server/api/Sprk.Bff.Api/appsettings.Testing.json
+++ b/src/server/api/Sprk.Bff.Api/appsettings.Testing.json
@@ -1,0 +1,8 @@
+{
+  "_purpose_comment": "ASP.NET Core environment-specific overrides loaded ONLY when ASPNETCORE_ENVIRONMENT=Testing. App Service uses Production (never Testing); local dev uses Development. This file's settings reach prod or local-dev configurations by no path. Loaded exclusively by WebApplicationFactory<Program>-based integration tests and CI runs that explicitly set Testing.",
+
+  "Redis": {
+    "_AllowInMemoryFallback_comment": "CI safety default — added 2026-06-30 as a follow-on to PR #521 (AzureMonitorGuard + CacheModule Testing allow-list). CacheModule branch (d) requires explicit opt-in to either Redis (Enabled=true) or in-memory fallback when Enabled=false. CI integration-test fixtures uniformly set Redis:Enabled=false (no real Redis available); shipping AllowInMemoryFallback=true here means CI just works without per-fixture or per-yaml duplication. Replaces the workaround setting Redis__AllowInMemoryFallback=true in .github/workflows/ci-tier1-blocking.yml (commit 37ef38c2f). Note: branch (d)'s fail-fast remains intentional — a deployed env that sets Enabled=false WITHOUT this file (because Testing-only file isn't loaded in deployed envs) still throws, preserving the safety net for misconfiguration.",
+    "AllowInMemoryFallback": true
+  }
+}


### PR DESCRIPTION
## Summary

Follow-on to [PR #521](https://github.com/spaarke-dev/spaarke/pull/521) (AzureMonitorGuard + CacheModule Testing allow-list).

Ships an `appsettings.Testing.json` with `Redis:AllowInMemoryFallback=true`. ASP.NET Core loads this file ONLY when `ASPNETCORE_ENVIRONMENT=Testing` (never Production, never Development). After this lands, CI workflow yaml can drop the explicit `Redis__AllowInMemoryFallback: \"true\"` setting (commit `37ef38c2f` workaround).

## Context

CI failure reported after PR #521 landed:

```
System.InvalidOperationException : Redis is disabled and in-memory fallback not opted in.
Set Redis:Enabled=true (recommended) or Redis:AllowInMemoryFallback=true (Development or Testing only).
```

This is **CacheModule branch (d)** — fires when neither cache backend is opted in. Different from the AzureMonitorGuard / branch (c) bug class PR #521 fixed.

The reporter applied the correct workaround (set `Redis__AllowInMemoryFallback=true` in CI yaml — exactly what the error message guides). This PR provides a cleaner path: ship the default via env-specific config so CI doesn't need the explicit yaml setting.

## Why not relax branch (d) at the validation layer

Branch (d) fires when neither Redis nor in-memory fallback is opted in. It's the **\"you forgot to wire ANY cache backend\" fail-fast** — intentional per R1 task 003 / ADR-009. Allow-listing Testing in branch (d) would silently default to in-memory cache when a developer forgets to configure anything. Hides misconfigs.

Config-layer approach preserves the explicit-opt-in semantic while shipping a sensible Testing-env default. If someone explicitly sets `AllowInMemoryFallback=false` in Testing, branch (d) still throws (correct behavior).

## Changes

- **`src/server/api/Sprk.Bff.Api/appsettings.Testing.json`** (NEW) — `Redis:AllowInMemoryFallback: true` with inline `_comment` field explaining purpose and the deployed-env safety invariant.
- **`.gitignore`** — narrow allow-list exception for `appsettings.Testing.json` (existing rule blocks all `appsettings.*.json` to prevent secret leaks; Testing files contain ONLY CI-safe defaults by design, and the comment requires PR authors to maintain that invariant).

## How the deployed-env safety guarantee is preserved

- App Service uses `ASPNETCORE_ENVIRONMENT=Production` → this file IS NOT loaded.
- Local dev uses `ASPNETCORE_ENVIRONMENT=Development` → this file IS NOT loaded.
- Only Testing-env runs (CI, WAF fixtures) → this file IS loaded.

Even though the file ships in the publish output (~1.3 KB), it cannot influence runtime behavior in deployed envs because ASP.NET Core's config loader only loads it when the env name matches.

## Test plan

- [x] `dotnet build src/server/api/Sprk.Bff.Api/` — 0 errors
- [x] `dotnet publish -c Release` — file present in output as `appsettings.Testing.json` (1.3 KB)
- [ ] CI Tier 1 (Blocking) checks pass
- [ ] After merge: cleanup PR to remove both yaml env vars from `ci-tier1-blocking.yml` (the `APPLICATIONINSIGHTS_CONNECTION_STRING` fake key from commit `fd657e0b2` was obsoleted by PR #521; the `Redis__AllowInMemoryFallback` setting from commit `37ef38c2f` is obsoleted by this PR).

## Future-proofing

Inline comment in `.gitignore` requires PR authors keep `appsettings.Testing.json` to CI-safe defaults only (no real connection strings, no real tenant IDs). The file is a defaults provider, not a secrets vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)