### PR TITLE
Merge R7 Wave 12 polish + High Priority section into master

### DIFF
--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/ActivityNotesSection.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/ActivityNotesSection.tsx
@@ -160,9 +160,6 @@ export const ActivityNotesSection: React.FC<ActivityNotesSectionProps> = ({
   if (isLoading) {
     return (
       <div>
-        <Text as="h2" size={500} weight="semibold" className={styles.heading}>
-          Activity Notes
-        </Text>
         <Skeleton aria-label="Loading activity notes">
           {[0, 1, 2].map(sectionIdx => (
             <div key={sectionIdx} className={styles.skeletonSection}>
@@ -196,11 +193,10 @@ export const ActivityNotesSection: React.FC<ActivityNotesSectionProps> = ({
     return null;
   }
 
+  // R7 W12 feedback item 10 (2026-07-01): "Activity Notes" title removed;
+  // each ChannelHeading is now the top-level section anchor per operator request.
   return (
     <div>
-      <Text as="h2" size={500} weight="semibold" className={styles.heading}>
-        Activity Notes
-      </Text>
       {filteredNarratives.map(channel => (
         <div key={channel.category} className={styles.channelSection}>
           <ChannelHeading

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/ActivityNotesSection.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/ActivityNotesSection.tsx
@@ -74,6 +74,15 @@ interface ChannelNarrativeBullet {
   primaryEntityType: string;
   primaryEntityId: string;
   primaryEntityName: string;
+  /** R7 W12 feedback items 2/3/4 — passed through to NarrativeBullet for
+   * inline-link + trailing-[N]-citation rendering. Optional for back-compat. */
+  references?: {
+    index: number;
+    entityType: string;
+    entityId: string;
+    entityName: string;
+    mentioned: boolean;
+  }[];
 }
 
 /** Shape of a channel narrative group. */
@@ -217,6 +226,7 @@ export const ActivityNotesSection: React.FC<ActivityNotesSectionProps> = ({
                 primaryEntityType={bullet.primaryEntityType}
                 primaryEntityId={bullet.primaryEntityId}
                 itemIds={bullet.itemIds}
+                references={bullet.references}
                 onAddToTodo={onAddToTodo}
                 onDismiss={onDismiss}
                 isTodoCreated={isTodoCreated(firstItemId)}

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx
@@ -52,6 +52,7 @@ import { TldrSection } from './TldrSection';
 import { ActivityNotesSection } from './ActivityNotesSection';
 import { CaughtUpFooter } from './CaughtUpFooter';
 import { PreferencesDropdown } from './PreferencesDropdown';
+import { HighPrioritySection } from './HighPrioritySection';
 import { useBriefingRender, useInlineTodoCreate, useBriefingPreferences } from '../hooks';
 import { TOASTER_ID } from '../utils/toastUtils';
 import type { IWebApi, NotificationCategory, NotificationItem } from '../types/notifications';
@@ -493,8 +494,9 @@ export const DailyBriefingApp: React.FC<DailyBriefingAppProps> = ({ params: _par
     );
   }
 
-  // Success — render TldrSection + filtered channelNarratives.
+  // Success — render HighPriority (if any) + TldrSection + filtered channelNarratives.
   const tldr = renderData?.tldr ?? null;
+  const highPriorityItems = renderData?.highPriorityItems ?? [];
 
   return (
     <div className={styles.container}>
@@ -506,6 +508,8 @@ export const DailyBriefingApp: React.FC<DailyBriefingAppProps> = ({ params: _par
         onBrowsePlaybooks={onBrowsePlaybooks}
       />
       <div className={styles.scrollContent}>
+        {/* R7 W12 feedback item 9 (2026-07-01): high-priority section above TL;DR. */}
+        <HighPrioritySection items={highPriorityItems} onOpenRecord={handleOpenRecord} />
         <TldrSection
           tldr={tldr}
           isLoading={false}

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/DailyBriefingApp.tsx
@@ -40,6 +40,8 @@ import {
   Toast,
   ToastTitle,
   ToastBody,
+  ToastFooter,
+  Link,
   MessageBar,
   MessageBarBody,
   MessageBarTitle,
@@ -226,7 +228,19 @@ export const DailyBriefingApp: React.FC<DailyBriefingAppProps> = ({ params: _par
 
   // Inline To Do creation from narrative bullets — writes first-class sprk_todo
   // records per ADR-024 + smart-todo-decoupling-r3 FR-29.
-  const { createTodo, isCreated, isPending, getError: getTodoError } = useInlineTodoCreate(webApi);
+  //
+  // R7 W12 feedback item 7 (2026-07-01): userId is passed so the hook can
+  // look up the user's sprk_primarycontact and bind it to sprk_assignedto on
+  // every created todo.
+  // R7 W12 feedback item 8 (2026-07-01): getCreatedId returns the new sprk_todo
+  // GUID so the success toast can wire an "Open To Do" action.
+  const {
+    createTodo,
+    isCreated,
+    isPending,
+    getError: getTodoError,
+    getCreatedId,
+  } = useInlineTodoCreate(webApi, userId);
 
   // Toaster setup for success/error notifications
   const toasterId = useId(TOASTER_ID);
@@ -309,12 +323,35 @@ export const DailyBriefingApp: React.FC<DailyBriefingAppProps> = ({ params: _par
             { intent: 'error', timeout: 5000 }
           );
         } else {
+          // R7 W12 feedback item 8: 15s timeout + "Open To Do" action link.
+          // Navigates to the newly-created sprk_todo record via the same
+          // Xrm.Navigation modal pattern the regarding-name link uses.
+          const newTodoId = getCreatedId(synthesized.id);
+          const openTodo = (): void => {
+            if (!newTodoId) return;
+            const navigateTo: ((page: object, options?: object) => Promise<unknown>) | undefined =
+              xrm?.Navigation?.navigateTo;
+            if (typeof navigateTo !== 'function') return;
+            navigateTo(
+              { pageType: 'entityrecord', entityName: 'sprk_todo', entityId: newTodoId },
+              { target: 2, width: { value: 80, unit: '%' }, height: { value: 80, unit: '%' } }
+            ).catch(() => {
+              /* user closed dialog */
+            });
+          };
           dispatchToast(
             <Toast>
               <ToastTitle>Added to To Do</ToastTitle>
               <ToastBody>{synthesized.title}</ToastBody>
+              {newTodoId ? (
+                <ToastFooter>
+                  <Link appearance="default" onClick={openTodo}>
+                    Open To Do
+                  </Link>
+                </ToastFooter>
+              ) : null}
             </Toast>,
-            { intent: 'success', timeout: 3000 }
+            { intent: 'success', timeout: 15000 }
           );
         }
       } catch (e) {
@@ -327,7 +364,7 @@ export const DailyBriefingApp: React.FC<DailyBriefingAppProps> = ({ params: _par
         );
       }
     },
-    [bulletIndex, generatedAtIso, createTodo, getTodoError, dispatchToast]
+    [bulletIndex, generatedAtIso, createTodo, getTodoError, getCreatedId, dispatchToast, xrm]
   );
 
   /**

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/HighPrioritySection.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/HighPrioritySection.tsx
@@ -1,0 +1,227 @@
+/**
+ * HighPrioritySection — cross-entity flagged-item roll-up shown above the TL;DR.
+ *
+ * R7 W12 feedback item 9 (2026-07-01):
+ *   "create a top section above TL;DR with a light subtle red background title
+ *    'High Priority'; this lists items that are due today or that are overdue
+ *    and the associated record has value sprk_monitor = yes or sprk_priority
+ *    (renamed sprk_highpriority in the shipped schema) = yes."
+ *
+ * MVP behavior (aligned with operator intent):
+ *   - Renders the section only when items[].length > 0. Empty state → null
+ *     (no wasted vertical space; the classic TL;DR fills the top).
+ *   - Each item is a clickable Link that opens the record in a Dataverse modal
+ *     (target:2, 80%×80%) via the parent's onOpenRecord callback.
+ *   - Compact single-line rows: [kindLabel] · Name · optional overdue/today badge.
+ *   - Subtle-red banner background using Fluent v9 semantic tokens
+ *     (colorPaletteRedBackground1) — passes dark-mode adaptation per ADR-021.
+ *   - Server-side sort is preserved (due-ascending, undated last).
+ *
+ * Constraints:
+ *   - ADR-021: Fluent v9 tokens only, dark-mode via semantic tokens.
+ *   - Xrm-free: navigation happens in the parent via onOpenRecord.
+ */
+
+import * as React from 'react';
+import {
+  makeStyles,
+  tokens,
+  Text,
+  Link,
+  Badge,
+} from '@fluentui/react-components';
+import { AlertUrgentRegular } from '@fluentui/react-icons';
+
+import type { HighPriorityItemResult } from '../services/briefingService';
+
+// ---------------------------------------------------------------------------
+// Styles (Fluent v9 semantic tokens only — ADR-021)
+// ---------------------------------------------------------------------------
+
+const useStyles = makeStyles({
+  container: {
+    // Subtle red banner. colorPaletteRedBackground1 is Fluent's lightest red;
+    // adapts in dark mode. Border adds visual anchor without heavy weight.
+    backgroundColor: tokens.colorPaletteRedBackground1,
+    borderTopWidth: '1px',
+    borderRightWidth: '1px',
+    borderBottomWidth: '1px',
+    borderLeftWidth: '1px',
+    borderTopStyle: 'solid',
+    borderRightStyle: 'solid',
+    borderBottomStyle: 'solid',
+    borderLeftStyle: 'solid',
+    borderTopColor: tokens.colorPaletteRedBorderActive,
+    borderRightColor: tokens.colorPaletteRedBorderActive,
+    borderBottomColor: tokens.colorPaletteRedBorderActive,
+    borderLeftColor: tokens.colorPaletteRedBorderActive,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingHorizontalM,
+    marginBottom: tokens.spacingVerticalL,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
+    marginBottom: tokens.spacingVerticalS,
+  },
+  headerIcon: {
+    fontSize: '20px',
+    color: tokens.colorPaletteRedForeground1,
+  },
+  headerText: {
+    color: tokens.colorPaletteRedForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  itemRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
+    paddingTop: tokens.spacingVerticalXXS,
+    paddingBottom: tokens.spacingVerticalXXS,
+    flexWrap: 'wrap',
+  },
+  kindLabel: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    minWidth: '90px',
+  },
+  itemLink: {
+    color: tokens.colorBrandForeground1,
+    textDecorationLine: 'none',
+    cursor: 'pointer',
+    ':hover': {
+      textDecorationLine: 'underline',
+    },
+    // Allow the name to grow but not push badges off-screen.
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  badgeOverdue: {
+    // Use Fluent's `severe` intent for overdue; distinct from the container's
+    // red background so it still reads as urgent.
+  },
+  badgeDueToday: {
+    // `warning` intent for due-today — softer than overdue.
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface HighPrioritySectionProps {
+  /** High-priority items from /render — pre-sorted by due date ascending. */
+  items: HighPriorityItemResult[];
+  /** Called on item click. Wire to the parent's Xrm.Navigation modal open. */
+  onOpenRecord?: (entityType: string, entityId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a due date relative to "today UTC start" for badge selection.
+ * Undated → null (no badge). Past → "overdue". Today → "today". Future → null
+ * (no badge — the section is already showing them because they're flagged).
+ */
+type DueClassification = 'overdue' | 'today' | 'future' | null;
+
+function classifyDueDate(iso: string | undefined): DueClassification {
+  if (!iso) return null;
+  try {
+    const due = new Date(iso);
+    if (Number.isNaN(due.getTime())) return null;
+    const now = new Date();
+    const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const tomorrowStart = new Date(todayStart.getTime() + 24 * 60 * 60 * 1000);
+    if (due < todayStart) return 'overdue';
+    if (due < tomorrowStart) return 'today';
+    return 'future';
+  } catch {
+    return null;
+  }
+}
+
+function formatDueLabel(iso: string | undefined, classification: DueClassification): string | null {
+  if (!iso || classification === null) return null;
+  try {
+    const due = new Date(iso);
+    if (Number.isNaN(due.getTime())) return null;
+    const shortDate = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(due);
+    if (classification === 'overdue') return `Overdue · ${shortDate}`;
+    if (classification === 'today') return `Due today`;
+    return `Due ${shortDate}`;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const HighPrioritySection: React.FC<HighPrioritySectionProps> = ({ items, onOpenRecord }) => {
+  const styles = useStyles();
+
+  if (!Array.isArray(items) || items.length === 0) {
+    return null;
+  }
+
+  const handleOpen = (entityType: string, entityId: string): void => {
+    if (!entityType || !entityId) return;
+    onOpenRecord?.(entityType, entityId);
+  };
+
+  return (
+    <div className={styles.container} role="region" aria-label="High priority items">
+      <div className={styles.header}>
+        <AlertUrgentRegular className={styles.headerIcon} aria-hidden="true" />
+        <Text as="h2" size={400} className={styles.headerText}>
+          High Priority ({items.length})
+        </Text>
+      </div>
+      {items.map(item => {
+        const classification = classifyDueDate(item.dueDate);
+        const dueLabel = formatDueLabel(item.dueDate, classification);
+        return (
+          <div key={`${item.entityType}-${item.entityId}`} className={styles.itemRow}>
+            {item.kindLabel && (
+              <Text size={200} className={styles.kindLabel}>
+                {item.kindLabel}
+              </Text>
+            )}
+            <Link
+              appearance="default"
+              className={styles.itemLink}
+              onClick={() => handleOpen(item.entityType, item.entityId)}
+              role="link"
+              tabIndex={0}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') handleOpen(item.entityType, item.entityId);
+              }}
+            >
+              {item.name || '(untitled)'}&nbsp;&#8599;
+            </Link>
+            {classification === 'overdue' && dueLabel && (
+              <Badge appearance="filled" color="danger" size="small" className={styles.badgeOverdue}>
+                {dueLabel}
+              </Badge>
+            )}
+            {classification === 'today' && dueLabel && (
+              <Badge appearance="filled" color="warning" size="small" className={styles.badgeDueToday}>
+                {dueLabel}
+              </Badge>
+            )}
+            {classification === 'future' && dueLabel && (
+              <Badge appearance="outline" color="informative" size="small">
+                {dueLabel}
+              </Badge>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
@@ -76,7 +76,7 @@ import {
   MenuItem,
 } from '@fluentui/react-components';
 import {
-  MoreHorizontalRegular,
+  MoreVerticalRegular,
   CheckmarkRegular,
   DismissRegular,
   CalendarAddRegular,
@@ -479,7 +479,7 @@ export const NarrativeBullet: React.FC<NarrativeBulletProps> = ({
         */}
         <Menu>
           <MenuTrigger disableButtonEnhancement>
-            <MenuButton appearance="subtle" size="small" icon={<MoreHorizontalRegular />} aria-label="More actions" />
+            <MenuButton appearance="subtle" size="small" icon={<MoreVerticalRegular />} aria-label="More actions" />
           </MenuTrigger>
           <MenuPopover>
             <MenuList>

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeBullet.tsx
@@ -83,8 +83,10 @@ import {
   OpenRegular,
 } from '@fluentui/react-icons';
 import type { NotificationItem } from '../types/notifications';
+import type { NarrativeBulletReferenceResult } from '../services/briefingService';
 import { formatDueDate } from '../utils/formatDueDate';
 import { SubRow } from './SubRow';
+import { NarrativeCitedText } from './NarrativeCitedText';
 
 // ---------------------------------------------------------------------------
 // Styles (Fluent v9 semantic tokens only -- ADR-021)
@@ -176,6 +178,16 @@ export interface NarrativeBulletProps {
   primaryEntityId: string;
   /** Notification IDs covered by this bullet. */
   itemIds: string[];
+  /**
+   * R7 W12 feedback items 2/3/4 (2026-07-01) — per-bullet entity references.
+   * When supplied and non-empty, the narrative text is rendered with inline
+   * hyperlinks on mentioned entity names + trailing [N] citations for implicit
+   * refs (via <NarrativeCitedText />). The separate regarding-name link line
+   * below the narrative is suppressed to avoid duplication.
+   * When omitted or empty, the classic plain-text + separate-link render is
+   * preserved (back-compat).
+   */
+  references?: NarrativeBulletReferenceResult[];
   /** Callback to add the covered notifications to To Do. */
   onAddToTodo: (itemIds: string[]) => void;
   /** Callback to dismiss the covered notifications. */
@@ -263,6 +275,7 @@ export const NarrativeBullet: React.FC<NarrativeBulletProps> = ({
   onRemove,
   onKeep,
   onOpenRecord,
+  references,
 }) => {
   const styles = useStyles();
 
@@ -384,10 +397,25 @@ export const NarrativeBullet: React.FC<NarrativeBulletProps> = ({
         &bull;
       </Text>
       <div className={styles.content}>
-        <Text size={300} className={styles.narrativeText}>
-          {narrative}
-        </Text>
-        {primaryEntityName && primaryEntityType && primaryEntityId && (
+        {references && references.length > 0 ? (
+          // R7 W12 feedback items 2/3/4 (2026-07-01): inline entity-name links
+          // + trailing [N] citations. Renderer handles both mentioned + implicit
+          // refs; the separate regarding-name line below is suppressed because
+          // the mentioned refs already surface it inline.
+          <NarrativeCitedText
+            narrative={narrative}
+            references={references}
+            onOpenRecord={onOpenRecord}
+            textSize={300}
+          />
+        ) : (
+          <Text size={300} className={styles.narrativeText}>
+            {narrative}
+          </Text>
+        )}
+        {/* Legacy standalone regarding-name link — only rendered when the
+             bullet has NO references[] (back-compat / narrator degraded path). */}
+        {(!references || references.length === 0) && primaryEntityName && primaryEntityType && primaryEntityId && (
           <Text
             size={300}
             className={styles.entityLink}

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeCitedText.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/NarrativeCitedText.tsx
@@ -1,0 +1,243 @@
+/**
+ * NarrativeCitedText — renders a narrative sentence with inline entity-name
+ * hyperlinks + trailing [N] citations.
+ *
+ * R7 W12 feedback items 2/3/4 (2026-07-01):
+ *   Every fact-based statement in an AI-narrated bullet should be traceable to
+ *   a source record. This component takes the plain narrative text plus a
+ *   references[] array and produces mixed text + Link output:
+ *
+ *   - Mentioned refs (entity name appears in text): wrap first occurrence of
+ *     `entityName` in a clickable Link with an "open" arrow icon (↗). Click →
+ *     `onOpenRecord(entityType, entityId)`.
+ *
+ *   - Implicit refs (entity NOT mentioned in text): append trailing
+ *     [1][2][3]... superscript citations. Click → same handler.
+ *
+ * Graceful degradation:
+ *   - references.length === 0 → renders as plain <Text>{narrative}</Text>.
+ *   - onOpenRecord omitted → links render but click is a no-op (still
+ *     visually distinct so operator sees the citation).
+ *
+ * Constraints:
+ *   - ADR-021: Fluent v9 tokens only, dark-mode via semantic tokens.
+ *   - Xrm-free: navigation happens in the parent via onOpenRecord (matches
+ *     the existing DailyBriefingApp.handleOpenRecord pattern).
+ */
+
+import * as React from 'react';
+import { makeStyles, tokens, Text, Link } from '@fluentui/react-components';
+
+import type { NarrativeBulletReferenceResult } from '../services/briefingService';
+
+// ---------------------------------------------------------------------------
+// Styles (Fluent v9 semantic tokens only — ADR-021)
+// ---------------------------------------------------------------------------
+
+const useStyles = makeStyles({
+  wrapper: {
+    color: tokens.colorNeutralForeground1,
+    lineHeight: tokens.lineHeightBase400,
+    // wrap over multiple lines like the original <Text>.
+    display: 'inline',
+  },
+  inlineLink: {
+    // Preserve token-driven brand color on the inline link.
+    color: tokens.colorBrandForeground1,
+    textDecorationLine: 'none',
+    cursor: 'pointer',
+    ':hover': {
+      textDecorationLine: 'underline',
+    },
+  },
+  citationList: {
+    display: 'inline',
+    marginLeft: tokens.spacingHorizontalXS,
+  },
+  citationLink: {
+    color: tokens.colorBrandForeground1,
+    textDecorationLine: 'none',
+    cursor: 'pointer',
+    fontSize: tokens.fontSizeBase200,
+    verticalAlign: 'super',
+    lineHeight: 1,
+    marginLeft: tokens.spacingHorizontalXXS,
+    marginRight: tokens.spacingHorizontalXXS,
+    ':hover': {
+      textDecorationLine: 'underline',
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface NarrativeCitedTextProps {
+  /** Plain narrative text emitted by the LLM. */
+  narrative: string;
+  /**
+   * Per-bullet references. When empty (or omitted), the component renders
+   * plain text — no interactive elements.
+   */
+  references?: NarrativeBulletReferenceResult[];
+  /**
+   * Called with (entityType, entityId) on any inline link or trailing citation
+   * click. Wire this to the parent's Xrm.Navigation.navigateTo (target:2)
+   * handler. When omitted, links render but click is a no-op.
+   */
+  onOpenRecord?: (entityType: string, entityId: string) => void;
+  /** Text size passed through to the Fluent Text primitive. Default: 300. */
+  textSize?: 200 | 300 | 400 | 500;
+}
+
+// ---------------------------------------------------------------------------
+// Segment builder — splits narrative text around mentioned entity names.
+// ---------------------------------------------------------------------------
+
+type Segment =
+  | { kind: 'text'; text: string }
+  | {
+      kind: 'link';
+      display: string;
+      entityType: string;
+      entityId: string;
+    };
+
+function buildSegments(
+  narrative: string,
+  mentioned: readonly NarrativeBulletReferenceResult[]
+): Segment[] {
+  if (!narrative) return [];
+  if (mentioned.length === 0) return [{ kind: 'text', text: narrative }];
+
+  // Find the first case-insensitive occurrence of each mentioned entity name.
+  // Skip refs whose name is empty or too short (avoid false matches on tokens
+  // like "of", "a"). Skip refs whose target ids are empty (no click target).
+  const lowerText = narrative.toLowerCase();
+  interface Match {
+    ref: NarrativeBulletReferenceResult;
+    start: number;
+    end: number;
+  }
+  const matches: Match[] = [];
+  const usedRanges: Array<[number, number]> = [];
+
+  for (const ref of mentioned) {
+    if (!ref.entityName || ref.entityName.length < 3) continue;
+    if (!ref.entityId) continue;
+    const idx = lowerText.indexOf(ref.entityName.toLowerCase());
+    if (idx < 0) continue;
+    const end = idx + ref.entityName.length;
+    // Skip if it overlaps with a previously matched range (defensive — dedupe
+    // narrative text with overlapping name matches).
+    const overlaps = usedRanges.some(([s, e]) => idx < e && end > s);
+    if (overlaps) continue;
+    matches.push({ ref, start: idx, end });
+    usedRanges.push([idx, end]);
+  }
+
+  matches.sort((a, b) => a.start - b.start);
+
+  const segments: Segment[] = [];
+  let cursor = 0;
+  for (const m of matches) {
+    if (m.start > cursor) {
+      segments.push({ kind: 'text', text: narrative.substring(cursor, m.start) });
+    }
+    segments.push({
+      kind: 'link',
+      display: narrative.substring(m.start, m.end),
+      entityType: m.ref.entityType,
+      entityId: m.ref.entityId,
+    });
+    cursor = m.end;
+  }
+  if (cursor < narrative.length) {
+    segments.push({ kind: 'text', text: narrative.substring(cursor) });
+  }
+  return segments;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const NarrativeCitedText: React.FC<NarrativeCitedTextProps> = ({
+  narrative,
+  references,
+  onOpenRecord,
+  textSize = 300,
+}) => {
+  const styles = useStyles();
+
+  const refs = React.useMemo<NarrativeBulletReferenceResult[]>(
+    () => (Array.isArray(references) ? references : []),
+    [references]
+  );
+
+  const mentionedRefs = React.useMemo(() => refs.filter(r => r.mentioned), [refs]);
+  const implicitRefs = React.useMemo(() => refs.filter(r => !r.mentioned && r.entityId), [refs]);
+
+  const segments = React.useMemo(() => buildSegments(narrative, mentionedRefs), [narrative, mentionedRefs]);
+
+  const handleClick = React.useCallback(
+    (entityType: string, entityId: string): void => {
+      if (!entityType || !entityId) return;
+      onOpenRecord?.(entityType, entityId);
+    },
+    [onOpenRecord]
+  );
+
+  // Nothing to render when narrative is empty AND there are no implicit refs.
+  if (!narrative && implicitRefs.length === 0) {
+    return null;
+  }
+
+  return (
+    <Text as="span" size={textSize} className={styles.wrapper}>
+      {segments.map((seg, i) => {
+        if (seg.kind === 'text') {
+          return <React.Fragment key={i}>{seg.text}</React.Fragment>;
+        }
+        // Inline entity-name link — appended arrow (↗) matches the existing
+        // regarding-name link on NarrativeBullet.
+        return (
+          <Link
+            key={i}
+            appearance="default"
+            className={styles.inlineLink}
+            onClick={() => handleClick(seg.entityType, seg.entityId)}
+            role="link"
+            tabIndex={0}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') handleClick(seg.entityType, seg.entityId);
+            }}
+          >
+            {seg.display}&nbsp;&#8599;
+          </Link>
+        );
+      })}
+      {implicitRefs.length > 0 && (
+        <span className={styles.citationList}>
+          {implicitRefs.map(ref => (
+            <Link
+              key={ref.index}
+              appearance="default"
+              className={styles.citationLink}
+              onClick={() => handleClick(ref.entityType, ref.entityId)}
+              title={ref.entityName || `Reference ${ref.index}`}
+              role="link"
+              tabIndex={0}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') handleClick(ref.entityType, ref.entityId);
+              }}
+            >
+              [{ref.index}]
+            </Link>
+          ))}
+        </span>
+      )}
+    </Text>
+  );
+};

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/index.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/index.ts
@@ -47,6 +47,9 @@ export type { NarrativeBulletProps } from './NarrativeBullet';
 export { NarrativeCitedText } from './NarrativeCitedText';
 export type { NarrativeCitedTextProps } from './NarrativeCitedText';
 
+export { HighPrioritySection } from './HighPrioritySection';
+export type { HighPrioritySectionProps } from './HighPrioritySection';
+
 // Sub-list slot components (FR-11..FR-14). Task 020 (Wave 8) lays the
 // skeleton + slot files; tasks 021/022/023 (Wave 9) implement per-row
 // link / To-Do / Dismiss behavior. Slots are exported here so consumers

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/index.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/index.ts
@@ -44,6 +44,9 @@ export type { ChannelHeadingProps } from './ChannelHeading';
 export { NarrativeBullet } from './NarrativeBullet';
 export type { NarrativeBulletProps } from './NarrativeBullet';
 
+export { NarrativeCitedText } from './NarrativeCitedText';
+export type { NarrativeCitedTextProps } from './NarrativeCitedText';
+
 // Sub-list slot components (FR-11..FR-14). Task 020 (Wave 8) lays the
 // skeleton + slot files; tasks 021/022/023 (Wave 9) implement per-row
 // link / To-Do / Dismiss behavior. Slots are exported here so consumers

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useBriefingRender.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useBriefingRender.ts
@@ -65,7 +65,12 @@ function isEmptyResponse(response: NarrateResponse): boolean {
     (tldr?.summary?.trim().length ?? 0) > 0 ||
     (tldr?.topAction?.trim().length ?? 0) > 0 ||
     (Array.isArray(tldr?.keyTakeaways) && tldr.keyTakeaways.length > 0);
-  return !hasTldrText;
+  if (hasTldrText) return false;
+  // R7 W12 feedback item 9 (2026-07-01): high-priority items ALONE are enough
+  // to keep the widget out of the empty state — operators want flagged records
+  // visible even when narrative channels are empty.
+  const hasHighPriority = Array.isArray(response.highPriorityItems) && response.highPriorityItems.length > 0;
+  return !hasHighPriority;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useInlineTodoCreate.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/hooks/useInlineTodoCreate.ts
@@ -66,6 +66,12 @@ export interface UseInlineTodoCreateResult {
   isPending: (itemId: string) => boolean;
   /** Returns the error message for a failed creation, or undefined. */
   getError: (itemId: string) => string | undefined;
+  /**
+   * Returns the sprk_todoid of the created record for this notification, or undefined
+   * if creation hasn't succeeded yet. Used by the widget to wire "Open To Do" toast
+   * actions (R7 W12 feedback item 8).
+   */
+  getCreatedId: (itemId: string) => string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,11 +187,22 @@ async function _discoverNavProps(entityLogicalName: string): Promise<INavPropEnt
  * Hook for inline To Do creation from notification items.
  *
  * @param webApi - Xrm.WebApi reference (from xrmProvider). Pass null if not yet available.
- * @returns Object with createTodo, isCreated, isPending, getError functions.
+ * @param userId - Optional current-user systemuserid. When supplied, the hook looks up the
+ *                 user's `sprk_primarycontact` and sets it as `sprk_assignedto` on every
+ *                 created sprk_todo (R7 W12 feedback item 7). Primary-contact value is
+ *                 cached in a ref for the hook's lifetime.
+ * @returns Object with createTodo, isCreated, isPending, getError, getCreatedId functions.
  */
-export function useInlineTodoCreate(webApi: IWebApi | null): UseInlineTodoCreateResult {
+export function useInlineTodoCreate(
+  webApi: IWebApi | null,
+  userId?: string
+): UseInlineTodoCreateResult {
   const [statusMap, setStatusMap] = useState<Map<string, TodoCreateStatus>>(() => new Map());
   const errorsRef = useRef<Map<string, string>>(new Map());
+  const createdIdRef = useRef<Map<string, string>>(new Map());
+  // Cache the current user's sprk_primarycontact value. undefined = not looked up yet;
+  // null = looked up + no primary contact configured on the user record.
+  const primaryContactRef = useRef<string | null | undefined>(undefined);
 
   const createTodo = useCallback(
     async (item: NotificationItem): Promise<void> => {
@@ -202,6 +219,30 @@ export function useInlineTodoCreate(webApi: IWebApi | null): UseInlineTodoCreate
       });
 
       try {
+        // R7 W12 feedback item 7 — resolve the current user's sprk_primarycontact
+        // (cached across creates for this hook lifetime). We do the lookup lazily
+        // on first createTodo rather than at hook-mount so consumers that never
+        // add to To Do don't pay the query cost. Fail-soft: if the field is missing
+        // or the query fails, primarycontact stays null and sprk_assignedto is left
+        // unset (the existing pre-item-7 behavior).
+        if (primaryContactRef.current === undefined && userId) {
+          try {
+            const user = await webApi.retrieveRecord(
+              'systemuser',
+              userId,
+              '?$select=_sprk_primarycontact_value'
+            );
+            const rawContact = (user as Record<string, unknown>)['_sprk_primarycontact_value'];
+            primaryContactRef.current = typeof rawContact === 'string' && rawContact.length > 0 ? rawContact : null;
+          } catch (lookupErr) {
+            console.info(
+              '[useInlineTodoCreate] sprk_primarycontact lookup failed — sprk_assignedto will be left unset:',
+              lookupErr
+            );
+            primaryContactRef.current = null;
+          }
+        }
+
         // 1. Build the core sprk_todo record (per entity-schema.md + SmartTodo
         //    DataverseService.createTodo pattern).
         const record: Record<string, unknown> = {
@@ -220,6 +261,13 @@ export function useInlineTodoCreate(webApi: IWebApi | null): UseInlineTodoCreate
           // sprk_notes is the rich-text/long-text body field on sprk_todo
           // (replaces the legacy sprk_event.sprk_description path).
           record['sprk_notes'] = item.body;
+        }
+
+        // R7 W12 feedback item 7 — bind sprk_assignedto to the current user's
+        // primary contact when known. Uses the @odata.bind syntax expected by
+        // Xrm.WebApi.createRecord for lookup fields (target entity set 'contacts').
+        if (primaryContactRef.current) {
+          record['sprk_assignedto@odata.bind'] = `/contacts(${primaryContactRef.current})`;
         }
 
         // 2. Apply regarding (multi-entity resolution per ADR-024) — only when
@@ -262,7 +310,10 @@ export function useInlineTodoCreate(webApi: IWebApi | null): UseInlineTodoCreate
         }
 
         // 3. Create the sprk_todo record (NEVER sprk_event).
-        await webApi.createRecord('sprk_todo', record);
+        const createResult = await webApi.createRecord('sprk_todo', record);
+        if (createResult?.id) {
+          createdIdRef.current.set(item.id, createResult.id);
+        }
 
         // Success
         setStatusMap(prev => {
@@ -292,7 +343,7 @@ export function useInlineTodoCreate(webApi: IWebApi | null): UseInlineTodoCreate
         });
       }
     },
-    [webApi]
+    [webApi, userId]
   );
 
   const isCreated = useCallback((itemId: string): boolean => statusMap.get(itemId) === 'created', [statusMap]);
@@ -307,5 +358,13 @@ export function useInlineTodoCreate(webApi: IWebApi | null): UseInlineTodoCreate
     [statusMap]
   );
 
-  return { createTodo, isCreated, isPending, getError };
+  const getCreatedId = useCallback(
+    (itemId: string): string | undefined => createdIdRef.current.get(itemId),
+    // Depend on statusMap so consumers re-render when creation completes and
+    // pick up the newly-populated id.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [statusMap]
+  );
+
+  return { createTodo, isCreated, isPending, getError, getCreatedId };
 }

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/services/briefingService.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/services/briefingService.ts
@@ -125,6 +125,28 @@ export interface NarrativeBulletResult {
   primaryEntityType: string;
   primaryEntityId: string;
   primaryEntityName: string;
+  /**
+   * R7 W12 feedback items 2/3/4 (2026-07-01) — per-bullet entity references.
+   * Ordered by first-appearance in narrative text (mentioned refs), then by
+   * channel order (implicit refs). Widget renders:
+   * - `mentioned=true` refs: wrap `entityName` in narrative text as clickable Link.
+   * - `mentioned=false` refs: append trailing `[N]` citations.
+   * Empty array (or field absent) => plain-text bullet, no citations.
+   */
+  references?: NarrativeBulletReferenceResult[];
+}
+
+export interface NarrativeBulletReferenceResult {
+  /** 1-based citation index for trailing `[N]` markers. */
+  index: number;
+  /** Dataverse logical name of the target entity (e.g., "sprk_matter"). */
+  entityType: string;
+  /** GUID of the target record. */
+  entityId: string;
+  /** Display name of the target record. */
+  entityName: string;
+  /** True if `entityName` appears in the narrative text. */
+  mentioned: boolean;
 }
 
 /** Result of a narration fetch attempt. */

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/services/briefingService.ts
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/services/briefingService.ts
@@ -99,6 +99,32 @@ export interface NarrateResponse {
   tldr: TldrResult;
   channelNarratives: ChannelNarrationResult[];
   generatedAtUtc: string;
+  /**
+   * R7 W12 feedback item 9 (2026-07-01) — cross-entity high-priority items.
+   * Populated when any of the 7 flagged entities (matter, project, invoice,
+   * document, workassignment, event, todo) has sprk_HighPriority=true or
+   * sprk_Monitor=true. Widget renders a compact "High Priority" section
+   * above the TL;DR with subtle red background. Absent/empty = no flagged
+   * items → widget hides the section.
+   */
+  highPriorityItems?: HighPriorityItemResult[];
+}
+
+export interface HighPriorityItemResult {
+  /** Dataverse logical name (e.g., "sprk_matter"). */
+  entityType: string;
+  /** GUID of the record. */
+  entityId: string;
+  /** Display name of the record. */
+  name: string;
+  /** ISO 8601 due date, or undefined for entities with no meaningful due date. */
+  dueDate?: string;
+  /** True if sprk_highpriority = Yes on the source record. */
+  highPriority: boolean;
+  /** True if sprk_monitor = Yes on the source record. */
+  monitor: boolean;
+  /** Short entity-kind label (e.g., "Matter", "Task", "To Do"). */
+  kindLabel: string;
 }
 
 export interface TldrResult {

--- a/src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs
+++ b/src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs
@@ -141,20 +141,36 @@ public static class DailyBriefingEndpoints
 
         try
         {
-            var payload = await collector.CollectAsync(systemUserId, cancellationToken).ConfigureAwait(false);
+            // R7 W12 feedback item 9 (2026-07-01): fan out the daily-briefing collect
+            // AND the high-priority scan in parallel — they hit disjoint Dataverse
+            // queries and combined latency stays close to the slower of the two.
+            var payloadTask = collector.CollectAsync(systemUserId, cancellationToken);
+            var highPriorityTask = collector.CollectHighPriorityAsync(systemUserId, cancellationToken);
+            await Task.WhenAll(payloadTask, highPriorityTask).ConfigureAwait(false);
+            var payload = await payloadTask.ConfigureAwait(false);
+            var highPriorityItems = await highPriorityTask.ConfigureAwait(false);
+
             if (payload.Channels.Length == 0 && payload.PriorityItems.Length == 0 && payload.Categories.Length == 0)
             {
-                logger.LogInformation("Daily briefing render: no notable items for systemuserid={SystemUserId} — returning empty narrative", systemUserId);
+                logger.LogInformation(
+                    "Daily briefing render: no notable channel items for systemuserid={SystemUserId} — returning narrative-empty response (highPriorityItems={HighPriorityCount})",
+                    systemUserId, highPriorityItems.Length);
+                // High-priority items STILL surface even when channel narrations are empty
+                // — operator wants flagged items visible regardless of channel content.
                 return TypedResults.Ok(new DailyBriefingNarrateResponse
                 {
                     Tldr = new TldrResult { Summary = string.Empty, KeyTakeaways = [], TopAction = string.Empty },
                     ChannelNarratives = [],
                     GeneratedAtUtc = DateTimeOffset.UtcNow,
+                    HighPriorityItems = highPriorityItems,
                 });
             }
 
             var response = await narrator.NarrateAsync(payload, cancellationToken).ConfigureAwait(false);
-            return TypedResults.Ok(response);
+            // Attach high-priority items via record `with` — narrator is unaware of this
+            // field (bypasses LLM per operator design decision — high priority is a
+            // structured list, not narrative content).
+            return TypedResults.Ok(response with { HighPriorityItems = highPriorityItems });
         }
         catch (OperationCanceledException)
         {
@@ -819,6 +835,18 @@ public record DailyBriefingNarrateResponse
     public DateTimeOffset GeneratedAtUtc { get; init; }
 
     /// <summary>
+    /// R7 W12 feedback item 9 (2026-07-01) — HIGH PRIORITY items across the 7 flagged
+    /// entities (sprk_matter, sprk_project, sprk_invoice, sprk_document,
+    /// sprk_workassignment, sprk_event, sprk_todo). Populated by
+    /// <c>DailyBriefingCollector.CollectHighPriorityAsync</c>, bypasses the narrator
+    /// (no LLM call — plain structured list). Widget renders a subtle red banner section
+    /// above the TL;DR when this array is non-empty. Ordered by due date ascending (undated
+    /// items last). Empty array = no flagged items, widget hides the section.
+    /// </summary>
+    [JsonPropertyName("highPriorityItems")]
+    public HighPriorityItemDto[] HighPriorityItems { get; init; } = [];
+
+    /// <summary>
     /// Optional sidecar with post-LLM entity-name validation metadata. Added by R7
     /// Wave 11 narrator spike (2026-06-30) to mirror the original playbook design's
     /// <c>_validationMetadata</c> responseBinding. Null when no scrubbing occurred
@@ -828,6 +856,51 @@ public record DailyBriefingNarrateResponse
     [JsonPropertyName("_validationMetadata")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ValidationMetadataDto? ValidationMetadata { get; init; }
+}
+
+/// <summary>
+/// A high-priority item from one of the 7 flagged entities. Assembled directly by
+/// <c>DailyBriefingCollector.CollectHighPriorityAsync</c> — no LLM narration. Widget
+/// renders as a compact list of clickable record refs with optional due-date badge.
+/// </summary>
+public record HighPriorityItemDto
+{
+    /// <summary>Dataverse logical name of the source entity (sprk_matter, sprk_event, etc.).</summary>
+    [JsonPropertyName("entityType")]
+    public string EntityType { get; init; } = "";
+
+    /// <summary>GUID of the source record — used by widget's Xrm.Navigation modal open.</summary>
+    [JsonPropertyName("entityId")]
+    public string EntityId { get; init; } = "";
+
+    /// <summary>Display name of the source record (primary name field per entity).</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    /// <summary>
+    /// Due date (ISO 8601) when the entity has a meaningful due-date field. Omitted (null)
+    /// for entities without a due date (matter, project, document, invoice). Widget uses
+    /// this to render an overdue/due-today badge next to the entry.
+    /// </summary>
+    [JsonPropertyName("dueDate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? DueDate { get; init; }
+
+    /// <summary>True if <c>sprk_highpriority</c> is Yes on the source record.</summary>
+    [JsonPropertyName("highPriority")]
+    public bool HighPriority { get; init; }
+
+    /// <summary>True if <c>sprk_monitor</c> is Yes on the source record.</summary>
+    [JsonPropertyName("monitor")]
+    public bool Monitor { get; init; }
+
+    /// <summary>
+    /// Optional short entity-label the widget can render next to the name (e.g., "Matter",
+    /// "Project", "Task"). Server-side rendering — widget just prints. Empty when the
+    /// entity's kind is implicit from the parent context.
+    /// </summary>
+    [JsonPropertyName("kindLabel")]
+    public string KindLabel { get; init; } = "";
 }
 
 /// <summary>

--- a/src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs
+++ b/src/server/api/Sprk.Bff.Api/Api/Ai/DailyBriefingEndpoints.cs
@@ -912,4 +912,50 @@ public record NarrativeBulletDto
     /// <summary>Display name of the primary related record.</summary>
     [JsonPropertyName("primaryEntityName")]
     public string PrimaryEntityName { get; init; } = "";
+
+    /// <summary>
+    /// R7 W12 feedback items 2/3/4 (2026-07-01): per-bullet entity references
+    /// for widget-side citation rendering. Each entry maps to a specific record
+    /// referenced by this bullet. Ordered by narrative appearance when possible.
+    /// The widget renders these two ways:
+    /// - Entries with <c>Mentioned=true</c>: replace <c>Name</c> in narrative
+    ///   text with a clickable Link that opens the record modal.
+    /// - Entries with <c>Mentioned=false</c>: append trailing <c>[N]</c>
+    ///   superscript citations after the narrative text.
+    /// Empty array = plain-text bullet (no interactive citations).
+    /// </summary>
+    [JsonPropertyName("references")]
+    public NarrativeBulletReferenceDto[] References { get; init; } = [];
+}
+
+/// <summary>
+/// A single reference from a narrative bullet to a Dataverse record. Drives the
+/// widget's inline hyperlink / trailing citation rendering. Ordered by narrative
+/// appearance when possible (post-processor scans narrative text left-to-right).
+/// </summary>
+public record NarrativeBulletReferenceDto
+{
+    /// <summary>1-based citation index for trailing <c>[N]</c> refs.</summary>
+    [JsonPropertyName("index")]
+    public int Index { get; init; }
+
+    /// <summary>Dataverse logical name of the target entity (e.g., "sprk_matter").</summary>
+    [JsonPropertyName("entityType")]
+    public string EntityType { get; init; } = "";
+
+    /// <summary>GUID of the target record.</summary>
+    [JsonPropertyName("entityId")]
+    public string EntityId { get; init; } = "";
+
+    /// <summary>Display name of the target record.</summary>
+    [JsonPropertyName("entityName")]
+    public string EntityName { get; init; } = "";
+
+    /// <summary>
+    /// True if <c>EntityName</c> appears in the narrative text (widget replaces
+    /// the name span with a clickable Link). False if the reference is only
+    /// implicit (widget renders as trailing <c>[N]</c> citation).
+    /// </summary>
+    [JsonPropertyName("mentioned")]
+    public bool Mentioned { get; init; }
 }

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Membership/MembershipFieldDiscoveryService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Membership/MembershipFieldDiscoveryService.cs
@@ -82,6 +82,20 @@ public class MembershipFieldDiscoveryService : IMembershipFieldDiscoveryService
         @"\d+$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    // ── R7 W12 T130 follow-up (2026-06-30) — well-known target sets for
+    // polymorphic Owner + Customer attributes. These are fixed by the Dataverse
+    // data model regardless of solution / entity — every Owner column targets
+    // systemuser + team; every Customer column targets account + contact.
+    // Used by FetchLookupAttributesAsync's fallback pass to synthesize
+    // LookupAttributeRow entries when the SDK's `.OfType<LookupAttributeMetadata>()`
+    // filter drops them (Owner/Customer are separate AttributeTypeCode values
+    // but the SDK exposes them without a distinct LookupAttributeMetadata
+    // subclass; see FetchLookupAttributesAsync rationale block for evidence).
+    private static readonly IReadOnlyList<string> OwnerAttributeTargets =
+        new[] { "systemuser", "team" };
+    private static readonly IReadOnlyList<string> CustomerAttributeTargets =
+        new[] { "account", "contact" };
+
     private readonly IDataverseService _dataverse;
     private readonly ITenantCache _cache;
     private readonly IHttpContextAccessor? _httpContextAccessor;
@@ -419,19 +433,7 @@ public class MembershipFieldDiscoveryService : IMembershipFieldDiscoveryService
                 () => serviceClient.Execute(request), ct).ConfigureAwait(false);
 
             var attributes = response.EntityMetadata?.Attributes ?? Array.Empty<AttributeMetadata>();
-            var rows = new List<LookupAttributeRow>();
-            foreach (var attr in attributes.OfType<LookupAttributeMetadata>())
-            {
-                if (string.IsNullOrWhiteSpace(attr.LogicalName))
-                {
-                    continue;
-                }
-
-                rows.Add(new LookupAttributeRow(
-                    LogicalName: attr.LogicalName,
-                    Targets: attr.Targets ?? Array.Empty<string>()));
-            }
-            return rows;
+            return ProjectLookupAttributeRows(attributes);
         }
         catch (OperationCanceledException)
         {
@@ -447,6 +449,104 @@ public class MembershipFieldDiscoveryService : IMembershipFieldDiscoveryService
             throw new InvalidOperationException(
                 $"Entity '{entityLogicalName}' not found in Dataverse metadata.", ex);
         }
+    }
+
+    // ── R7 W12 T130 follow-up (2026-06-30) — testable projection of the
+    // SDK's raw attribute list into LookupAttributeRow[] with polymorphic
+    // Owner + Customer synthesis. Extracted from FetchLookupAttributesAsync
+    // as `internal static` so unit tests can pin the classification
+    // contract without constructing a RetrieveEntityResponse.
+    //
+    // Rationale + evidence (root cause of production symptom "sprk_matter
+    // resolved rows=0 for a user who owns 44 matters via ownerid"):
+    //
+    //   Empirical check on the shipped Microsoft.Xrm.Sdk.dll
+    //   (Microsoft.PowerPlatform.Dataverse.Client v1.1.32 → net6.0 asset)
+    //   confirms:
+    //     * `LookupAttributeMetadata` is `sealed` and inherits directly from
+    //       `AttributeMetadata` — there is no `OwnerAttributeMetadata` subclass
+    //       in the modern SDK's public type surface (verified by enumerating
+    //       every `*AttributeMetadata` type in the loaded assembly).
+    //     * `AttributeMetadata`'s [KnownType] deserialization allow-list does
+    //       NOT include a distinct OwnerAttributeMetadata type either — so
+    //       Owner-typed attributes deserialize as base `AttributeMetadata`
+    //       when the server sends `@odata.type=OwnerAttributeMetadata`.
+    //     * `AttributeTypeCode` has three lookup-shaped values —
+    //       `Lookup = 6`, `Customer = 1`, `Owner = 9`.
+    //
+    //   Observed production symptom (R7 W12, 2026-06-30 App Insights):
+    //   `MembershipFieldDiscoveryService resolved entity=sprk_matter
+    //    (discovered=14, excluded=4, ignored=6)` and
+    //   `MembershipResolverService resolved ... (descriptors=14, conditions=9,
+    //    rows=0)` — but the user OWNS 44 matters via `ownerid = {systemUserId}
+    //    AND statecode = 0` (verified via raw SQL). Only `ownerid` matches
+    //    those 44 rows for that user; the assigned* fields do not. Therefore
+    //    `ownerid` must be missing from the 14 descriptors — meaning the
+    //    `OfType<LookupAttributeMetadata>()` filter dropped it.
+    //
+    // Fix: after the primary LookupAttributeMetadata pass, walk every
+    // attribute whose `AttributeType` is Owner or Customer and synthesize a
+    // LookupAttributeRow using the well-known Dataverse target sets
+    // (Owner → {systemuser, team}; Customer → {account, contact}). The `seen`
+    // set guarantees an attribute captured by the primary path is never
+    // double-counted (belt-and-suspenders for SDK versions where the primary
+    // path DOES pick up the Owner/Customer attributes).
+    internal static IReadOnlyList<LookupAttributeRow> ProjectLookupAttributeRows(
+        IEnumerable<AttributeMetadata> attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        var rows = new List<LookupAttributeRow>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Primary pass: LookupAttributeMetadata (sealed; covers standard Lookup
+        // attributes and — depending on SDK version — some Customer/Owner
+        // deserializations). Extract Targets[] as-is.
+        foreach (var attr in attributes.OfType<LookupAttributeMetadata>())
+        {
+            if (string.IsNullOrWhiteSpace(attr.LogicalName))
+            {
+                continue;
+            }
+
+            rows.Add(new LookupAttributeRow(
+                LogicalName: attr.LogicalName,
+                Targets: attr.Targets ?? Array.Empty<string>()));
+            seen.Add(attr.LogicalName);
+        }
+
+        // Fallback pass: any Owner or Customer attribute the primary pass
+        // didn't catch. Synthesize the well-known target set.
+        foreach (var attr in attributes)
+        {
+            if (attr is null || string.IsNullOrWhiteSpace(attr.LogicalName))
+            {
+                continue;
+            }
+            if (seen.Contains(attr.LogicalName))
+            {
+                continue;
+            }
+
+            var syntheticTargets = attr.AttributeType switch
+            {
+                AttributeTypeCode.Owner    => OwnerAttributeTargets,
+                AttributeTypeCode.Customer => CustomerAttributeTargets,
+                _                          => null
+            };
+
+            if (syntheticTargets is null)
+            {
+                continue;
+            }
+
+            rows.Add(new LookupAttributeRow(
+                LogicalName: attr.LogicalName,
+                Targets: syntheticTargets));
+            seen.Add(attr.LogicalName);
+        }
+
+        return rows;
     }
 
     /// <summary>

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Narrators/DailyBriefingCollector.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Narrators/DailyBriefingCollector.cs
@@ -240,6 +240,257 @@ public class DailyBriefingCollector
     }
 
     // ──────────────────────────────────────────────────────────────────────────
+    // High Priority section (R7 W12 feedback item 9)
+    //
+    // Cross-entity flag scan: returns every record across the 7 flagged entities
+    // (matter, project, invoice, document, workassignment, event, todo) where
+    // sprk_HighPriority = true OR sprk_Monitor = true — regardless of ownership
+    // in this MVP (operator flags what THEY care about; scoping by owninguser is
+    // a follow-up refinement if the list becomes too broad).
+    //
+    // No LLM call — widget renders as a compact list of clickable record refs.
+    // Ordered by due date ascending (undated items last).
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// R7 W12 feedback item 9 (2026-07-01) — collect all high-priority items across the 7
+    /// flagged entities. Bypasses membership resolution + narrator. Returns items whose
+    /// <c>sprk_HighPriority</c> OR <c>sprk_Monitor</c> = true, sorted by due date ascending.
+    /// Empty array on error (per-entity queries are failure-soft).
+    /// </summary>
+    public virtual async Task<HighPriorityItemDto[]> CollectHighPriorityAsync(
+        Guid systemUserId,
+        CancellationToken ct)
+    {
+        if (systemUserId == Guid.Empty)
+        {
+            throw new ArgumentException("systemUserId is required", nameof(systemUserId));
+        }
+        var startedAt = DateTimeOffset.UtcNow;
+
+        _logger.LogInformation(
+            "DailyBriefingCollector.CollectHighPriorityAsync starting for systemUserId={SystemUserId}",
+            systemUserId);
+
+        // 7 parallel queries — one per flagged entity. Each returns HighPriorityItemDto[].
+        // Every query is failure-soft: on Dataverse exception, the entity contributes
+        // an empty array (logged as warning) so the digest still renders.
+        var queries = await Task.WhenAll(
+            QueryHighPriorityMatterAsync(ct),
+            QueryHighPriorityProjectAsync(ct),
+            QueryHighPriorityInvoiceAsync(ct),
+            QueryHighPriorityDocumentAsync(ct),
+            QueryHighPriorityWorkassignmentAsync(ct),
+            QueryHighPriorityEventAsync(ct),
+            QueryHighPriorityTodoAsync(systemUserId, ct)
+        ).ConfigureAwait(false);
+
+        var all = queries.SelectMany(x => x)
+            .OrderBy(x => x.DueDate ?? DateTimeOffset.MaxValue)
+            .ThenBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        _logger.LogInformation(
+            "DailyBriefingCollector.CollectHighPriorityAsync completed in {DurationMs}ms: total={Total} " +
+            "(matters={M}, projects={P}, invoices={I}, docs={D}, workassignments={W}, events={E}, todos={T})",
+            (long)(DateTimeOffset.UtcNow - startedAt).TotalMilliseconds,
+            all.Length,
+            queries[0].Length, queries[1].Length, queries[2].Length, queries[3].Length,
+            queries[4].Length, queries[5].Length, queries[6].Length);
+
+        return all;
+    }
+
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityMatterAsync(CancellationToken ct)
+    {
+        return await QueryHighPriorityGenericAsync(
+            entityType: EntityMatter,
+            idColumn: "sprk_matterid",
+            nameColumn: "sprk_mattername",
+            dueDateColumn: null,
+            kindLabel: "Matter",
+            includeStateFilter: true,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityProjectAsync(CancellationToken ct)
+    {
+        return await QueryHighPriorityGenericAsync(
+            entityType: EntityProject,
+            idColumn: "sprk_projectid",
+            nameColumn: "sprk_projectname",
+            dueDateColumn: null,
+            kindLabel: "Project",
+            includeStateFilter: true,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityInvoiceAsync(CancellationToken ct)
+    {
+        // Invoice has sprk_invoicedate (invoice date, NOT payment due date) — don't map to
+        // DueDate. Include all flagged invoices regardless of date. Operator can refine later.
+        return await QueryHighPriorityGenericAsync(
+            entityType: "sprk_invoice",
+            idColumn: "sprk_invoiceid",
+            nameColumn: "sprk_name",
+            dueDateColumn: null,
+            kindLabel: "Invoice",
+            includeStateFilter: true,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityDocumentAsync(CancellationToken ct)
+    {
+        return await QueryHighPriorityGenericAsync(
+            entityType: EntityDocument,
+            idColumn: "sprk_documentid",
+            nameColumn: "sprk_documentname",
+            dueDateColumn: null,
+            kindLabel: "Document",
+            includeStateFilter: true,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityWorkassignmentAsync(CancellationToken ct)
+    {
+        return await QueryHighPriorityGenericAsync(
+            entityType: "sprk_workassignment",
+            idColumn: "sprk_workassignmentid",
+            nameColumn: "sprk_name",
+            dueDateColumn: "sprk_responseduedate",
+            kindLabel: "Work Assignment",
+            includeStateFilter: true,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityEventAsync(CancellationToken ct)
+    {
+        // Event has both sprk_duedate and sprk_finalduedate; use sprk_finalduedate first,
+        // fall back to sprk_duedate. This mirrors QueryUpcomingTasksAsync's precedence.
+        return await QueryHighPriorityGenericAsync(
+            entityType: EntityEvent,
+            idColumn: "sprk_eventid",
+            nameColumn: "sprk_eventname",
+            dueDateColumn: "sprk_finalduedate",
+            fallbackDueDateColumn: "sprk_duedate",
+            kindLabel: "Task",
+            includeStateFilter: false,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityTodoAsync(Guid systemUserId, CancellationToken ct)
+    {
+        // R7 W12 fix (2026-07-01): todos scoped to `owninguser = systemUserId` to match
+        // the primary Todos channel — operators shouldn't see other users' flagged todos
+        // in their own briefing.
+        return await QueryHighPriorityGenericAsync(
+            entityType: EntityTodo,
+            idColumn: "sprk_todoid",
+            nameColumn: "sprk_name",
+            dueDateColumn: "sprk_duedate",
+            kindLabel: "To Do",
+            includeStateFilter: true,
+            ownerUserId: systemUserId,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Shared query pattern for high-priority items on any of the 7 flagged entities.
+    /// Applies the flag filter (sprk_HighPriority=true OR sprk_Monitor=true), optional
+    /// state filter (statecode=0), and optional owner filter (owninguser=systemuserid).
+    /// Projects into HighPriorityItemDto. Failure-soft: returns empty array on error.
+    /// </summary>
+    private async Task<HighPriorityItemDto[]> QueryHighPriorityGenericAsync(
+        string entityType,
+        string idColumn,
+        string nameColumn,
+        string? dueDateColumn,
+        string kindLabel,
+        bool includeStateFilter,
+        CancellationToken ct,
+        string? fallbackDueDateColumn = null,
+        Guid? ownerUserId = null)
+    {
+        try
+        {
+            var columns = new List<string> { idColumn, nameColumn, "sprk_HighPriority", "sprk_Monitor" };
+            if (!string.IsNullOrEmpty(dueDateColumn)) columns.Add(dueDateColumn);
+            if (!string.IsNullOrEmpty(fallbackDueDateColumn)) columns.Add(fallbackDueDateColumn);
+
+            var query = new QueryExpression(entityType)
+            {
+                NoLock = true,
+                TopCount = PerChannelMaxRows,
+                ColumnSet = new ColumnSet(columns.ToArray())
+            };
+
+            // Flag filter: HighPriority OR Monitor
+            var flagGroup = new FilterExpression(LogicalOperator.Or);
+            flagGroup.AddCondition("sprk_HighPriority", ConditionOperator.Equal, true);
+            flagGroup.AddCondition("sprk_Monitor", ConditionOperator.Equal, true);
+            query.Criteria.AddFilter(flagGroup);
+
+            if (includeStateFilter)
+            {
+                query.Criteria.AddCondition("statecode", ConditionOperator.Equal, 0);
+            }
+
+            if (ownerUserId.HasValue && ownerUserId.Value != Guid.Empty)
+            {
+                query.Criteria.AddCondition("owninguser", ConditionOperator.Equal, ownerUserId.Value);
+            }
+
+            var result = await _entityService.RetrieveMultipleAsync(query, ct).ConfigureAwait(false);
+            var items = new List<HighPriorityItemDto>(result.Entities.Count);
+            foreach (var e in result.Entities)
+            {
+                var id = e.GetAttributeValue<Guid>(idColumn);
+                if (id == Guid.Empty) continue;
+
+                DateTimeOffset? dueDate = null;
+                if (!string.IsNullOrEmpty(dueDateColumn))
+                {
+                    var raw = e.GetAttributeValue<DateTime?>(dueDateColumn);
+                    if (!raw.HasValue && !string.IsNullOrEmpty(fallbackDueDateColumn))
+                    {
+                        raw = e.GetAttributeValue<DateTime?>(fallbackDueDateColumn);
+                    }
+                    if (raw.HasValue)
+                    {
+                        dueDate = new DateTimeOffset(DateTime.SpecifyKind(raw.Value, DateTimeKind.Utc));
+                    }
+                }
+
+                var highPriority = e.GetAttributeValue<bool?>("sprk_HighPriority") ?? false;
+                var monitor = e.GetAttributeValue<bool?>("sprk_Monitor") ?? false;
+
+                items.Add(new HighPriorityItemDto
+                {
+                    EntityType = entityType,
+                    EntityId = id.ToString(),
+                    Name = e.GetAttributeValue<string>(nameColumn) ?? "(untitled)",
+                    DueDate = dueDate,
+                    HighPriority = highPriority,
+                    Monitor = monitor,
+                    KindLabel = kindLabel,
+                });
+            }
+            return items.ToArray();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "DailyBriefingCollector.QueryHighPriority failed for entity={EntityType} — returning empty",
+                entityType);
+            return Array.Empty<HighPriorityItemDto>();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Membership resolution (delegates to IMembershipResolverService)
     // ──────────────────────────────────────────────────────────────────────────
 

--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Narrators/DailyBriefingNarrator.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Narrators/DailyBriefingNarrator.cs
@@ -347,9 +347,28 @@ public class DailyBriefingNarrator
             }
         }
 
+        // R7 W12 feedback items 2/3/4 (2026-07-01) — build per-bullet references[]
+        // for widget-side inline citations. Two categories:
+        //   - Mentioned refs: item's RegardingName or Title appears in the narrative
+        //     text. Widget wraps the name in a clickable Link (opens modal).
+        //   - Implicit refs: bullet aggregates additional channel items whose names
+        //     don't appear in text (LLM said "several others" instead of naming).
+        //     Widget renders as trailing [N] citations.
+        //
+        // Coverage rule: when the LLM emits aggregated statements ("several to-dos
+        // added recently"), the collector's channel items provide the ground truth.
+        // If the LLM mentioned only ONE item explicitly but the channel has 5 items,
+        // we surface all 5 — mentioned=true for the named one, mentioned=false for
+        // the other 4. Operator can click any of them.
+        var references = BuildBulletReferences(narrativeText, matches, channelItems);
+
         if (matches.Count == 0)
         {
-            return new NarrativeBulletDto { Narrative = narrativeText };
+            return new NarrativeBulletDto
+            {
+                Narrative = narrativeText,
+                References = references,
+            };
         }
 
         var itemIds = matches
@@ -370,6 +389,7 @@ public class DailyBriefingNarrator
                 PrimaryEntityType = primaryByRegarding.RegardingEntityType ?? string.Empty,
                 PrimaryEntityId = primaryByRegarding.RegardingId ?? string.Empty,
                 PrimaryEntityName = primaryByRegarding.RegardingName ?? string.Empty,
+                References = references,
             };
         }
 
@@ -390,6 +410,7 @@ public class DailyBriefingNarrator
                 PrimaryEntityName = !string.IsNullOrEmpty(primaryBySource.Title)
                     ? primaryBySource.Title
                     : (primaryBySource.RegardingName ?? string.Empty),
+                References = references,
             };
         }
 
@@ -403,7 +424,147 @@ public class DailyBriefingNarrator
             PrimaryEntityType = primary.RegardingEntityType ?? string.Empty,
             PrimaryEntityId = primary.RegardingId ?? string.Empty,
             PrimaryEntityName = primary.RegardingName ?? string.Empty,
+            References = references,
         };
+    }
+
+    /// <summary>
+    /// R7 W12 feedback items 2/3/4 — build the References array for a bullet.
+    /// Combines two sources:
+    ///   1. Explicit mentions (RegardingName or Title appears in narrativeText) →
+    ///      <c>Mentioned=true</c>, widget renders name as inline Link.
+    ///   2. Implicit refs from remaining <paramref name="channelItems"/> whose
+    ///      names don't appear in text — <c>Mentioned=false</c>, widget renders
+    ///      as trailing <c>[N]</c> citations.
+    ///
+    /// Each reference resolves to a click-through target using the same tiered
+    /// logic as the primary entity (regarding first, then source entity type).
+    /// Dedupes by target (EntityType + EntityId) so a single record cited by
+    /// both RegardingName and Title only produces one reference.
+    ///
+    /// Ordering: mentioned refs by first-appearance in text (left-to-right),
+    /// then implicit refs by channel-items order. Index numbers reflect this
+    /// order so trailing [1][2][3] citations line up with the narrative reading.
+    /// </summary>
+    private static NarrativeBulletReferenceDto[] BuildBulletReferences(
+        string narrativeText,
+        IReadOnlyList<ChannelItemDto> matches,
+        ChannelItemDto[] channelItems)
+    {
+        if (channelItems is null || channelItems.Length == 0)
+        {
+            return Array.Empty<NarrativeBulletReferenceDto>();
+        }
+
+        // (a) Score matches by first-appearance in narrative text so inline
+        //     links render in reading order. Items not found in text get
+        //     int.MaxValue and sort last.
+        var scored = matches
+            .Select(m => new
+            {
+                Item = m,
+                Position = FirstMentionIndex(narrativeText, m),
+            })
+            .OrderBy(x => x.Position)
+            .ToList();
+
+        // (b) Add channel items that WEREN'T mentioned — implicit refs.
+        var mentionedIds = new HashSet<string>(
+            matches.Select(m => m.Id).Where(id => !string.IsNullOrEmpty(id)),
+            StringComparer.OrdinalIgnoreCase);
+        var implicitItems = channelItems
+            .Where(ci => !string.IsNullOrEmpty(ci.Id) && !mentionedIds.Contains(ci.Id))
+            .ToList();
+
+        var references = new List<NarrativeBulletReferenceDto>();
+        var seenTargets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        int index = 1;
+
+        foreach (var scoredMatch in scored)
+        {
+            var refDto = BuildReferenceFor(scoredMatch.Item, index, mentioned: true);
+            var targetKey = refDto.EntityType + "|" + refDto.EntityId;
+            if (string.IsNullOrEmpty(refDto.EntityId) || seenTargets.Add(targetKey))
+            {
+                references.Add(refDto);
+                index++;
+            }
+        }
+
+        foreach (var implicitItem in implicitItems)
+        {
+            var refDto = BuildReferenceFor(implicitItem, index, mentioned: false);
+            var targetKey = refDto.EntityType + "|" + refDto.EntityId;
+            if (string.IsNullOrEmpty(refDto.EntityId) || seenTargets.Add(targetKey))
+            {
+                references.Add(refDto);
+                index++;
+            }
+        }
+
+        return references.ToArray();
+    }
+
+    /// <summary>
+    /// Build a NarrativeBulletReferenceDto for one channel item using the same
+    /// tiered click-target logic as the primary entity resolver: regarding first,
+    /// then source entity type, then bare fields as fallback.
+    /// </summary>
+    private static NarrativeBulletReferenceDto BuildReferenceFor(ChannelItemDto item, int index, bool mentioned)
+    {
+        string entityType;
+        string entityId;
+        string entityName;
+
+        if (!string.IsNullOrEmpty(item.RegardingId))
+        {
+            entityType = item.RegardingEntityType ?? string.Empty;
+            entityId = item.RegardingId ?? string.Empty;
+            entityName = item.RegardingName ?? string.Empty;
+        }
+        else if (!string.IsNullOrEmpty(item.SourceEntityType) && !string.IsNullOrEmpty(item.Id))
+        {
+            entityType = item.SourceEntityType ?? string.Empty;
+            entityId = item.Id ?? string.Empty;
+            entityName = !string.IsNullOrEmpty(item.Title) ? item.Title : (item.RegardingName ?? string.Empty);
+        }
+        else
+        {
+            entityType = item.RegardingEntityType ?? string.Empty;
+            entityId = item.RegardingId ?? string.Empty;
+            entityName = item.RegardingName ?? string.Empty;
+        }
+
+        return new NarrativeBulletReferenceDto
+        {
+            Index = index,
+            EntityType = entityType,
+            EntityId = entityId,
+            EntityName = entityName,
+            Mentioned = mentioned,
+        };
+    }
+
+    /// <summary>
+    /// Returns the character index of the first mention of a channel item in
+    /// <paramref name="narrativeText"/>, or int.MaxValue if not mentioned.
+    /// Checks RegardingName first, then Title. Case-insensitive, ≥3-char guard.
+    /// </summary>
+    private static int FirstMentionIndex(string narrativeText, ChannelItemDto item)
+    {
+        int regardingIdx = NameIndex(narrativeText, item.RegardingName);
+        int titleIdx = NameIndex(narrativeText, item.Title);
+        int best = int.MaxValue;
+        if (regardingIdx >= 0 && regardingIdx < best) best = regardingIdx;
+        if (titleIdx >= 0 && titleIdx < best) best = titleIdx;
+        return best;
+    }
+
+    private static int NameIndex(string narrativeText, string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name) || name.Length < 3) return -1;
+        return narrativeText.IndexOf(name, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/Membership/MembershipFieldDiscoveryServiceTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/Membership/MembershipFieldDiscoveryServiceTests.cs
@@ -467,6 +467,128 @@ public class MembershipFieldDiscoveryServiceTests
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // R7 W12 T130 follow-up (2026-06-30) — polymorphic Owner + Customer
+    // fallback synthesis. Pins the ProjectLookupAttributeRows contract that
+    // fixes the "sprk_matter resolved rows=0 for a user who owns 44 matters"
+    // production symptom. See rationale block in MembershipFieldDiscoveryService
+    // for evidence + root-cause analysis.
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ProjectLookupAttributeRows_OwnerAttributeAsBaseAttributeMetadata_SynthesizesSystemUserAndTeamTargets()
+    {
+        // Simulates the modern-SDK deserialization behavior for polymorphic
+        // Owner attributes: `ownerid` comes back as base `AttributeMetadata`
+        // with `AttributeType=Owner` because OwnerAttributeMetadata is not a
+        // registered [KnownType] on AttributeMetadata. Without the fallback
+        // synthesis, `.OfType<LookupAttributeMetadata>()` would drop it.
+        var ownerAttr = CreateBaseAttributeMetadata(Microsoft.Xrm.Sdk.Metadata.AttributeTypeCode.Owner);
+        ownerAttr.LogicalName = "ownerid";
+
+        var regularLookup = new Microsoft.Xrm.Sdk.Metadata.LookupAttributeMetadata();
+        regularLookup.LogicalName = "sprk_someregularlookup";
+
+        var attributes = new Microsoft.Xrm.Sdk.Metadata.AttributeMetadata[]
+        {
+            ownerAttr,
+            regularLookup,
+        };
+
+        var rows = MembershipFieldDiscoveryService.ProjectLookupAttributeRows(attributes);
+
+        rows.Should().HaveCount(2);
+
+        var ownerRow = rows.Single(r => r.LogicalName == "ownerid");
+        ownerRow.Targets.Should().BeEquivalentTo(new[] { "systemuser", "team" },
+            because: "polymorphic Owner attributes always target systemuser + team in Dataverse");
+
+        var regularRow = rows.Single(r => r.LogicalName == "sprk_someregularlookup");
+        regularRow.Targets.Should().BeEmpty(
+            because: "the regular Lookup has no Targets configured in this synthetic test");
+    }
+
+    [Fact]
+    public void ProjectLookupAttributeRows_CustomerAttributeAsBaseAttributeMetadata_SynthesizesAccountAndContactTargets()
+    {
+        // Same rationale as the Owner case, but for polymorphic Customer
+        // attributes (targets account + contact — the standard Dataverse
+        // Customer type binding).
+        var customerAttr = CreateBaseAttributeMetadata(Microsoft.Xrm.Sdk.Metadata.AttributeTypeCode.Customer);
+        customerAttr.LogicalName = "customerid";
+
+        var attributes = new[] { customerAttr };
+
+        var rows = MembershipFieldDiscoveryService.ProjectLookupAttributeRows(attributes);
+
+        var customerRow = rows.Should().ContainSingle().Subject;
+        customerRow.LogicalName.Should().Be("customerid");
+        customerRow.Targets.Should().BeEquivalentTo(new[] { "account", "contact" });
+    }
+
+    [Fact]
+    public void ProjectLookupAttributeRows_OwnerAttributeAlreadyCapturedByPrimaryPath_NotDoubleCounted()
+    {
+        // Belt-and-suspenders: if a future SDK version DOES deserialize an
+        // Owner attribute as LookupAttributeMetadata (with Targets already
+        // populated), the primary-pass row must win and the fallback pass
+        // must NOT append a duplicate. The `seen` set is what guards this.
+        var ownerAsLookup = new Microsoft.Xrm.Sdk.Metadata.LookupAttributeMetadata();
+        ownerAsLookup.LogicalName = "ownerid";
+        // Simulate the SDK populating Targets from the server response — the
+        // Targets property is publicly settable via the DataContract surface.
+        typeof(Microsoft.Xrm.Sdk.Metadata.LookupAttributeMetadata)
+            .GetProperty("Targets")!
+            .SetValue(ownerAsLookup, new[] { "systemuser", "team" });
+
+        var attributes = new Microsoft.Xrm.Sdk.Metadata.AttributeMetadata[]
+        {
+            ownerAsLookup,
+        };
+
+        var rows = MembershipFieldDiscoveryService.ProjectLookupAttributeRows(attributes);
+
+        rows.Should().ContainSingle(r => r.LogicalName == "ownerid",
+            because: "the primary LookupAttributeMetadata pass captured it — " +
+                     "the Owner fallback pass must not double-count");
+        rows.Single().Targets.Should().BeEquivalentTo(new[] { "systemuser", "team" });
+    }
+
+    [Fact]
+    public void ProjectLookupAttributeRows_NonLookupNonOwnerNonCustomerAttribute_Ignored()
+    {
+        // Baseline: a String attribute (or anything that isn't Lookup/Owner/
+        // Customer) is not membership-bearing and must not appear.
+        var stringAttr = new Microsoft.Xrm.Sdk.Metadata.StringAttributeMetadata();
+        stringAttr.LogicalName = "sprk_name";
+
+        var intAttr = CreateBaseAttributeMetadata(Microsoft.Xrm.Sdk.Metadata.AttributeTypeCode.Integer);
+        intAttr.LogicalName = "sprk_count";
+
+        var attributes = new Microsoft.Xrm.Sdk.Metadata.AttributeMetadata[]
+        {
+            stringAttr,
+            intAttr,
+        };
+
+        var rows = MembershipFieldDiscoveryService.ProjectLookupAttributeRows(attributes);
+
+        rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProjectLookupAttributeRows_AttributeWithEmptyLogicalName_Skipped()
+    {
+        var noNameOwner = CreateBaseAttributeMetadata(Microsoft.Xrm.Sdk.Metadata.AttributeTypeCode.Owner);
+        // LogicalName intentionally left null
+
+        var attributes = new[] { noNameOwner };
+
+        var rows = MembershipFieldDiscoveryService.ProjectLookupAttributeRows(attributes);
+
+        rows.Should().BeEmpty();
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // Helpers
     // ────────────────────────────────────────────────────────────────────
 
@@ -493,6 +615,29 @@ public class MembershipFieldDiscoveryServiceTests
         string logicalName,
         params string[] targets)
         => new(logicalName, targets);
+
+    /// <summary>
+    /// Creates a bare <see cref="Microsoft.Xrm.Sdk.Metadata.AttributeMetadata"/>
+    /// with the requested <paramref name="typeCode"/> via reflection — the
+    /// `AttributeMetadata(AttributeTypeCode)` constructor is `protected` in
+    /// the SDK, but reflection can still invoke it. This mirrors the way the
+    /// SDK's DataContract deserializer materializes attributes that don't
+    /// match a registered `[KnownType]` (i.e., what happens for
+    /// `@odata.type=OwnerAttributeMetadata` responses in modern Dataverse).
+    /// </summary>
+    private static Microsoft.Xrm.Sdk.Metadata.AttributeMetadata CreateBaseAttributeMetadata(
+        Microsoft.Xrm.Sdk.Metadata.AttributeTypeCode typeCode)
+    {
+        var ctor = typeof(Microsoft.Xrm.Sdk.Metadata.AttributeMetadata)
+            .GetConstructor(
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                binder: null,
+                types: new[] { typeof(Microsoft.Xrm.Sdk.Metadata.AttributeTypeCode) },
+                modifiers: null)
+            ?? throw new InvalidOperationException(
+                "AttributeMetadata(AttributeTypeCode) constructor not found — SDK version drift?");
+        return (Microsoft.Xrm.Sdk.Metadata.AttributeMetadata)ctor.Invoke(new object[] { typeCode });
+    }
 
     private static MembershipDescriptor DescriptorFor(DiscoveryResult result, string field)
         => result.DiscoveredFields.SingleOrDefault(d => d.Field == field)


### PR DESCRIPTION
Second batch of R7 Wave 12 work (post PR #520). 4 commits shipping tonight's operator feedback + one resolver bug fix.

## Summary

- **Item 6** (`5988966b8`) — Vertical three-dot toolbar, sprk_primarycontact → sprk_assignedto wiring, toast 15s + Open link, elevated channel headings
- **Items 2/3/4/5** (`ad903e01f`) — Perplexity-style inline hyperlinks + trailing `[N]` citations for AI-narrated bullets. New `NarrativeBulletReferenceDto` + `NarrativeCitedText` component; open records in Xrm modal via existing `onOpenRecord` handler.
- **Item 9** (`9a683c2c5`) — High Priority section above TL;DR. New `sprk_HighPriority` + `sprk_Monitor` Boolean fields added to 6 entities via MCP (sprk_matter already had them). New `HighPriorityItemDto` + `HighPrioritySection` widget component. Subtle-red banner listing flagged records across matter, project, invoice, document, workassignment, event, todo.
- **DEF fix** (`02d925ae9`) — Membership resolver polymorphic-Owner bug: `OfType<LookupAttributeMetadata>()` silently dropped `ownerid` because `LookupAttributeMetadata` is sealed and `OwnerAttributeMetadata` doesn't inherit from it. Fix synthesizes Owner + Customer targets from base `AttributeMetadata`. Benefits chat scope resolution, KB filtering, and any other `IMembershipResolverService` consumer.

## Verification

- Local build: ✅ `dotnet build src/server/api/Sprk.Bff.Api/` — 0 errors, 19 warnings (all pre-existing)
- Widget lib: ✅ `tsc --noEmit` — 0 errors from new code (4 pre-existing workspace-symlink errors)
- SpaarkeAi bundle: ✅ vite build — 3.99 MB / 1.09 MB gzip
- End-to-end smoke: ✅ Operator confirmed inline entity links + trailing [N] citations render correctly, high-priority section pending final smoke
- All 4 commits already deployed to spaarke-bff-dev + sprk_spaarkeai webresource on spaarkedev1

## Conflict resolution

None expected — MERGEABLE.

## Post-merge

- Auto-deploy from master will bring these fixes to spaarke-bff-dev via GitHub Actions (matches existing R7 code that's already deployed via manual push)
- compose-r1 unblocked for rebase (was waiting on this merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)