### PR TITLE
style(r7): auto-format Prettier follow-up

### DIFF
--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/HighPrioritySection.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/HighPrioritySection.tsx
@@ -158,13 +158,25 @@ interface ActionBadgeStyle {
 function actionToBadge(action: string, dueDate?: string, modifiedOn?: string): ActionBadgeStyle | null {
   switch (action) {
     case 'Overdue':
-      return { label: dueDate ? `Overdue · ${formatShortDate(dueDate)}` : 'Overdue', color: 'danger', appearance: 'filled' };
+      return {
+        label: dueDate ? `Overdue · ${formatShortDate(dueDate)}` : 'Overdue',
+        color: 'danger',
+        appearance: 'filled',
+      };
     case 'DueToday':
       return { label: 'Due today', color: 'warning', appearance: 'filled' };
     case 'DueSoon':
-      return { label: dueDate ? `Due ${formatShortDate(dueDate)}` : 'Due soon', color: 'informative', appearance: 'outline' };
+      return {
+        label: dueDate ? `Due ${formatShortDate(dueDate)}` : 'Due soon',
+        color: 'informative',
+        appearance: 'outline',
+      };
     case 'Recent':
-      return { label: modifiedOn ? `Updated ${formatRelative(modifiedOn)}` : 'Recently updated', color: 'subtle', appearance: 'outline' };
+      return {
+        label: modifiedOn ? `Updated ${formatRelative(modifiedOn)}` : 'Recently updated',
+        color: 'subtle',
+        appearance: 'outline',
+      };
     default:
       return null;
   }

--- a/src/client/shared/Spaarke.DailyBriefing.Components/src/components/TldrSection.tsx
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/src/components/TldrSection.tsx
@@ -130,24 +130,7 @@ export interface TldrSectionProps {
  * every fresh /render call (i.e., every refresh). Kept small + lightweight per
  * operator request ("add some fun, not if too much effort").
  */
-const FUN_EMOJI_POOL = [
-  '🚀',
-  '👍',
-  '⛰️',
-  '😊',
-  '☀️',
-  '🎯',
-  '💡',
-  '🌟',
-  '🍀',
-  '🌈',
-  '⚡',
-  '🎉',
-  '🌱',
-  '🔥',
-  '🎨',
-  '🏆',
-];
+const FUN_EMOJI_POOL = ['🚀', '👍', '⛰️', '😊', '☀️', '🎯', '💡', '🌟', '🍀', '🌈', '⚡', '🎉', '🌱', '🔥', '🎨', '🏆'];
 
 function pickTldrEmoji(seed: string | null): string {
   if (!seed) return FUN_EMOJI_POOL[0];


### PR DESCRIPTION
## Summary

Follow-up to PR #528 — CI added a Prettier auto-format commit (`af3712fe4`) to the R7 branch after #528 merged. This PR brings that formatting to master so the two branches stay in sync.

## Verification

- Auto-format only (Prettier CI). No behavior change.
- Files touched: `HighPrioritySection.tsx`, `TldrSection.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)