### PR TITLE
chore(ai-spaarke-ai-workspace-UI-r2): add portfolio pointer + mark Complete

### DIFF
--- a/projects/ai-spaarke-ai-workspace-UI-r2/README.md
+++ b/projects/ai-spaarke-ai-workspace-UI-r2/README.md
@@ -1,6 +1,7 @@
 # AI SpaarkeAi Workspace UI — R2
 
-> **Status**: **Complete pending PR #530 merge** (all 13 phase tasks + wrap-up task 090 executed 2026-07-01)
+> **Portfolio**: [Issue #532](https://github.com/spaarke-dev/spaarke/issues/532) · Parent Epic [#430 Insights/Widgets/Search](https://github.com/spaarke-dev/spaarke/issues/430) · [Portfolio Board](https://github.com/users/spaarke-dev/projects/2)
+> **Status**: **Complete** (PR #530 + PR #531 merged; both PRs shipped 2026-07-01/02; project registered on portfolio 2026-07-02 via backfill)
 > **Branch**: `work/ai-spaarke-ai-workspace-UI-r2`
 > **Worktree**: `C:\code_files\spaarke-wt-ai-spaarke-ai-workspace-UI-r2`
 > **Owner**: Ralph Schroeder


### PR DESCRIPTION
Small doc-only follow-up after backfilling the ai-spaarke-ai-workspace-UI-r2 project onto the DevOps portfolio (Issue #532).

Adds the `> **Portfolio**:` pointer block to the R2 README so future `/devops-project-sync` runs can discover the Issue # without additional input. Also updates Status line to "Complete" since both PRs (#530 + #531) shipped.

**Backfill summary**:
- Issue #532 created via `/devops-project-register`
- Added to Project #2 board
- 9 portfolio fields populated (Type=Project, Project Type=UI, Status=Completed, Task Count=14, Tasks Completed=14, dates, worktree path, folder)
- Parent Epic: #430 [Insights/Widgets/Search]

Zero code impact.