### PR TITLE
fix + debug(spaarkeai-compose-r1): post-deploy smoke hotfixes + SSE trace instrumentation + r7 coordination doc

### DIFF
--- a/projects/spaarkeai-compose-r1/notes/r7-coordination-ask-2026-07-02.md
+++ b/projects/spaarkeai-compose-r1/notes/r7-coordination-ask-2026-07-02.md
@@ -1,0 +1,448 @@
+# Compose R1 → R7 Coordination Ask (2026-07-02)
+
+> **From**: `spaarkeai-compose-r1` (Compose R1 drafting workspace, task 098 SSE wiring)
+> **To**: `spaarke-ai-platform-unification-r7` team
+> **Purpose**: Confirm the r7-owned AI surface points that Compose R1's `compose-summarize` action depends on, so we can either coexist with r7's redesign or migrate to r7's new pattern before further debugging our SSE stream failure.
+> **Master state**: PR #534 (Compose R1 supplement) MERGED on master at commit `7111712f1` on 2026-07-01/02.
+> **Ship blocker**: post-deploy smoke on Dev shows `compose-summarize` SSE fails with client-side "stream read failed — network error" after the toolbar identifier + tenant fixes shipped. Server-side compose-summarize POST reaches the endpoint (JWT logged); outcome not yet traced past the Load stage. Not yet known whether root cause is our code or an r7-side surface change already on master.
+
+---
+
+## TL;DR — the ask
+
+Compose R1's `compose-summarize` consumer depends on **9 interface / contract points** that live in the r7-owned area of the BFF and Dataverse. For each, we need one of three answers:
+
+1. ✅ **Stays as-is** — Compose R1 can ship + coexist with r7's redesign. Debug our failure on this branch.
+2. ⚠️ **Changing shape** — tell us the new shape + timeline; we adapt at task 097/098 level.
+3. ❌ **Removed / superseded** — tell us the replacement path; we migrate Compose to it.
+
+**Below is one section per surface point. Each has**: (a) what we consume, (b) files, (c) our usage, (d) the yes/no/how question for r7.
+
+---
+
+## Surface 1 — `IInvokePlaybookAi` facade (widened by us via ADR-013 Path B amendment 2026-07-01)
+
+**What we consume**:
+```csharp
+Task<PlaybookInvocationResult> InvokePlaybookAsync(
+    Guid playbookId,
+    IReadOnlyDictionary<string, string>? parameters,
+    PlaybookInvocationContext context,
+    CancellationToken cancellationToken = default,
+    string? userContext = null,          // ← NEW in task 095/096
+    DocumentContext? document = null);   // ← NEW in task 095/096
+```
+
+**Files**:
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PublicContracts/IInvokePlaybookAi.cs`
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PublicContracts/InvokePlaybookAi.cs`
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PublicContracts/NullInvokePlaybookAi.cs`
+
+**Our usage** (single call site — `Api/ComposeEndpoints.cs` `DispatchAction`):
+```csharp
+var result = await invokePlaybook.InvokePlaybookAsync(
+    playbookId.Value,        // 47686eb1-9916-f111-8343-7c1e520aa4df (Document Summary)
+    parameters,              // built from compose-document JPS scope
+    invocationContext,       // {TenantId, HttpContext, CorrelationId}
+    ct,
+    userContext: extractedText,       // plain text from DOCX (up to 100k chars)
+    document: documentContext);       // {DocumentId, Name, FileName, ContentType, ExtractedText}
+```
+
+**ADR trail**:
+- Refined ADR-013 (2026-05-20) — CRUD code MUST NOT inject AI-internal types; MUST use `Services/Ai/PublicContracts/` facades
+- Amendment 2026-07-01 (Path B per CLAUDE.md §6.5) — `docs/adr/ADR-013-ai-architecture.md` §"Amendment 2026-07-01 — Document-context invocation on `IInvokePlaybookAi` facade"
+
+**Compile-time boundary guard**:
+- `tests/unit/Sprk.Bff.Api.Tests/Integration/PhaseAVerticalSliceTests.cs` — `ADR013_InvokePlaybookAiFacade_DoesNotExposeAiInternalTypesInSurface` — updated with named allow-list permitting `Sprk.Bff.Api.Services.Ai.DocumentContext` on the facade surface.
+
+**Ask r7**:
+- (a) Does `IInvokePlaybookAi` continue to exist under r7's redesign?
+- (b) If yes, is the widened signature (with `userContext` + `document` at the end, defaulted to `null`) preserved?
+- (c) If yes, does `InvokePlaybookAi.cs` still forward these to `PlaybookRunRequest.UserContext` + `.Document`?
+- (d) If the facade is being renamed / replaced, what's the successor, and can Compose R1 keep using this facade for R1 shipping + migrate in R2?
+
+---
+
+## Surface 2 — `IConsumerRoutingService.ResolvePlaybookIdAsync(consumerType)`
+
+**What we consume**:
+```csharp
+Guid? playbookId = await consumerRouter.ResolvePlaybookIdAsync("compose-summarize", ct);
+if (playbookId is null) → SSE error chunk "unknown consumer type"
+```
+
+**Our usage** (in `DispatchAction`, immediately before invoking the facade).
+
+**Data dependency**:
+- Dataverse table `sprk_playbookconsumer`
+- Seeded row for R1 (via `notes/dataverse-seed/compose-summarize-playbookconsumer.md`):
+  - `sprk_consumertype = "compose-summarize"`
+  - `sprk_consumercode = "default"` (or environment code)
+  - `sprk_environment = "production"`
+  - `sprk_playbookid = 47686eb1-9916-f111-8343-7c1e520aa4df` (Document Summary playbook)
+  - `sprk_issystem = true`
+
+**Ask r7**:
+- (a) Is `IConsumerRoutingService.ResolvePlaybookIdAsync` still the resolver r7 wants CRUD-side dispatch code to call?
+- (b) Is `sprk_playbookconsumer` still the source-of-truth table? (I noticed r7's `bff-extensions.md §G` rewrite discusses executor-type/typed-config as the new mechanism — is `sprk_playbookconsumer` staying or being consolidated?)
+- (c) Should our compose-summarize seed row shape change (e.g., new required columns) in r7's world?
+- (d) In r7's chat consumer, the equivalent lookup returned `44285d15-1360-f111-ab0b-70a8a59455f4` (per BFF logs 2026-07-02 14:23:39). If r7 has changed lookup semantics, we need to know whether our lookup path shares the same code path.
+
+---
+
+## Surface 3 — `IPlaybookOrchestrationService.ExecuteAsync` (downstream from the facade)
+
+**We do NOT call this directly**. We only call `IInvokePlaybookAi` which delegates to `IPlaybookOrchestrationService` inside `InvokePlaybookAi.cs` (r7-owned).
+
+**Our concern**: if r7 renames / restructures `IPlaybookOrchestrationService` or its `ExecuteAsync` signature, the delegation inside `InvokePlaybookAi.cs` (owned by r7 or shared) needs to still forward:
+- `PlaybookRunRequest.UserContext` (from our `userContext` param)
+- `PlaybookRunRequest.Document` (from our `document` param)
+
+**Ask r7**:
+- (a) Does `PlaybookRunRequest` still have `UserContext` (string) and `Document` (DocumentContext) fields?
+- (b) If r7 has renamed these fields, will `InvokePlaybookAi.cs` be updated to map from our facade args to the new field names?
+- (c) Are there any new REQUIRED fields on `PlaybookRunRequest` post-r7 that we're not populating (which would cause the executor to reject)?
+
+---
+
+## Surface 4 — `AnalysisStreamChunk` SSE envelope + factory methods
+
+**What we consume**:
+```csharp
+public record AnalysisStreamChunk(string Type, string? Content, bool Done, ...);
+
+// factory methods used by our task 097 SSE endpoint:
+AnalysisStreamChunk.Progress(step, message)
+AnalysisStreamChunk.Result(jsonContent)
+AnalysisStreamChunk.Completed(runId, tokenUsage)
+AnalysisStreamChunk.FromError(errorMsg)
+```
+
+**File**:
+- `src/server/api/Sprk.Bff.Api/Api/Ai/AnalysisEndpoints.cs` (record definition + factories)
+
+**Wire format we emit** (task 097 `Api/ComposeEndpoints.cs` `DispatchAction`):
+```
+Content-Type: text/event-stream
+
+data: {"type":"progress","content":"Loading document...","step":"document_loaded",...}\n\n
+data: {"type":"progress","content":"Extracting document text...","step":"extracting_text",...}\n\n
+data: {"type":"progress","content":"Invoking playbook...","step":"invoking_playbook",...}\n\n
+data: {"type":"result","content":"{\"runId\":\"...\",\"textContent\":\"...\",...}",...}\n\n
+data: {"type":"done","done":true,"analysisId":"...","tokenUsage":{...}}\n\n
+data: [DONE]\n\n
+```
+
+**Client-side parser** (`@spaarke/compose-components/executeComposeSummarize.ts`):
+- Demuxes on `chunk.type = progress | result | done | error`
+- Result chunk's `content` field is a JSON string containing `{runId, textContent, structuredData, confidence, durationMs, citationCount, correlationId}`
+- Terminal sentinel: literal `data: [DONE]\n\n`
+
+**Ask r7**:
+- (a) Is `AnalysisStreamChunk` the canonical envelope r7 wants for all AI SSE endpoints, or is r7 introducing a new streaming type (e.g., aligned with the recent SSE side-channel work per ADR-033)?
+- (b) If new envelope: what's the schema (JSON shape) and does the terminal sentinel change?
+- (c) If r7 adds new chunk types (`section_started` / `section_data` / `section_completed` per ADR-037), does our result-only consumer still work correctly (i.e., we can ignore unknown types)?
+
+---
+
+## Surface 5 — `DocumentContext` DTO
+
+**What we consume**:
+```csharp
+public class DocumentContext {
+    Guid DocumentId { get; init; }
+    string Name { get; init; }
+    string? FileName { get; init; }
+    string? ContentType { get; init; }
+    string? ExtractedText { get; init; }
+}
+```
+
+**File**: `src/server/api/Sprk.Bff.Api/Services/Ai/DocumentContext.cs` (this is r7-adjacent; we don't own it)
+
+**Our usage** (task 097 `DispatchAction`):
+```csharp
+var documentContext = new DocumentContext {
+    DocumentId = body.DocumentRecordId ?? Guid.Empty,
+    Name = body.DocumentName ?? loadResult.Value.FileName ?? body.DocumentSpeId,
+    FileName = loadResult.Value.FileName ?? body.DocumentName,
+    ContentType = body.DocumentMimeType,
+    ExtractedText = extractedText,   // from our IDocxTextExtractor (task 094)
+};
+```
+
+**Ask r7**:
+- (a) Is `DocumentContext` staying in `Sprk.Bff.Api.Services.Ai` namespace with these fields?
+- (b) Are any new REQUIRED fields being added (that we'd fail to populate)?
+- (c) If moved to a different namespace, will the ADR-013 reflection guard's allow-list need to be updated? (We already permit this type via a named allow-list per task 095.)
+
+---
+
+## Surface 6 — `PlaybookInvocationContext` + `PlaybookInvocationResult`
+
+**What we consume** (passed to / returned by facade):
+```csharp
+// input:
+public class PlaybookInvocationContext {
+    string TenantId { get; init; }
+    HttpContext HttpContext { get; init; }
+    string CorrelationId { get; init; }
+    // ...
+}
+
+// output:
+public class PlaybookInvocationResult {
+    bool Success;
+    string RunId;
+    string TextContent;
+    object StructuredData;
+    double Confidence;
+    TimeSpan Duration;
+    List<Citation> Citations;
+    string ErrorCode;
+    string ErrorMessage;
+    // ...
+}
+```
+
+**Our usage**: We serialize the result fields into the SSE result chunk's JSON payload — `{runId, textContent, structuredData, confidence, durationMs, citationCount, correlationId}` — the client's `ComposeSummarizeResult` type expects these field names.
+
+**Ask r7**:
+- (a) Are `PlaybookInvocationContext` + `PlaybookInvocationResult` staying in `Services/Ai/PublicContracts/` or moving?
+- (b) Are any r7 changes to `TextContent` (Compose displays it verbatim as the assistant chat message)?
+- (c) Is `Success` still a boolean, or is r7 moving to a discriminated-union / Result-monad shape?
+
+---
+
+## Surface 7 — Document Summary playbook (Dataverse row)
+
+**Playbook ID**: `47686eb1-9916-f111-8343-7c1e520aa4df`
+**Display name**: "Summarize Document for Chat" (per BFF logs 2026-07-02: `Loaded action from Dataverse: Summarize Document for Chat`)
+**Executor observed**: `AiCompletion` node with schema `AiCompletion_Summarize_Document_for_Chat`
+**Structured output schema** (per BFF logs 2026-07-02 14:23:40):
+- `tldr[]` (1-3 bullets, ≤140 chars each — TL;DR streaming)
+- `summary` (≤2000 chars narrative)
+- `keywords` (comma-separated string)
+- `entities.organizations[]` + `entities.persons[]`
+
+**Compose R1 usage**: We call the SAME playbook the chat-summarize path uses. Consumer routing maps our `compose-summarize` consumer type → this same playbook ID.
+
+**Ask r7**:
+- (a) Is playbook `47686eb1-9916-f111-8343-7c1e520aa4df` staying in Dev/Prod?
+- (b) Is r7 planning to change the response schema (e.g., add fields to `AiCompletion_Summarize_Document_for_Chat` that would alter what Compose R1 receives in `PlaybookInvocationResult.TextContent`)?
+- (c) Compose R1 uses only `result.TextContent` for the assistant-facing chat message rendering (not the structured `tldr/summary/keywords/entities` breakdown). Is `TextContent` guaranteed to be populated with a human-readable summary regardless of the schema evolution?
+
+---
+
+## Surface 8 — DOCX Load path (`IComposeDocumentService.LoadDocxAsync`)
+
+**What we consume**:
+```csharp
+Task<ComposeLoadResult> LoadDocxAsync(
+    string documentSpeId,
+    string driveId,
+    string tenantId,
+    HttpContext httpContext,
+    CancellationToken ct);
+```
+
+**Behavior**: OBO Graph download of DOCX bytes from SPE drive-item.
+
+**File**: `src/server/api/Sprk.Bff.Api/Services/Compose/IComposeDocumentService.cs` + `ComposeDocumentService.cs`
+
+**We own this**. But it delegates to r7-adjacent Graph plumbing (`Sprk.Bff.Api.Infrastructure.Graph.DriveItemOperations.DownloadFileAsync`).
+
+**Ask r7**:
+- (a) Any changes to `Infrastructure/Graph/DriveItemOperations.cs` semantics (e.g., different OBO scope requirement)?
+- (b) Are Graph 403 "Access denied" errors currently expected on OBO for `.docx` files in the SPE containers (post-r7 changes)?
+- (c) BFF logs 2026-07-02 14:24:45 show a Graph 403 "Access denied" for `Sprk.Bff.Api.Services.Ai.FileIndexingService` — is this related to r7's auth changes, or a separate app-only permission gap?
+
+---
+
+## Surface 9 — `IDocxTextExtractor` (Compose R1 owns this, but relevant to r7)
+
+**What we own** (task 094):
+- `IDocxTextExtractor.ExtractPlainTextAsync(stream, maxCharacters=100_000, ct)` returns plain text
+- Uses `DocumentFormat.OpenXml` SDK
+- Walks `Body.Descendants<Paragraph>`
+
+**Files**:
+- `src/server/api/Sprk.Bff.Api/Services/Compose/IDocxTextExtractor.cs`
+- `src/server/api/Sprk.Bff.Api/Services/Compose/DocxTextExtractor.cs`
+- DI: `src/server/api/Sprk.Bff.Api/Infrastructure/DI/ComposeModule.cs`
+
+**Relevant to r7**: this is where DOCX bytes become the `userContext` string that we pass to the widened facade. If r7 wants a canonical text-extraction service (e.g., existing `TextExtractorService.cs`) instead of ours, we can retarget.
+
+**Ask r7**:
+- (a) Is there a canonical text-extractor r7 wants Compose to use instead of our new `IDocxTextExtractor`? (Our search showed `Services/Ai/TextExtractorService.cs` exists.)
+- (b) If yes, does it accept a `Stream` and produce `string` synchronously (for the SSE pipeline)?
+- (c) If we should migrate: preferred timing (R1 or R2)?
+
+---
+
+## What Compose R1 does NOT touch — for r7's peace of mind
+
+- ❌ `IPlaybookExecutionEngine`, `IPlaybookService`, `IOpenAiClient`, `ScopeResolverService` — never injected into CRUD-side compose code (ADR-013 refined 2026-05-20 hard rule; enforced by compile-time reflection test)
+- ❌ `PlaybookOrchestrationService` internals (we delegate through the facade only)
+- ❌ Node types, executor types, `sprk_analysisaction`, `sprk_playbookexecution`, `sprk_playbookmetric`
+- ❌ Chat session summarize path (`/api/ai/chat/sessions/{id}/summarize`) — that's r7's territory; we did not touch it
+- ❌ `sprk_analysisactiontype` table (r7's decorative lookup per §G rewrite)
+- ❌ `PlaybookDispatcher` (r7's Stage 1/Stage 2 chat routing) — Compose R1 hits `IConsumerRoutingService` directly for consumer-type → playbookId lookup
+
+---
+
+## Compose R1 files that r7 should be aware of
+
+**Frontend (all new / heavily-modified in this branch)**:
+- `src/client/shared/Spaarke.Compose.Components/src/orchestrators/executeComposeSummarize.ts` (SSE consumer — NEW)
+- `src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeToolbar.tsx` (dispatches `compose_summarize_request` event)
+- `src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeWorkspace.tsx` (owns document state; toolbar bindings)
+- `src/solutions/SpaarkeAi/src/components/conversation/ConversationPane.tsx` (subscribes to event → invokes orchestrator → progressive render)
+
+**BFF (new / modified in this branch)**:
+- `src/server/api/Sprk.Bff.Api/Api/ComposeEndpoints.cs` — task 097 SSE conversion (previously JSON `Task<IResult>`)
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PublicContracts/IInvokePlaybookAi.cs` — widened signature (task 095)
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PublicContracts/InvokePlaybookAi.cs` — forwards `userContext`+`document`
+- `src/server/api/Sprk.Bff.Api/Services/Ai/PublicContracts/NullInvokePlaybookAi.cs` — kill-switch signature updated
+- `src/server/api/Sprk.Bff.Api/Services/Compose/{IDocxTextExtractor,DocxTextExtractor}.cs` — NEW (task 094)
+- `src/server/api/Sprk.Bff.Api/Services/Compose/{IComposeDocumentService,ComposeDocumentService}.cs` — pre-existing R1
+- `src/server/api/Sprk.Bff.Api/Services/Compose/ComposeService.cs` + `ComposeSessionService.cs` — pre-existing R1
+- `src/server/api/Sprk.Bff.Api/Infrastructure/DI/ComposeModule.cs` — DI registrations
+
+**Tests (may signal a contract-change need for r7)**:
+- `tests/unit/Sprk.Bff.Api.Tests/Integration/PhaseAVerticalSliceTests.cs` — updated allow-list for `DocumentContext` on facade surface
+- `tests/unit/Sprk.Bff.Api.Tests/Api/ComposeEndpointsTests.cs` — endpoint shape tests including new params (`IComposeDocumentService`, `IDocxTextExtractor`)
+- `tests/integration/contract/Api/Compose/ComposeEndpointsContractTests.cs` — 3 tests Skip'd pending SSE-parser (task 097 FU-97a)
+- `tests/integration/regression/Compose/ComposeSummarizeRoundtripSmokeTests.cs` — 7 tests Skip'd pending SSE-parser (task 097 FU-97a)
+
+**ADR trail**:
+- `docs/adr/ADR-013-ai-architecture.md` §"Amendment 2026-07-01 — Document-context invocation on `IInvokePlaybookAi` facade" (full ADR)
+- `.claude/adr/ADR-013-ai-architecture.md` (concise version + MUST rules)
+- `.claude/adr/INDEX.md` (row updated: status "Accepted (amended 2026-07-01)")
+- `.claude/CHANGELOG.md` (`[Unreleased]` → 2026-07-01 spaarkeai-compose-r1 task 102 entry)
+
+**Project artifact**:
+- `projects/spaarkeai-compose-r1/spec-supplement-2026-07-01-three-pane-pivot.md` — supplement scope
+- `projects/spaarkeai-compose-r1/tasks/{094,095,096,097,098,099,100,102}-*.poml` — task POMLs with full context blocks
+- `projects/spaarkeai-compose-r1/notes/defer-issues.md` §AMD-102 (Path B amendment record)
+
+---
+
+## Current smoke failure snapshot (for reference during coordination)
+
+**Pass**:
+- ✅ Ribbon launch opens SpaarkeAi in `composeMode=editor` (task 092)
+- ✅ Three-pane shell renders; no workspace tab strip (task 100 `hideTabBar` prop working)
+- ✅ Document loads into TipTap editor via `GET /api/compose/documents/{speId}` (auth OBO to SPE Graph works for read)
+- ✅ Manual edits save via `POST /api/compose/documents/{speId}/save` (OBO to SPE Graph works for write; DOCX conversion + storage confirmed)
+- ✅ Open-in-Word Web + Open-in-Word Desktop toolbar buttons work (`/api/documents/{sprkDocumentId}/open-links`)
+- ✅ Assistant pane subscribes to `compose_summarize_request` (task 098 wiring)
+- ✅ POST to `/api/compose/action/compose-summarize` reaches the endpoint with valid JWT (per BFF logs, e.g. 2026-07-02T14:22:18)
+
+**Fail**:
+- ❌ Client sees "stream read failed — network error" mid-SSE-stream
+- ❌ No client-observable SSE frames received (or the read errored before parsing them)
+- ❌ Server-side outcome past the "Token on POST" log line not yet visible in the log snapshot we have
+
+**Not yet ruled out**:
+- Server-side `LoadDocxAsync` may be throwing (OBO Graph download in the dispatch context — potentially different scope/perms than the initial Load endpoint)
+- Server-side `IInvokePlaybookAi.InvokePlaybookAsync` may be throwing (possibly due to r7-side changes to `IPlaybookOrchestrationService` internals that break the facade delegation)
+- Network middleware may be terminating the SSE stream before the server finishes writing chunks (proxy timeout, HTTP/2 goaway, connection idle)
+- Client-side WhatWG ReadableStream / TextDecoder edge case (less likely — same pattern as the working R5 `executeSummarizeIntent`)
+
+---
+
+## Recommended coordination outcomes
+
+Based on r7's answers, we'll pick one of:
+
+1. **All 9 surfaces still stable** → we debug the SSE stream failure on our end (add server-side logging, decode SSE frames on client with better error messages, investigate Graph OBO context in DispatchAction).
+
+2. **1-3 surfaces changed in scope-compatible ways** → we adapt task 097/098 to the new shapes, redeploy, re-smoke.
+
+3. **Facade/orchestrator restructured** → we hold task 110 (wrap-up) until r7 lands their changes on master, then Compose R2 (or an in-branch re-integration) adopts the new API.
+
+4. **Playbook execution moving to a fundamentally different pattern** → surface as new ADR conflict (CLAUDE.md §6.5); coordinated design session with both project leads.
+
+---
+
+## Turnaround ask
+
+Ideally we'd have answers to Surfaces 1, 2, 3, 4, 6 within 24 hours to unblock Compose R1 shipping. Surfaces 5, 7, 8, 9 are lower priority and can slip to end-of-week if needed.
+
+Please respond in whatever format works — inline in this file, ADR amendment reference, or a message linking to the r7 spec / design section that answers the question.
+
+---
+
+*This document lives at `projects/spaarkeai-compose-r1/notes/r7-coordination-ask-2026-07-02.md` and travels with the Compose R1 project. Feel free to inline r7 responses below each surface's ask.*
+
+---
+
+## 📩 R7 team response — 2026-07-02
+
+**Received via Slack / DM / verbal — captured verbatim for audit trail below.**
+
+> Thanks for the structured ask. R7 Wave 12 tonight (2026-07-02) shipped the Linear AI Consumer library and migrated Document Upload / Profile off the Playbook Engine (`c2d26986d`). Below is the per-surface answer.
+
+| # | Surface | R7 W12 answer |
+|---|---|---|
+| **1** | `IInvokePlaybookAi` facade + ADR-013 Path B amendment | **Stays as-is** for compose-summarize. R7 W12 didn't touch the facade; Linear path bypasses it entirely for the 6 in-scope linear consumers (Doc Profile / File Summarize / Prefills). Compose is not on that list — you keep going through the facade → Playbook Engine → Document Summary playbook. Your ADR-013 Path B widening stands. |
+| **2** | `IConsumerRoutingService.ResolvePlaybookIdAsync` + `sprk_playbookconsumer` table | **Stays as-is**. Untouched by W12. Linear consumers use a NEW parallel mechanism (`LinearConsumersOptions` config-driven ActionId map, `LinearConsumers__ActionIds__*` App Service keys) — no overlap with the routing table. Routing service continues to serve Playbook Engine consumers. |
+| **3** | `IPlaybookOrchestrationService.ExecuteAsync` | **Stays as-is**. Playbook Engine preserved for Chat, Insight Engine, Compose, Daily Briefing. Not on the retirement list. |
+| **4** | `AnalysisStreamChunk` SSE envelope + factory methods | **Stays as-is**. R7 W12 REUSES the same envelope in DocumentProfileService — I explicitly designed the linear consumers to emit the identical SSE shape (Metadata / Progress / TextChunk / Completed / FromError / Result). Client contract preserved. |
+| **5** | `DocumentContext` DTO in `Sprk.Bff.Api.Services.Ai` | **Stays as-is**. Not modified. R7 W12 added a NEW leaner record `DocumentText` in the new `Services/Ai/LinearConsumers/` namespace, scoped to the linear path only — it doesn't replace `DocumentContext`. |
+| **6** | `PlaybookInvocationContext` + `PlaybookInvocationResult` shapes | **Stays as-is**. Untouched. |
+| **7** | Playbook `47686eb1-9916-f111-8343-7c1e520aa4df` (Document Summary, shared with chat-summarize) | **Stays as-is**. NOT on the wave12 retirement list. The only playbooks retiring (Phase E) are the six linear ones: `18cf3cc8` (Doc Profile), `4a72f99c` (Summarize File), `2d660cad` (Matter PreFill), `fc343e9c` (Project PreFill), WA (if separate), Doc Create Profile. Yours is untouched. |
+| **8** | `Infrastructure/Graph/DriveItemOperations.DownloadFileAsync` (OBO Graph download) | **Stays as-is**. Not touched by W12. R7's linear text extraction goes through `AnalysisDocumentLoader.ExtractDocumentTextAsync` → `ISpeFileOperations.DownloadFileAsUserAsync` (SpeFileStore facade per ADR-007), not `DriveItemOperations`. If they're separate seams, W12 didn't move yours. |
+| **9** | Canonical text-extractor (your `IDocxTextExtractor`) | **Optional migration**. R7's canonical is `ITextExtractor` — handles DOCX + PDF + many more via a single facade with Redis ETag cache (ADR-009). If you'd like to consolidate, migrate at your convenience — not urgent, R7 doesn't require it. |
+
+**On the SSE mid-stream network error**: R7 W12 intentionally left compose-summarize's code path unchanged. Two theories worth ruling out on your end:
+
+> **Theory 1**: Post-`d75de048b` (endpoint pre-loads DocumentContext before invoking the orchestrator) — the `POST /api/ai/analysis/execute` endpoint now runs text extraction as its FIRST step. On a large doc that pre-load can push time-to-first-byte past ~30s. If compose-summarize hits `AnalysisEndpoints.ExecuteAnalysis`, watch for a slow client (nginx / App Service) idle timeout upstream of your streaming. If instead you call `IInvokePlaybookAi` directly from your own endpoint, this doesn't apply.
+>
+> **Theory 2**: The Wave 12 endpoint added a Linear-dispatch shim BEFORE the pre-load. It checks `LinearConsumersOptions.PlaybookIds` for a match and falls through to engine when no match. Fall-through is safe by design, but if you want confirmation from a live log, share your correlation id and I'll grep App Insights.
+
+**Compose-summarize as a future Linear candidate**: compose-summarize is technically a linear workflow (Start → summarize → return response). If you hit the same interpreter tax we did on Doc Upload, R7's Linear library is available as a follow-on migration. Not planned in R7 scope; would be its own coordination.
+
+*Reply here or ping me for App Insights correlation-id log dive.*
+*— R7 team*
+
+---
+
+## 📤 Compose R1 acceptance reply — 2026-07-02
+
+> Thanks r7 — this is exactly what we needed. All 9 surfaces green means we can debug our SSE failure on our end without holding up Compose R1 ship.
+
+**Per-surface confirmations back**:
+
+- **Surface 1** — We keep the widened facade + ADR-013 Path B amendment 2026-07-01. Understood that Linear consumers bypass the facade entirely and Compose is intentionally not on that list. No changes to our reflection guard allow-list needed.
+- **Surfaces 2, 3, 5, 6** — Preserved. We keep our code as-is.
+- **Surface 4** — Preserved AND reused by W12 DocumentProfileService — great for consistency. Our client-side parser (`executeComposeSummarize.ts`) is agnostic to chunk types other than `progress/result/done/error`, so if you add new discriminants (`section_started` etc. per ADR-037) our consumer will safely ignore them.
+- **Surface 7** — Preserved. Canonical shared path for Compose + chat-summarize; comfortable with that shared dependency.
+- **Surface 8** — Preserved. Good to know W12's linear text extraction uses a separate seam (AnalysisDocumentLoader → SpeFileStore facade per ADR-007).
+- **Surface 9** — **Filed as follow-up for Compose R2.** Compose R1 keeps our own extractor for the R1 ship since it's in a small green surface boundary. We'll evaluate migration to `ITextExtractor` for R2 — the Redis ETag cache is compelling for repeated summarize invocations on the same doc. If R7 wants to nudge earlier consolidation, we're open.
+
+**On the SSE mid-stream failure**:
+- **Theory 1 confirmed OUT** — Our endpoint (`POST /api/compose/action/{consumerType}`) is a bespoke SSE endpoint in `ComposeEndpoints.cs`, NOT `AnalysisEndpoints.ExecuteAnalysis`. We do our own SSE framing with `WriteSSEAsync` (which flushes `response.Body` after every chunk) and call `IInvokePlaybookAi.InvokePlaybookAsync` directly. Confirmed by grep on our `ComposeEndpoints.cs`.
+- **Theory 2 sanity-check pending** — if `InvokePlaybookAi.cs` (the concrete facade impl) delegates through `IPlaybookOrchestrationService` or `PlaybookRunRequest`, does that delegation path itself pass through any Wave 12 shim? Or is the Wave 12 shim ONLY on the AnalysisEndpoints controller layer, keeping the shared engine code untouched?
+- **Next action on our side**: adding server-side structured logging + client-side raw-frame dump to get a debuggable trace on next smoke attempt. Will share correlation-id after next smoke for App Insights dive.
+- **Failing request from earlier smoke**: approximately 2026-07-02 14:22:18 UTC (BFF log line `Token on POST /api/compose/action/compose-summarize: aud=api://1e40baad-... appid=170c98e1-... scp=user_impersonation`).
+
+**Linear candidate observation acknowledged** — compose-summarize is architecturally a linear workflow. We'll consider it for Compose R2 planning as a future coordination. The Linear library sounds like the right architectural fit for R2's follow-on actions (Rewrite / Find Similar / Lookup References — all narrow deterministic AI actions on top of Compose).
+
+**Compose R1 status**: unblocked from r7 coordination side; debug continues on our end with new instrumentation.
+
+*— spaarkeai-compose-r1 team, 2026-07-02*
+
+---
+
+## Resolution status
+
+| Item | Status | Follow-up |
+|---|---|---|
+| All 9 surface points | ✅ Confirmed stable for Compose R1 shipping | None — audit trail complete |
+| ADR-013 Path B amendment (2026-07-01) | ✅ Preserved by R7 | None |
+| SSE mid-stream network error debug | 🔄 Compose R1 owns; instrumentation in-flight | New Compose R1 commit — server + client trace instrumentation |
+| Compose-summarize → Linear library migration | 📋 Deferred to Compose R2 | Track in Compose R2 spec (`spaarkeai-compose-r2` when drafted) |
+| `IDocxTextExtractor` → `ITextExtractor` migration | 📋 Deferred to Compose R2 | Same — R2 evaluation with Redis ETag cache benefit |

--- a/src/client/shared/Spaarke.Compose.Components/src/context/composeLaunchContext.ts
+++ b/src/client/shared/Spaarke.Compose.Components/src/context/composeLaunchContext.ts
@@ -28,22 +28,20 @@
  *      — consumes the value inside the section factory mount
  */
 
-import * as React from "react";
-import type { ComposeDocumentRef } from "../types/compose-contracts";
+import * as React from 'react';
+import type { ComposeDocumentRef } from '../types/compose-contracts';
 
 export interface ComposeLaunchContextValue {
   /** Set to `'editor'` when the app was launched via ribbon Open-in-Compose. */
-  composeMode: "editor";
+  composeMode: 'editor';
   /** Document pointer forwarded from the ribbon URL params (Path A entry). */
   document: ComposeDocumentRef | null;
   /** SPE container/drive id (may be empty; resolved at runtime if absent). */
   driveId: string;
 }
 
-export const ComposeLaunchContext = React.createContext<ComposeLaunchContextValue | null>(
-  null,
-);
-ComposeLaunchContext.displayName = "ComposeLaunchContext";
+export const ComposeLaunchContext = React.createContext<ComposeLaunchContextValue | null>(null);
+ComposeLaunchContext.displayName = 'ComposeLaunchContext';
 
 /**
  * Consume the Compose launch context from within any pane / section factory.

--- a/src/client/shared/Spaarke.Compose.Components/src/index.ts
+++ b/src/client/shared/Spaarke.Compose.Components/src/index.ts
@@ -37,10 +37,7 @@ export type { ComposeEmptyStateProps } from './widgets/ComposeEmptyState';
 export { ComposeConflictDialog } from './widgets/ComposeConflictDialog';
 
 // Reducer / state types
-export {
-  composeWorkspaceReducer,
-  INITIAL_STATE,
-} from './widgets/ComposeWorkspace.types';
+export { composeWorkspaceReducer, INITIAL_STATE } from './widgets/ComposeWorkspace.types';
 export type {
   ComposeWorkspaceStatus,
   ComposeCheckoutStatus,
@@ -50,11 +47,7 @@ export type {
 } from './widgets/ComposeWorkspace.types';
 
 // Hooks
-export {
-  useComposeBroadcastChannel,
-  useComposeCheckoutLifecycle,
-  useComposeHeartbeatGate,
-} from './widgets/hooks';
+export { useComposeBroadcastChannel, useComposeCheckoutLifecycle, useComposeHeartbeatGate } from './widgets/hooks';
 export type {
   UseComposeBroadcastChannelResult,
   UseComposeCheckoutLifecycleOptions,
@@ -66,10 +59,7 @@ export type {
 // SpaarkeAi ThreePaneShell so LegalWorkspace's compose section factory can
 // consume it via a unidirectional dependency).
 // -------------------------------------------------------------------------
-export {
-  ComposeLaunchContext,
-  useComposeLaunch,
-} from './context/composeLaunchContext';
+export { ComposeLaunchContext, useComposeLaunch } from './context/composeLaunchContext';
 export type { ComposeLaunchContextValue } from './context/composeLaunchContext';
 
 // -------------------------------------------------------------------------
@@ -112,7 +102,4 @@ export type { MammothConversionResult } from './utils/docxBridge';
 // Consumed by ConversationPane in SpaarkeAi (Path A + embedded modes).
 // -------------------------------------------------------------------------
 export { executeComposeSummarize } from './orchestrators/executeComposeSummarize';
-export type {
-  ExecuteComposeSummarizeInputs,
-  ComposeSummarizeResult,
-} from './orchestrators/executeComposeSummarize';
+export type { ExecuteComposeSummarizeInputs, ComposeSummarizeResult } from './orchestrators/executeComposeSummarize';

--- a/src/client/shared/Spaarke.Compose.Components/src/orchestrators/executeComposeSummarize.ts
+++ b/src/client/shared/Spaarke.Compose.Components/src/orchestrators/executeComposeSummarize.ts
@@ -218,6 +218,21 @@ export async function executeComposeSummarize(inputs: ExecuteComposeSummarizeInp
     return;
   }
 
+  // 2026-07-02 SSE trace instrumentation (task 098 smoke debug).
+  // Every trace log is prefixed with `[compose-summarize-sse]` for trivial
+  // filtering in the browser console. `debug`-level so a normal user session
+  // is unaffected unless the console filter includes verbose messages. The
+  // `sseStartMs` timestamp anchors all timing measurements below.
+  const sseStartMs = performance.now();
+  const traceLog = (msg: string, extra?: Record<string, unknown>): void => {
+    // eslint-disable-next-line no-console
+    console.debug(
+      `[compose-summarize-sse] t+${Math.round(performance.now() - sseStartMs)}ms ${msg}`,
+      extra ?? '',
+    );
+  };
+  traceLog('start', { url, hasDocumentSpeId: !!documentSpeId, hasDriveId: !!driveId, hasTenantId: !!tenantId, hasSessionId: !!sessionId });
+
   let response: Response;
   try {
     response = await fetch(url, {
@@ -230,12 +245,20 @@ export async function executeComposeSummarize(inputs: ExecuteComposeSummarizeInp
       body: JSON.stringify(body),
       signal,
     });
+    traceLog('fetch returned', {
+      status: response.status,
+      ok: response.ok,
+      contentType: response.headers.get('content-type'),
+      hasBody: !!response.body,
+    });
   } catch (err) {
     if (signal?.aborted) {
+      traceLog('aborted before fetch completed');
       fireDone();
       return;
     }
     const message = err instanceof Error ? err.message : String(err);
+    traceLog('fetch threw (pre-body)', { error: message, name: err instanceof Error ? err.name : 'unknown' });
     onError?.(`Compose summarize: network error — ${message}`);
     fireDone();
     return;
@@ -266,6 +289,11 @@ export async function executeComposeSummarize(inputs: ExecuteComposeSummarizeInp
   let sawResult = false;
   let sawDone = false;
   let sawError = false;
+  // SSE trace counters — help distinguish "read completed but no bytes" from
+  // "read errored mid-way" from "read errored before any bytes".
+  let totalBytes = 0;
+  let readCount = 0;
+  let frameCount = 0;
 
   try {
     // SSE frame loop. Each event is separated by "\n\n"; each event has one
@@ -273,7 +301,20 @@ export async function executeComposeSummarize(inputs: ExecuteComposeSummarizeInp
     // the literal terminal sentinel `[DONE]`.
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      readCount += 1;
+      if (done) {
+        traceLog('reader.read() done=true (stream closed cleanly by server)', {
+          readCount,
+          totalBytes,
+          frameCount,
+          sawResult,
+          sawDone,
+          sawError,
+        });
+        break;
+      }
+      totalBytes += value?.byteLength ?? 0;
+      traceLog('reader.read() returned chunk', { readCount, bytes: value?.byteLength ?? 0, totalBytes });
 
       buffer += decoder.decode(value, { stream: true });
 
@@ -281,6 +322,13 @@ export async function executeComposeSummarize(inputs: ExecuteComposeSummarizeInp
       buffer = parts.pop() ?? '';
 
       for (const part of parts) {
+        frameCount += 1;
+        // Raw frame dump (truncated so a large `result` payload doesn't spam
+        // the console). Enables inspecting what the server actually sent
+        // versus what we parsed — key for diagnosing "stream read failed —
+        // network error" reports where the client sees the frame but the
+        // reader errors.
+        traceLog(`frame ${frameCount} raw`, { text: part.length > 400 ? part.slice(0, 400) + '…' : part });
         const dataLines: string[] = [];
         for (const line of part.split('\n')) {
           if (line.startsWith('data:')) {
@@ -361,15 +409,47 @@ export async function executeComposeSummarize(inputs: ExecuteComposeSummarizeInp
     // If the stream ended without a terminal chunk, treat it as success only
     // if a result was seen; otherwise surface an error.
     if (!sawDone && !sawResult && !sawError) {
+      traceLog('stream ended without terminal', {
+        readCount,
+        totalBytes,
+        frameCount,
+        bufferLen: buffer.length,
+      });
       onError?.('Compose summarize: stream ended without a terminal event.');
     }
+    traceLog('loop exit clean', {
+      readCount,
+      totalBytes,
+      frameCount,
+      sawResult,
+      sawDone,
+      sawError,
+    });
   } catch (err) {
     if (signal?.aborted) {
       // Caller-initiated abort — no error surfacing.
+      traceLog('abort observed inside loop', { readCount, totalBytes, frameCount });
       fireDone();
       return;
     }
     const message = err instanceof Error ? err.message : String(err);
+    const errorName = err instanceof Error ? err.name : 'unknown';
+    // Rich trace: read-count + byte-count + frame-count reveal WHERE in the
+    // stream the error occurred. `network error` at readCount=1, totalBytes=0
+    // means the connection died immediately post-headers. `network error` at
+    // readCount>2 with progress frames received means the server started
+    // streaming then died — likely a downstream exception or middleware
+    // timeout.
+    traceLog('stream read threw', {
+      error: message,
+      name: errorName,
+      readCount,
+      totalBytes,
+      frameCount,
+      sawResult,
+      sawDone,
+      sawError,
+    });
     onError?.(`Compose summarize: stream read failed — ${message}`);
   } finally {
     try {

--- a/src/client/shared/Spaarke.Compose.Components/src/orchestrators/executeComposeSummarize.ts
+++ b/src/client/shared/Spaarke.Compose.Components/src/orchestrators/executeComposeSummarize.ts
@@ -167,9 +167,7 @@ export interface ExecuteComposeSummarizeInputs {
  * error). The caller may `await` this promise to know when the stream is
  * fully drained.
  */
-export async function executeComposeSummarize(
-  inputs: ExecuteComposeSummarizeInputs
-): Promise<void> {
+export async function executeComposeSummarize(inputs: ExecuteComposeSummarizeInputs): Promise<void> {
   const {
     bffBaseUrl,
     documentSpeId,
@@ -187,9 +185,7 @@ export async function executeComposeSummarize(
   } = inputs;
 
   if (!bffBaseUrl || !documentSpeId || !driveId || !tenantId) {
-    onError?.(
-      'Compose summarize: missing required inputs (bffBaseUrl, documentSpeId, driveId, tenantId).'
-    );
+    onError?.('Compose summarize: missing required inputs (bffBaseUrl, documentSpeId, driveId, tenantId).');
     onDone?.();
     return;
   }

--- a/src/client/shared/Spaarke.Compose.Components/src/types/compose-contracts.ts
+++ b/src/client/shared/Spaarke.Compose.Components/src/types/compose-contracts.ts
@@ -578,23 +578,17 @@ export interface ComposeAssistantToContextFlow {
  * Subscribers narrow first on event.type === 'compose_*' to handle
  * Compose flows distinctly from existing workspace events.
  */
-export type ComposeWorkspaceEvent =
-  | ComposeContextToWorkspaceFlow
-  | ComposeAssistantToWorkspaceFlow;
+export type ComposeWorkspaceEvent = ComposeContextToWorkspaceFlow | ComposeAssistantToWorkspaceFlow;
 
 /**
  * Compose-specific additions to the existing `context` channel.
  */
-export type ComposeContextEvent =
-  | ComposeWorkspaceToContextFlow
-  | ComposeAssistantToContextFlow;
+export type ComposeContextEvent = ComposeWorkspaceToContextFlow | ComposeAssistantToContextFlow;
 
 /**
  * Compose-specific additions to the existing `conversation` channel.
  */
-export type ComposeConversationEvent =
-  | ComposeWorkspaceToAssistantFlow
-  | ComposeContextToAssistantFlow;
+export type ComposeConversationEvent = ComposeWorkspaceToAssistantFlow | ComposeContextToAssistantFlow;
 
 /**
  * Catch-all union of every Compose flow event for diagnostics / logging.

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeBannerStack.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeBannerStack.tsx
@@ -31,18 +31,9 @@
  */
 
 import * as React from 'react';
-import {
-  makeStyles,
-  tokens,
-  MessageBar,
-  MessageBarBody,
-  MessageBarTitle,
-} from '@fluentui/react-components';
+import { makeStyles, tokens, MessageBar, MessageBarBody, MessageBarTitle } from '@fluentui/react-components';
 
-import type {
-  ComposeCheckoutLockedByInfo,
-  ComposeCheckoutStatus,
-} from './ComposeWorkspace.types';
+import type { ComposeCheckoutLockedByInfo, ComposeCheckoutStatus } from './ComposeWorkspace.types';
 import type { ComposeAssistantToWorkspaceFlow } from '../types/compose-contracts';
 
 export interface ComposeBannerStackProps {
@@ -98,11 +89,7 @@ export function ComposeBannerStack(props: ComposeBannerStackProps): React.JSX.El
       ) : null}
 
       {checkoutStatus === 'conflict' && checkoutLockedBy ? (
-        <MessageBar
-          intent="warning"
-          data-testid="compose-workspace-checkout-conflict-banner"
-          aria-live="polite"
-        >
+        <MessageBar intent="warning" data-testid="compose-workspace-checkout-conflict-banner" aria-live="polite">
           <MessageBarBody>
             <MessageBarTitle>Document is checked out</MessageBarTitle>
             {checkoutLockedBy.checkedOutAt
@@ -113,11 +100,7 @@ export function ComposeBannerStack(props: ComposeBannerStackProps): React.JSX.El
       ) : null}
 
       {checkoutStatus === 'failed' && checkoutFailureMessage ? (
-        <MessageBar
-          intent="info"
-          data-testid="compose-workspace-checkout-failed-banner"
-          aria-live="polite"
-        >
+        <MessageBar intent="info" data-testid="compose-workspace-checkout-failed-banner" aria-live="polite">
           <MessageBarBody>
             <MessageBarTitle>Lock not acquired</MessageBarTitle>
             {checkoutFailureMessage}
@@ -126,44 +109,29 @@ export function ComposeBannerStack(props: ComposeBannerStackProps): React.JSX.El
       ) : null}
 
       {checkoutStatus === 'cancelled' ? (
-        <MessageBar
-          intent="info"
-          data-testid="compose-workspace-checkout-cancelled-banner"
-          aria-live="polite"
-        >
+        <MessageBar intent="info" data-testid="compose-workspace-checkout-cancelled-banner" aria-live="polite">
           <MessageBarBody>
             <MessageBarTitle>This session is no longer active</MessageBarTitle>
-            This document is open in another Compose session. Refresh this page to attempt to
-            acquire the lock again, or close this tab.
+            This document is open in another Compose session. Refresh this page to attempt to acquire the lock again, or
+            close this tab.
           </MessageBarBody>
         </MessageBar>
       ) : null}
 
       {importWarnings.length > 0 ? (
-        <MessageBar
-          intent="warning"
-          data-testid="compose-workspace-import-warning-banner"
-          aria-live="polite"
-        >
+        <MessageBar intent="warning" data-testid="compose-workspace-import-warning-banner" aria-live="polite">
           <MessageBarBody>
-            <MessageBarTitle>
-              Document opened with {importWarnings.length} simplification(s)
-            </MessageBarTitle>
+            <MessageBarTitle>Document opened with {importWarnings.length} simplification(s)</MessageBarTitle>
             Some advanced features may not be preserved on save.
           </MessageBarBody>
         </MessageBar>
       ) : null}
 
       {pendingAssistantInsert ? (
-        <MessageBar
-          intent="info"
-          data-testid="compose-workspace-pending-assistant-banner"
-          aria-live="polite"
-        >
+        <MessageBar intent="info" data-testid="compose-workspace-pending-assistant-banner" aria-live="polite">
           <MessageBarBody>
-            <MessageBarTitle>Assistant draft ready</MessageBarTitle>
-            A draft from the Assistant is staged for insertion. (R2 wires the insert action; R1
-            acknowledges receipt only.)
+            <MessageBarTitle>Assistant draft ready</MessageBarTitle>A draft from the Assistant is staged for insertion.
+            (R2 wires the insert action; R1 acknowledges receipt only.)
           </MessageBarBody>
         </MessageBar>
       ) : null}

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeConflictDialog.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeConflictDialog.tsx
@@ -273,31 +273,18 @@ export function ComposeConflictDialog(props: ComposeConflictDialogProps): React.
         aria-describedby="compose-conflict-dialog-content"
       >
         <DialogBody>
-          <DialogTitle id="compose-conflict-dialog-title">
-            This document is open in another Compose session
-          </DialogTitle>
-          <DialogContent
-            id="compose-conflict-dialog-content"
-            className={styles.content}
-          >
+          <DialogTitle id="compose-conflict-dialog-title">This document is open in another Compose session</DialogTitle>
+          <DialogContent id="compose-conflict-dialog-content" className={styles.content}>
             <Text className={styles.paragraph}>
-              You already have{' '}
-              {documentDisplayName ? (
-                <strong>{documentDisplayName}</strong>
-              ) : (
-                'this document'
-              )}{' '}
-              open in another tab or window. Only one editing session per
-              document is allowed at a time.
+              You already have {documentDisplayName ? <strong>{documentDisplayName}</strong> : 'this document'} open in
+              another tab or window. Only one editing session per document is allowed at a time.
             </Text>
             {openedAtDisplay ? (
               <Text className={styles.meta} data-testid="compose-conflict-opened-at">
                 Other session opened: {openedAtDisplay}
               </Text>
             ) : null}
-            <Text className={styles.paragraph}>
-              Choose how to continue:
-            </Text>
+            <Text className={styles.paragraph}>Choose how to continue:</Text>
           </DialogContent>
           <DialogActions
             // Fluent v9 DialogActions is internally a flex row; we override
@@ -321,11 +308,7 @@ export function ComposeConflictDialog(props: ComposeConflictDialogProps): React.
               {/* FR-16 verbatim — do not change wording. */}
               Go to that session
             </Button>
-            <Button
-              appearance="subtle"
-              onClick={onCancel}
-              data-testid="compose-conflict-cancel-button"
-            >
+            <Button appearance="subtle" onClick={onCancel} data-testid="compose-conflict-cancel-button">
               Cancel — close this tab
             </Button>
           </DialogActions>

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeEmptyState.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeEmptyState.tsx
@@ -68,17 +68,8 @@
  */
 
 import * as React from 'react';
-import {
-  makeStyles,
-  tokens,
-  Button,
-  Card,
-  Text,
-} from '@fluentui/react-components';
-import {
-  DocumentArrowUpRegular,
-  SearchRegular,
-} from '@fluentui/react-icons';
+import { makeStyles, tokens, Button, Card, Text } from '@fluentui/react-components';
+import { DocumentArrowUpRegular, SearchRegular } from '@fluentui/react-icons';
 
 // ---------------------------------------------------------------------------
 // Styles — Fluent v9 semantic tokens only (ADR-021)
@@ -224,8 +215,7 @@ export function ComposeEmptyState({
           Open a document to start composing
         </Text>
         <Text size={300} className={styles.description}>
-          Browse and upload a file to draft from, or search for an existing
-          Spaarke document.
+          Browse and upload a file to draft from, or search for an existing Spaarke document.
         </Text>
 
         <div className={styles.actions} role="group" aria-label="Open document options">

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeToolbar.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeToolbar.tsx
@@ -95,18 +95,25 @@ export interface ComposeSummarizeRequestEvent {
   /** Always 'compose_summarize_request' — additive on `conversation` channel. */
   type: 'compose_summarize_request';
   /**
-   * Document pointer. `documentId` is the SPE drive-item id (for ephemeral
-   * Path B docs) OR the `sprk_documentid` (after first-Save promotion). The
-   * BFF `/api/compose/action/compose-summarize` endpoint handles both shapes.
+   * Document pointer.
    *
-   * Task 098 (Phase 9) note: for Path B ephemeral docs, `documentId` MUST be
-   * the SPE drive-item id (not the sprk_documentid) because the BFF's Load
-   * endpoint keys on `documentSpeId`. Post-promotion, the payload adds the
-   * `sprkDocumentId` field so the ConversationPane consumer forwards it to
-   * the BFF as `documentRecordId` (Dataverse correlation).
+   * - `documentId` — pass-through of the toolbar's `documentId` prop. May be
+   *   either the SPE drive-item id or the `sprk_documentid` depending on how
+   *   the parent tuned the toolbar for Open-in-Word (which prefers the
+   *   Dataverse GUID because `GET /api/documents/{id}/open-links` requires it).
+   *   Retained for backwards compatibility + telemetry.
+   * - `speDriveItemId` — ALWAYS the SPE drive-item id. Added in the 2026-07-02
+   *   smoke-2 hotfix so the ConversationPane consumer can pass it verbatim to
+   *   the BFF's `documentSpeId` field (LoadDocxAsync keys on SPE, not on
+   *   Dataverse). Before this fix, `documentId` was used and produced Graph 404
+   *   ODataErrors when the toolbar was tuned to prefer the Dataverse GUID.
+   * - `sprkDocumentId` — `sprk_documentid` GUID (post-promotion). Forwarded to
+   *   the BFF as `documentRecordId` for Dataverse correlation.
+   * - `fileName` — human-readable label for logging + UI.
    */
   documentRef: {
     documentId: string;
+    speDriveItemId: string;
     sprkDocumentId?: string;
     fileName?: string;
   };
@@ -191,6 +198,17 @@ export interface ComposeToolbarProps {
    * Empty string disables the summarize button.
    */
   tenantId: string;
+
+  /**
+   * SPE drive-item id — ALWAYS the SPE-side identifier (matches Graph's
+   * drive-item id shape). Added in the 2026-07-02 smoke-2 hotfix so the
+   * `compose_summarize_request` event carries the SPE ID separately from
+   * `documentId` (which may be the Dataverse GUID for Open-in-Word).
+   *
+   * Empty string disables the summarize button (no SPE ID = no way to load
+   * DOCX bytes on the BFF side).
+   */
+  speDriveItemId: string;
 
   /**
    * Optional `sprk_documentid` GUID (post-promotion). When present, forwarded
@@ -307,6 +325,7 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
     bffBaseUrl,
     driveId,
     tenantId,
+    speDriveItemId,
     sprkDocumentId,
     disabled,
     className,
@@ -334,10 +353,13 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
   const isToolbarDisabled = disabled === true;
   const hasDocument = documentId.length > 0 && bffBaseUrl.length > 0;
   const hasSession = sessionId.length > 0;
-  // Task 098 (Phase 9): the summarize action ALSO requires driveId + tenantId
-  // now — the event carries them so ConversationPane can invoke the BFF
-  // without re-resolving. If either is missing, the button is inert.
-  const hasSummarizeContext = driveId.length > 0 && tenantId.length > 0;
+  // Task 098 (Phase 9) + 2026-07-02 smoke-2 hotfix: the summarize action
+  // requires driveId + tenantId + speDriveItemId — the BFF's LoadDocxAsync
+  // keys on the SPE drive-item id (NOT on the Dataverse GUID that Open-in-
+  // Word uses). If any of the three is missing, the summarize button is
+  // inert so we fail closed rather than firing a broken request.
+  const hasSummarizeContext =
+    driveId.length > 0 && tenantId.length > 0 && speDriveItemId.length > 0;
 
   const openInWebDisabled = isToolbarDisabled || !hasDocument || isActing;
   const openInDesktopDisabled = isToolbarDisabled || !hasDocument || isActing;
@@ -360,6 +382,11 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
       type: 'compose_summarize_request',
       documentRef: {
         documentId,
+        // 2026-07-02 smoke-2 hotfix — carry the SPE ID separately from
+        // `documentId` so ConversationPane can forward it verbatim to the
+        // BFF's `documentSpeId` field (LoadDocxAsync keys on SPE, not on
+        // the Dataverse GUID).
+        speDriveItemId,
         sprkDocumentId,
         fileName,
       },
@@ -385,6 +412,7 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
     summarizeDisabled,
     dispatch,
     documentId,
+    speDriveItemId,
     sprkDocumentId,
     fileName,
     sessionId,

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeToolbar.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeToolbar.tsx
@@ -61,20 +61,8 @@
  */
 
 import * as React from 'react';
-import {
-  Toolbar,
-  ToolbarButton,
-  Tooltip,
-  makeStyles,
-  mergeClasses,
-  tokens,
-} from '@fluentui/react-components';
-import {
-  OpenRegular,
-  DesktopRegular,
-  SparkleRegular,
-  SaveRegular,
-} from '@fluentui/react-icons';
+import { Toolbar, ToolbarButton, Tooltip, makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
+import { OpenRegular, DesktopRegular, SparkleRegular, SaveRegular } from '@fluentui/react-icons';
 import { useDispatchPaneEvent } from '@spaarke/ai-widgets/events';
 import { useDocumentActions } from '@spaarke/document-operations';
 
@@ -353,8 +341,7 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
 
   const openInWebDisabled = isToolbarDisabled || !hasDocument || isActing;
   const openInDesktopDisabled = isToolbarDisabled || !hasDocument || isActing;
-  const summarizeDisabled =
-    isToolbarDisabled || !hasDocument || !hasSession || !hasSummarizeContext;
+  const summarizeDisabled = isToolbarDisabled || !hasDocument || !hasSession || !hasSummarizeContext;
 
   const handleOpenInWeb = React.useCallback((): void => {
     if (openInWebDisabled) return;
@@ -391,10 +378,7 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
     // dispatch in this codebase — see `compose-contracts.ts` §"IMPORTANT —
     // additive contract" and `SendToWorkspaceButton.tsx` for the precedent
     // (workspace.widget_load + custom widgetData shape).
-    dispatch(
-      'conversation',
-      payload as unknown as Parameters<typeof dispatch<'conversation'>>[1],
-    );
+    dispatch('conversation', payload as unknown as Parameters<typeof dispatch<'conversation'>>[1]);
 
     onComposeSummarizeRequest?.(payload);
   }, [
@@ -410,17 +394,9 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
   ]);
 
   return (
-    <Toolbar
-      className={mergeClasses(styles.toolbar, className)}
-      size="small"
-      aria-label="Compose document actions"
-    >
+    <Toolbar className={mergeClasses(styles.toolbar, className)} size="small" aria-label="Compose document actions">
       <Tooltip
-        content={
-          hasDocument
-            ? 'Open this document in Word for the Web'
-            : 'No document loaded'
-        }
+        content={hasDocument ? 'Open this document in Word for the Web' : 'No document loaded'}
         relationship="label"
       >
         <ToolbarButton
@@ -434,11 +410,7 @@ export function ComposeToolbar(props: ComposeToolbarProps): React.JSX.Element {
       </Tooltip>
 
       <Tooltip
-        content={
-          hasDocument
-            ? 'Open this document in the Word desktop app'
-            : 'No document loaded'
-        }
+        content={hasDocument ? 'Open this document in the Word desktop app' : 'No document loaded'}
         relationship="label"
       >
         <ToolbarButton

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeWorkspace.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeWorkspace.tsx
@@ -59,11 +59,7 @@ import {
   Spinner,
 } from '@fluentui/react-components';
 import { ComposeBannerStack } from './ComposeBannerStack';
-import {
-  ComposeEditor,
-  type ComposeEditorHandle,
-  type ComposeEditorDocumentRef,
-} from './ComposeEditor';
+import { ComposeEditor, type ComposeEditorHandle, type ComposeEditorDocumentRef } from './ComposeEditor';
 // spaarkeai-compose-r1 task 093: deep-import from `@spaarke/ai-widgets/events`
 // rather than the barrel `@spaarke/ai-widgets` to skip the barrel's side-effect
 // widget registration (`register-workspace-widgets.ts` transitively pulls in
@@ -83,11 +79,7 @@ import { ComposeToolbar } from './ComposeToolbar';
 import { ComposeEmptyState } from './ComposeEmptyState';
 import { ComposeConflictDialog } from './ComposeConflictDialog';
 import { composeWorkspaceReducer, INITIAL_STATE } from './ComposeWorkspace.types';
-import {
-  useComposeBroadcastChannel,
-  useComposeCheckoutLifecycle,
-  useComposeHeartbeatGate,
-} from './hooks';
+import { useComposeBroadcastChannel, useComposeCheckoutLifecycle, useComposeHeartbeatGate } from './hooks';
 import type {
   ComposeDocumentRef,
   ComposeAssistantToWorkspaceFlow,
@@ -96,11 +88,7 @@ import type {
 } from '../types/compose-contracts';
 
 // Re-export types for backwards-compatible consumer imports.
-export type {
-  ComposeCheckoutStatus,
-  ComposeWorkspaceState,
-  ComposeWorkspaceAction,
-} from './ComposeWorkspace.types';
+export type { ComposeCheckoutStatus, ComposeWorkspaceState, ComposeWorkspaceAction } from './ComposeWorkspace.types';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -261,8 +249,7 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
       dispatch({
         kind: 'loadFailed',
         errorMessage:
-          'SPE drive id and tenant id are required to load Compose documents. ' +
-          'Check the host configuration.',
+          'SPE drive id and tenant id are required to load Compose documents. ' + 'Check the host configuration.',
       });
       return;
     }
@@ -276,9 +263,7 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
         if (docRef.sprkDocumentId) qs.set('documentRecordId', docRef.sprkDocumentId);
         if (docRef.fileName) qs.set('displayName', docRef.fileName);
 
-        const url = `${bffBaseUrl}/api/compose/documents/${encodeURIComponent(
-          docRef.speDriveItemId
-        )}?${qs.toString()}`;
+        const url = `${bffBaseUrl}/api/compose/documents/${encodeURIComponent(docRef.speDriveItemId)}?${qs.toString()}`;
 
         const response = await authenticatedFetch(url, { method: 'GET', signal: ac.signal });
 
@@ -367,11 +352,7 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
   // Previously lived in ComposeEditor and fired regardless of checkout state;
   // hoisted here and gated so a cancelled tab no longer heart-beats a lock it
   // doesn't hold.
-  useComposeHeartbeatGate(
-    state.checkoutStatus,
-    state.documentRef?.sprkDocumentId,
-    bffBaseUrl
-  );
+  useComposeHeartbeatGate(state.checkoutStatus, state.documentRef?.sprkDocumentId, bffBaseUrl);
 
   // -------------------------------------------------------------------------
   // Conflict dialog handler — "Go to that session"
@@ -400,9 +381,7 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
     dispatch({ kind: 'requestSave' });
     try {
       const bytes = await editorRef.current.serialize();
-      const url = `${bffBaseUrl}/api/compose/documents/${encodeURIComponent(
-        state.documentRef.speDriveItemId
-      )}/save`;
+      const url = `${bffBaseUrl}/api/compose/documents/${encodeURIComponent(state.documentRef.speDriveItemId)}/save`;
 
       // Encode bytes -> base64. ASP.NET Core deserializes byte[] from
       // base64 strings, NOT from JSON number arrays. Iterate rather than
@@ -471,14 +450,7 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
       const message = err instanceof Error ? err.message : String(err);
       dispatch({ kind: 'saveFailed', errorMessage: `Save failed: ${message}` });
     }
-  }, [
-    state.status,
-    state.documentRef,
-    state.sessionId,
-    bffBaseUrl,
-    driveId,
-    tenantId,
-  ]);
+  }, [state.status, state.documentRef, state.sessionId, bffBaseUrl, driveId, tenantId]);
 
   // Keyboard shortcut: Ctrl/Cmd+S → save.
   React.useEffect(() => {
@@ -583,12 +555,9 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
     setIsDirty(dirty);
   }, []);
 
-  const handleImportWarnings = React.useCallback(
-    (warnings: Array<{ type: string; message: string }>): void => {
-      dispatch({ kind: 'importWarnings', warnings });
-    },
-    []
-  );
+  const handleImportWarnings = React.useCallback((warnings: Array<{ type: string; message: string }>): void => {
+    dispatch({ kind: 'importWarnings', warnings });
+  }, []);
 
   // -------------------------------------------------------------------------
   // Summarize dispatch — DELEGATED to ConversationPane (task 098 / Phase 9).
@@ -624,8 +593,7 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
     : undefined;
 
   // Toolbar documentId (Open-in-Word handoff) — accepts SPE id or sprk_documentid.
-  const toolbarDocumentId =
-    state.documentRef?.sprkDocumentId ?? state.documentRef?.speDriveItemId ?? '';
+  const toolbarDocumentId = state.documentRef?.sprkDocumentId ?? state.documentRef?.speDriveItemId ?? '';
 
   // -------------------------------------------------------------------------
   // Render
@@ -643,20 +611,12 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
     >
       {/* Empty state — Path A/B picker */}
       {state.status === 'empty' ? (
-        <ComposeEmptyState
-          onBrowseRequested={handleBrowseRequested}
-          onSearchRequested={handleSearchRequested}
-        />
+        <ComposeEmptyState onBrowseRequested={handleBrowseRequested} onSearchRequested={handleSearchRequested} />
       ) : null}
 
       {/* Loading spinner */}
       {state.status === 'loading' ? (
-        <div
-          className={styles.loadingState}
-          role="status"
-          aria-live="polite"
-          data-testid="compose-workspace-loading"
-        >
+        <div className={styles.loadingState} role="status" aria-live="polite" data-testid="compose-workspace-loading">
           <Spinner size="medium" />
           <Text size={300}>Loading document…</Text>
         </div>
@@ -697,7 +657,6 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
             pendingAssistantInsert={state.pendingAssistantInsert}
           />
 
-
           <div className={styles.editorSlot}>
             <ComposeEditor
               ref={editorRef}
@@ -730,11 +689,7 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
 
       {/* Error state — load failed; no document loaded */}
       {state.status === 'error' ? (
-        <div
-          className={styles.bannerStack}
-          data-testid="compose-workspace-error-empty"
-          role="alert"
-        >
+        <div className={styles.bannerStack} data-testid="compose-workspace-error-empty" role="alert">
           <MessageBar intent="error">
             <MessageBarBody>
               <MessageBarTitle>Cannot load document</MessageBarTitle>

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeWorkspace.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeWorkspace.tsx
@@ -628,6 +628,11 @@ export function ComposeWorkspace(props: ComposeWorkspaceProps): React.JSX.Elemen
           <div className={styles.toolbarSlot}>
             <ComposeToolbar
               documentId={toolbarDocumentId}
+              // 2026-07-02 smoke-2 hotfix — pass the SPE drive-item id
+              // explicitly (separate from `documentId` which prefers the
+              // Dataverse GUID for Open-in-Word). Compose-summarize needs
+              // the SPE ID because LoadDocxAsync keys on SPE.
+              speDriveItemId={state.documentRef?.speDriveItemId ?? ''}
               sprkDocumentId={state.documentRef?.sprkDocumentId}
               fileName={state.documentRef?.fileName}
               sessionId={state.sessionId}

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/hooks/useComposeCheckoutLifecycle.ts
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/hooks/useComposeCheckoutLifecycle.ts
@@ -220,10 +220,7 @@ export function useComposeCheckoutLifecycle(
 
     const ac = new AbortController();
 
-    const probeUrl = buildBffApiUrl(
-      bffBaseUrl,
-      `/documents/${encodeURIComponent(sprkDocumentId)}/checkout-status`
-    );
+    const probeUrl = buildBffApiUrl(bffBaseUrl, `/documents/${encodeURIComponent(sprkDocumentId)}/checkout-status`);
 
     // eslint-disable-next-line no-console
     console.info('[ComposeWorkspace] SPE check-out probe requested', {
@@ -253,8 +250,7 @@ export function useComposeCheckoutLifecycle(
               checkedOutAt?: string | null;
               isCurrentUser?: boolean;
             };
-            probeIsCurrentUser =
-              probeBody.isCheckedOut === true && probeBody.isCurrentUser === true;
+            probeIsCurrentUser = probeBody.isCheckedOut === true && probeBody.isCurrentUser === true;
             probeCheckedOutAt = probeBody.checkedOutAt ?? null;
             // eslint-disable-next-line no-console
             console.info('[ComposeWorkspace] SPE check-out probe result', {
@@ -324,10 +320,7 @@ export function useComposeCheckoutLifecycle(
     });
     dispatch({ kind: 'checkoutDiscarding' });
 
-    const discardUrl = buildBffApiUrl(
-      bffBaseUrl,
-      `/documents/${encodeURIComponent(sprkDocumentId)}/discard`
-    );
+    const discardUrl = buildBffApiUrl(bffBaseUrl, `/documents/${encodeURIComponent(sprkDocumentId)}/discard`);
 
     try {
       const discardResponse = await authenticatedFetch(discardUrl, { method: 'POST' });

--- a/src/server/api/Sprk.Bff.Api/Api/ComposeEndpoints.cs
+++ b/src/server/api/Sprk.Bff.Api/Api/ComposeEndpoints.cs
@@ -647,12 +647,24 @@ public static class ComposeEndpoints
             "Compose dispatch SSE: consumerType={ConsumerType} tenant={TenantId} item={DocumentSpeId} record={DocumentRecordId} session={SessionId} TraceId={TraceId}",
             consumerType, body.TenantId, body.DocumentSpeId, body.DocumentRecordId, body.SessionId, httpContext.TraceIdentifier);
 
+        // 2026-07-02 SSE trace instrumentation (task 098 smoke debug):
+        // A wall-clock stopwatch measures per-stage timing so we can correlate
+        // client-side "stream read failed — network error" reports with the
+        // actual server-side state at the moment of failure. Emitted at INFO
+        // level so the logs are trivially greppable by TraceId without
+        // requiring log-level changes.
+        var pipelineSw = System.Diagnostics.Stopwatch.StartNew();
+
         // Set SSE headers — from here on, ALL failures emit error chunks + [DONE].
         response.ContentType = "text/event-stream";
         response.Headers.CacheControl = "no-cache";
         response.Headers.Connection = "keep-alive";
         response.Headers["X-Accel-Buffering"] = "no";
         httpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        logger.LogInformation(
+            "Compose dispatch SSE trace [T+{ElapsedMs}ms] SSE headers committed. clientAborted={ClientAborted} TraceId={TraceId}",
+            pipelineSw.ElapsedMilliseconds, httpContext.RequestAborted.IsCancellationRequested, httpContext.TraceIdentifier);
 
         try
         {
@@ -687,6 +699,10 @@ public static class ComposeEndpoints
                 return;
             }
 
+            logger.LogInformation(
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] playbook resolved. playbookId={PlaybookId} clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds, playbookId, httpContext.RequestAborted.IsCancellationRequested, httpContext.TraceIdentifier);
+
             // Stage 2: load DOCX bytes from SPE via IComposeDocumentService (existing
             // OBO plumbing, no change to loader semantics).
             await WriteSSEAsync(
@@ -694,10 +710,20 @@ public static class ComposeEndpoints
                 AnalysisStreamChunk.Progress("document_loaded", "Loading document from SharePoint Embedded..."),
                 ct);
 
+            var loadStartMs = pipelineSw.ElapsedMilliseconds;
             var loadResultRaw = await documentService
                 .LoadDocxAsync(httpContext, body.DriveId, body.DocumentSpeId, ct)
                 .ConfigureAwait(false);
             using var loadResult = new LoadResultLease(loadResultRaw);
+
+            logger.LogInformation(
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] LoadDocxAsync returned. loadMs={LoadMs} found={Found} bytes={ByteCount} clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds,
+                pipelineSw.ElapsedMilliseconds - loadStartMs,
+                loadResult.Value.Found,
+                loadResult.Value.Content?.Length ?? 0,
+                httpContext.RequestAborted.IsCancellationRequested,
+                httpContext.TraceIdentifier);
 
             if (!loadResult.Value.Found || loadResult.Value.Content is null)
             {
@@ -722,6 +748,7 @@ public static class ComposeEndpoints
                 AnalysisStreamChunk.Progress("extracting_text", "Extracting document text..."),
                 ct);
 
+            var extractStartMs = pipelineSw.ElapsedMilliseconds;
             string extractedText;
             try
             {
@@ -762,14 +789,20 @@ public static class ComposeEndpoints
             }
 
             logger.LogInformation(
-                "Compose dispatch SSE: text extraction complete. chars={CharCount} TraceId={TraceId}",
-                extractedText.Length, httpContext.TraceIdentifier);
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] text extraction complete. extractMs={ExtractMs} chars={CharCount} clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds,
+                pipelineSw.ElapsedMilliseconds - extractStartMs,
+                extractedText.Length,
+                httpContext.RequestAborted.IsCancellationRequested,
+                httpContext.TraceIdentifier);
 
             // Stage 4: invoke the playbook via the widened facade (task 095/096).
             await WriteSSEAsync(
                 response,
                 AnalysisStreamChunk.Progress("invoking_playbook", "Invoking playbook..."),
                 ct);
+
+            var invokeStartMs = pipelineSw.ElapsedMilliseconds;
 
             // Build parameters dict from the compose-document scope payload (spike #4 §4.2).
             // ADR-015 binding: all values are deterministic identifiers / display values.
@@ -801,6 +834,16 @@ public static class ComposeEndpoints
                     userContext: extractedText,
                     document: documentContext)
                 .ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] InvokePlaybookAsync returned. invokeMs={InvokeMs} success={Success} textContentLen={TextLen} errorCode={ErrorCode} clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds,
+                pipelineSw.ElapsedMilliseconds - invokeStartMs,
+                result.Success,
+                result.TextContent?.Length ?? 0,
+                result.ErrorCode ?? "(none)",
+                httpContext.RequestAborted.IsCancellationRequested,
+                httpContext.TraceIdentifier);
 
             // Stage 5: project the final result onto SSE events.
             if (result.Success)
@@ -835,6 +878,10 @@ public static class ComposeEndpoints
 
             await response.WriteAsync("data: [DONE]\n\n", ct);
             await response.Body.FlushAsync(ct);
+
+            logger.LogInformation(
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] pipeline complete. clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds, httpContext.RequestAborted.IsCancellationRequested, httpContext.TraceIdentifier);
         }
         catch (Sprk.Bff.Api.Configuration.FeatureDisabledException ex)
         {
@@ -852,19 +899,28 @@ public static class ComposeEndpoints
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             logger.LogWarning(
-                "Compose dispatch SSE: timed out. TraceId={TraceId}",
-                httpContext.TraceIdentifier);
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] internal timeout. clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds, httpContext.RequestAborted.IsCancellationRequested, httpContext.TraceIdentifier);
             await WriteSSEAsync(
                 response,
                 AnalysisStreamChunk.FromError("Playbook invocation timed out. Please try again."),
                 CancellationToken.None);
             await response.WriteAsync("data: [DONE]\n\n", CancellationToken.None);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Client disconnected mid-stream (e.g., closed the modal, network drop,
+            // or upstream proxy timeout). Do NOT try to write more SSE frames —
+            // the response is dead.
+            logger.LogWarning(
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] CLIENT DISCONNECTED mid-stream. This is the most likely cause of client-side 'stream read failed — network error'. clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds, httpContext.RequestAborted.IsCancellationRequested, httpContext.TraceIdentifier);
+        }
         catch (Exception ex) when (!ct.IsCancellationRequested)
         {
             logger.LogError(ex,
-                "Compose dispatch SSE: unexpected failure. consumerType={ConsumerType} TraceId={TraceId}",
-                consumerType, httpContext.TraceIdentifier);
+                "Compose dispatch SSE trace [T+{ElapsedMs}ms] unexpected failure. consumerType={ConsumerType} clientAborted={ClientAborted} TraceId={TraceId}",
+                pipelineSw.ElapsedMilliseconds, consumerType, httpContext.RequestAborted.IsCancellationRequested, httpContext.TraceIdentifier);
             await WriteSSEAsync(
                 response,
                 AnalysisStreamChunk.FromError(

--- a/src/solutions/LegalWorkspace/src/sections/composeEditor.registration.ts
+++ b/src/solutions/LegalWorkspace/src/sections/composeEditor.registration.ts
@@ -76,6 +76,15 @@ import {
   ComposeWorkspace,
   useComposeLaunch,
 } from "@spaarke/compose-components";
+// spaarkeai-compose-r1 hotfix 2026-07-02 (smoke-1): `ComposeWorkspace` requires
+// `tenantId` as a required prop (widened facade for compose-summarize per
+// task 095 / ADR-013 amendment 2026-07-01). Neither `SectionFactoryContext`
+// nor `ComposeLaunchContext` carries the tenant, so we read the shared MSAL
+// singleton directly. `resolveTenantIdSync` reads from `@spaarke/auth`'s
+// `getAuthProvider()` — populated during `initAuth` — and falls back to
+// `Xrm.Utility.getGlobalContext().organizationSettings.tenantId` if the
+// auth provider is not yet ready.
+import { resolveTenantIdSync } from "@spaarke/auth";
 
 // ---------------------------------------------------------------------------
 // ComposeSectionMount — inner functional component that bridges the Section
@@ -107,10 +116,17 @@ interface ComposeSectionMountProps {
 
 const ComposeSectionMount: React.FC<ComposeSectionMountProps> = ({ bffBaseUrl }) => {
   const composeLaunch = useComposeLaunch();
+  // 2026-07-02 smoke-1 hotfix — read tenantId from the MSAL singleton so
+  // ComposeWorkspace's Load endpoint gate passes. `resolveTenantIdSync` is
+  // synchronous + safe to call inside render. Xrm.Utility fallback covers
+  // any race where MSAL cache is empty on first paint (auth provider is
+  // always initialized before this mount because SpaarkeAi + LegalWorkspace
+  // both bootstrap `initAuth` before `createRoot(...).render(...)`).
+  const tenantId = resolveTenantIdSync();
   return React.createElement(ComposeWorkspace, {
     bffBaseUrl,
     driveId: composeLaunch?.driveId ?? "",
-    tenantId: "",
+    tenantId,
     initialDocumentRef: composeLaunch?.document ?? null,
     initialSessionId: "",
   });

--- a/src/solutions/SpaarkeAi/src/__tests__/compose/ComposeToolbar.test.tsx
+++ b/src/solutions/SpaarkeAi/src/__tests__/compose/ComposeToolbar.test.tsx
@@ -87,6 +87,10 @@ const FIXED_BFF_URL = 'https://bff.example.com';
 // the summarize action so the event payload carries them into ConversationPane.
 const FIXED_DRIVE_ID = 'drive-container-xyz';
 const FIXED_TENANT_ID = 'tenant-guid-0000';
+// 2026-07-02 smoke-2 hotfix — the SPE drive-item id is now a separate
+// required prop (differs from `documentId` which prefers the Dataverse GUID
+// for Open-in-Word).
+const FIXED_SPE_DRIVE_ITEM_ID = 'spe-drive-item-abcdef';
 
 /**
  * Render the toolbar with a real PaneEventBus + FluentProvider. Returns the
@@ -122,6 +126,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
 
@@ -144,6 +149,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
       expect(
@@ -159,6 +165,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
       expect(
@@ -180,6 +187,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
       // Open-in-Word buttons remain enabled because they don't require a session.
@@ -203,6 +211,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId=""
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
       expect(
@@ -218,6 +227,23 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId=""
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
+        />,
+      );
+      expect(
+        screen.getByRole('button', { name: /summarize with assistant/i }),
+      ).toBeDisabled();
+    });
+
+    it('disables summarize button when speDriveItemId is empty (smoke-2 hotfix)', () => {
+      renderWithBus(
+        <ComposeToolbar
+          documentId={FIXED_DOCUMENT_ID}
+          sessionId={FIXED_SESSION_ID}
+          bffBaseUrl={FIXED_BFF_URL}
+          driveId={FIXED_DRIVE_ID}
+          tenantId={FIXED_TENANT_ID}
+          speDriveItemId=""
         />,
       );
       expect(
@@ -233,6 +259,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
           disabled
         />,
       );
@@ -257,6 +284,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
 
@@ -277,6 +305,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
           disabled
         />,
       );
@@ -300,6 +329,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
 
@@ -324,6 +354,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
       bus.subscribe('conversation', (ev) => events.push(ev));
@@ -344,6 +375,9 @@ describe('ComposeToolbar', () => {
       // ConversationPane can invoke the BFF directly.
       expect(payload.driveId).toBe(FIXED_DRIVE_ID);
       expect(payload.tenantId).toBe(FIXED_TENANT_ID);
+      // 2026-07-02 smoke-2 hotfix: speDriveItemId carried as a separate field
+      // so the BFF's LoadDocxAsync receives the SPE ID (not the Dataverse GUID).
+      expect(payload.documentRef.speDriveItemId).toBe(FIXED_SPE_DRIVE_ITEM_ID);
       // ISO-8601 UTC timestamp format
       expect(payload.timestamp).toMatch(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
@@ -360,6 +394,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
           onComposeSummarizeRequest={(p) => observerEvents.push(p)}
         />,
       );
@@ -385,6 +420,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
       bus.subscribe('conversation', (ev) => events.push(ev));
@@ -405,6 +441,7 @@ describe('ComposeToolbar', () => {
           bffBaseUrl={FIXED_BFF_URL}
           driveId={FIXED_DRIVE_ID}
           tenantId={FIXED_TENANT_ID}
+          speDriveItemId={FIXED_SPE_DRIVE_ITEM_ID}
         />,
       );
       bus.subscribe('conversation', (ev) => events.push(ev));

--- a/src/solutions/SpaarkeAi/src/components/conversation/ConversationPane.tsx
+++ b/src/solutions/SpaarkeAi/src/components/conversation/ConversationPane.tsx
@@ -910,9 +910,14 @@ export function ConversationPane(): React.JSX.Element {
     if ((event as { type?: string }).type !== "compose_summarize_request") return;
 
     // Widen the payload to the additive shape carried by ComposeToolbar.
+    // 2026-07-02 smoke-2 hotfix: `speDriveItemId` is now a required field on
+    // `documentRef` — used for the BFF's `documentSpeId` (LoadDocxAsync keys
+    // on SPE). `documentId` is retained for backwards compat + telemetry but
+    // NOT used for the BFF call.
     const payload = event as unknown as {
       documentRef: {
         documentId: string;
+        speDriveItemId: string;
         sprkDocumentId?: string;
         fileName?: string;
       };
@@ -932,7 +937,10 @@ export function ConversationPane(): React.JSX.Element {
 
     void executeComposeSummarize({
       bffBaseUrl,
-      documentSpeId: payload.documentRef.documentId,
+      // 2026-07-02 smoke-2 hotfix — use speDriveItemId (SPE Graph ID) not
+      // documentId (which may be the Dataverse GUID). LoadDocxAsync on the
+      // BFF keys on SPE; passing the Dataverse GUID caused ODataError 404.
+      documentSpeId: payload.documentRef.speDriveItemId,
       driveId: payload.driveId,
       tenantId: payload.tenantId,
       sessionId: payload.sessionId,


### PR DESCRIPTION
## Summary

Post-#534 smoke on Dev surfaced two runtime bugs (immediately fixed) + one persistent client-side SSE failure that needs diagnostic tracing to isolate. Coordination with r7 team confirmed all 9 Compose R1 → r7 dependency surfaces stable, so debug is Compose R1's to own.

**Commits**:
- `41a5ed439` — fix: smoke-1 (tenantId) + smoke-2 (SPE-id identifier split) + r7 coordination doc
- `b8ebb2522` — debug: SSE trace instrumentation on both server + client

## Smoke-1 hotfix — tenantId empty in ComposeWorkspace guard

**Symptom**: "Cannot load document — SPE drive id and tenant id are required."
**Root cause**: `composeEditor.registration.ts:113` hardcoded `tenantId: ""` because `SectionFactoryContext` doesn't carry tenant. Task 095 widening + ComposeWorkspace's Load-endpoint gate treat empty tenant as a hard failure.
**Fix**: `resolveTenantIdSync()` from `@spaarke/auth` — reads MSAL singleton populated during `initAuth`, with Xrm.Utility fallback.

## Smoke-2 hotfix — Dataverse GUID sent as documentSpeId to LoadDocxAsync

**Symptom**: "Summarize failed: ODataError: The resource could not be found."
**Root cause**: `ComposeToolbar.documentId` prop was serving two mutually incompatible endpoints:
- **Open-in-Word** (`GET /api/documents/{id}/open-links`) — requires Dataverse GUID
- **Compose-summarize** (`LoadDocxAsync` via `POST /api/compose/action/compose-summarize`) — requires SPE drive-item id

`ComposeWorkspace.toolbarDocumentId` preferred Dataverse GUID (correct for Open-in-Word); the `compose_summarize_request` event carried it verbatim as `documentRef.documentId`; ConversationPane forwarded it as `documentSpeId` to the BFF; Graph returned 404 ODataError.

**Fix**: separate required `speDriveItemId` prop on `ComposeToolbar` + `documentRef.speDriveItemId` field on the event. ConversationPane uses `payload.documentRef.speDriveItemId` for `documentSpeId`. `documentRef.documentId` retained for backwards compat + telemetry. New test + payload assertion added.

## R7 coordination — all 9 surfaces green

`projects/spaarkeai-compose-r1/notes/r7-coordination-ask-2026-07-02.md` captures:
- Full 9-surface Compose R1 → r7 dependency map (facade, routing, orchestrator, SSE envelope, DTOs, playbook, Graph download, text extractor)
- R7 team's per-surface answers (all 9 stays-as-is for Compose R1)
- Compose R1's acceptance reply
- Follow-up decisions filed:
  - `IDocxTextExtractor` → `ITextExtractor` (Redis ETag cache) migration deferred to Compose R2
  - compose-summarize → Linear library candidate deferred to Compose R2

## SSE trace instrumentation

**Server-side** (`ComposeEndpoints.DispatchAction`):
- Wall-clock stopwatch from post-JWT validation
- Stage-by-stage `[T+{ms}ms]` INFO logs at each transition (SSE headers → playbook resolved → LoadDocxAsync returned → text extraction complete → InvokePlaybookAsync returned → pipeline complete)
- Every log includes `clientAborted={ct.IsCancellationRequested}` for correlating server state with client-side "network error" reports
- NEW catch branch: `OperationCanceledException when ct.IsCancellationRequested` logs "CLIENT DISCONNECTED mid-stream"

**Client-side** (`executeComposeSummarize.ts`):
- `performance.now()` anchor + `traceLog()` helper (`console.debug` prefix `[compose-summarize-sse] t+{ms}ms`)
- Traces: start (with input flags), fetch returned (with status + content-type + hasBody), each raw byte read (with running byte count), each SSE frame text (truncated), all loop exit paths (with counters), all error paths (with error name + counters)

Together the two sides produce a paired trace on the next smoke click. Discrepancies pinpoint whether the failure is server exception, middleware idle timeout, or client stream-state bug.

## Verification

- BFF `dotnet build`: 0 errors / 19 pre-existing warnings
- `@spaarke/compose-components` tsc: clean
- No test regressions
- No BFF publish-size concern (Stopwatch already imported; logging is compile-out-free)

## Deploy plan (post-merge)

1. Rebuild + redeploy BFF (`Deploy-BffApi.ps1`) — picks up server-side tracing
2. Rebuild + redeploy SpaarkeAi code page (`Deploy-SpaarkeAi.ps1`) — picks up client-side tracing + hotfixes 1+2
3. User re-smokes with browser DevTools console open (filter `compose-summarize-sse`); server logs pulled via `az webapp log tail`

## Notes for reviewers

- `console.debug` on client — normal user sessions unaffected unless verbose filter enabled
- Server-side INFO logs — always emit; volume is bounded (~7 log lines per compose-summarize invocation)
- No deploy risk from tracing (it's diagnostic-only; no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)