### PR TITLE
fix(compose): buffer Graph download stream to fix NotSupportedException

### DIFF
--- a/src/server/api/Sprk.Bff.Api/Services/Ai/LinearConsumers/DocumentProfileService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/LinearConsumers/DocumentProfileService.cs
@@ -334,51 +334,51 @@ public sealed class DocumentProfileService
                     continue;
 
                 case JsonValueKind.String:
-                {
-                    var stringValue = prop.Value.GetString();
-                    if (string.IsNullOrWhiteSpace(stringValue)) continue;
-
-                    if (name.Equals("sprk_documenttype", StringComparison.OrdinalIgnoreCase))
                     {
-                        var optionValue = DocumentTypeMapper.ToDataverseValue(stringValue);
-                        if (optionValue.HasValue)
+                        var stringValue = prop.Value.GetString();
+                        if (string.IsNullOrWhiteSpace(stringValue)) continue;
+
+                        if (name.Equals("sprk_documenttype", StringComparison.OrdinalIgnoreCase))
                         {
-                            // Dataverse SDK Choice/OptionSet attributes require OptionSetValue,
-                            // not a raw int. R5 Doc 06 Choice-field coercion pattern.
-                            fields[name] = new OptionSetValue(optionValue.Value);
-                            stringOutputs[name] = stringValue;
+                            var optionValue = DocumentTypeMapper.ToDataverseValue(stringValue);
+                            if (optionValue.HasValue)
+                            {
+                                // Dataverse SDK Choice/OptionSet attributes require OptionSetValue,
+                                // not a raw int. R5 Doc 06 Choice-field coercion pattern.
+                                fields[name] = new OptionSetValue(optionValue.Value);
+                                stringOutputs[name] = stringValue;
+                            }
+                            else
+                            {
+                                _logger.LogWarning(
+                                    "Could not coerce documentType='{DocType}' to a Dataverse Choice value; dropping the field",
+                                    stringValue);
+                            }
                         }
                         else
                         {
-                            _logger.LogWarning(
-                                "Could not coerce documentType='{DocType}' to a Dataverse Choice value; dropping the field",
-                                stringValue);
+                            fields[name] = stringValue;
+                            stringOutputs[name] = stringValue;
                         }
+                        break;
                     }
-                    else
-                    {
-                        fields[name] = stringValue;
-                        stringOutputs[name] = stringValue;
-                    }
-                    break;
-                }
 
                 case JsonValueKind.Array:
                 case JsonValueKind.Object:
-                {
-                    var jsonBlob = prop.Value.GetRawText();
-                    fields[name] = jsonBlob;
-                    stringOutputs[name] = jsonBlob;
-                    break;
-                }
+                    {
+                        var jsonBlob = prop.Value.GetRawText();
+                        fields[name] = jsonBlob;
+                        stringOutputs[name] = jsonBlob;
+                        break;
+                    }
 
                 default:
-                {
-                    var raw = prop.Value.GetRawText();
-                    fields[name] = raw;
-                    stringOutputs[name] = raw;
-                    break;
-                }
+                    {
+                        var raw = prop.Value.GetRawText();
+                        fields[name] = raw;
+                        stringOutputs[name] = raw;
+                        break;
+                    }
             }
         }
 

--- a/src/server/api/Sprk.Bff.Api/Services/Compose/ComposeDocumentService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Compose/ComposeDocumentService.cs
@@ -83,10 +83,10 @@ public sealed class ComposeDocumentService : IComposeDocumentService
             }
 
             // Then stream content. SPE returns null for missing content; we surface that as NotFound.
-            var stream = await graphClient.Drives[driveId].Items[itemId].Content
+            var graphStream = await graphClient.Drives[driveId].Items[itemId].Content
                 .GetAsync(cancellationToken: ct);
 
-            if (stream == null)
+            if (graphStream == null)
             {
                 _logger.LogWarning(
                     "Compose load: drive-item {DriveId}/{ItemId} metadata exists but content stream is null",
@@ -94,13 +94,23 @@ public sealed class ComposeDocumentService : IComposeDocumentService
                 return ComposeLoadResult.NotFound;
             }
 
+            // Buffer to a seekable MemoryStream. Graph returns a non-seekable HttpBaseStream
+            // whose Length/Position throw NotSupportedException; DocumentFormat.OpenXml
+            // (used downstream for text extract) also requires a seekable stream.
+            var buffered = new MemoryStream(capacity: (int)Math.Min(item.Size ?? 0, int.MaxValue));
+            await using (graphStream.ConfigureAwait(false))
+            {
+                await graphStream.CopyToAsync(buffered, ct).ConfigureAwait(false);
+            }
+            buffered.Position = 0;
+
             _logger.LogInformation(
-                "Compose load DOCX succeeded for {DriveId}/{ItemId}, size={Size}",
-                driveId, itemId, item.Size);
+                "Compose load DOCX succeeded for {DriveId}/{ItemId}, size={Size} bufferedBytes={BufferedBytes}",
+                driveId, itemId, item.Size, buffered.Length);
 
             return new ComposeLoadResult(
                 Found: true,
-                Content: stream,
+                Content: buffered,
                 FileName: item.Name,
                 ETag: item.ETag,
                 Size: item.Size);


### PR DESCRIPTION
## Summary

Fixes `NotSupportedException: Specified method is not supported` in Compose summarize pipeline (observed in smoke test 2026-07-02 17:55Z after PR #540 merged R7 + Compose R1 to master and both surfaces were deployed).

## Root cause

`ComposeDocumentService.LoadDocxAsync` returned the raw stream from `graphClient.Drives[..].Items[..].Content.GetAsync()` — a non-seekable `System.Net.Http.HttpBaseStream`. Downstream code then failed:

1. **Log call at ComposeEndpoints.cs:724** — `loadResult.Value.Content?.Length ?? 0` → `HttpBaseStream.get_Length()` throws
2. **DOCX text extract** — `DocumentFormat.OpenXml.WordprocessingDocument.Open()` requires a seekable stream

Server stack trace:
```
System.NotSupportedException: Specified method is not supported.
   at System.Net.Http.HttpBaseStream.get_Length()
   at ComposeEndpoints.DispatchAction() ComposeEndpoints.cs:line 719
```

Client SSE trace confirmed: `progress` event `document_loaded` arrived, then error frame ~600ms later.

## Fix

In `ComposeDocumentService.LoadDocxAsync`, copy the Graph download stream into a `MemoryStream` before returning. Sized with `item.Size` where available. Original Graph stream disposed inside `await using`. Buffered stream position reset to 0.

## Verification

- Local build: `dotnet build src/server/api/Sprk.Bff.Api/` → **0 errors, 19 warnings** (all pre-existing)
- Post-merge deploy + re-smoke to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)