### PR TITLE
test(ai-redesign-r1): follow-up — fix CrossPillarIntegrationTests ctor drift (master CI red)

### DIFF
--- a/projects/spaarke-ai-architecture-redesign-r1/notes/track-b-completion-audit.md
+++ b/projects/spaarke-ai-architecture-redesign-r1/notes/track-b-completion-audit.md
@@ -188,3 +188,7 @@ Small, itemized; none block G-P4 (the gate criterion is code estate + explained 
 ## 12. ADR-038 test register (for task-090 /test-diet)
 
 Deleted this task, all SCAFFOLDING-class (tests of deleted dead surface): `AiPlaybookBuilderServiceTests.cs`, `Builder/ConfigurePromptSchemaTests.cs`, `ClarificationFlowTests.cs`, `ExecutorConfigSchemasEndpointTests.cs`, `EntityResolutionServiceTests.cs`, `Chat/SessionCleanupSecurityTests.cs`, `Infrastructure/Streaming/ServerSentEventWriterTests.cs`, `Models/Ai/BuilderSseEventsTests.cs`, `Models/Ai/AnalysisChunkFieldDeltaTests.cs`. Edited fixtures (mock-DI line removal only): 5 `Spe.Integration.Tests` files.
+
+## 13. Post-close correction (2026-07-08, task 090 post-merge smoke)
+
+The §4 disposition "TL-004/006/008/010 → Inactive" was **reverted**: the ADR-039 boot reconciliation (`/healthz/catalog`) went Unhealthy on the deployed master build — those four rows' handler classes (`DocumentClassifierHandler`, `SummaryHandler`, `SemanticSearchHandler`, `GenericAnalysisHandler`) are still REGISTERED in code, and a registered handler without an active `sprk_analysistool` row is drift class "registered handler without tool row". All four rows re-activated 2026-07-08 ~05:30Z; health verified `Healthy`. The correct retirement is COORDINATED code+row (delete the handler registrations in the same change that deactivates the rows) — exactly the O-2 pattern. Filed as an addition to the O-register: **O-6 — TL-004/006/008/010 coordinated handler+row retirement (r2)**; tracked on issue #557.

--- a/src/client/pcf/MatterHeader/control/MatterHeaderView.tsx
+++ b/src/client/pcf/MatterHeader/control/MatterHeaderView.tsx
@@ -176,19 +176,17 @@ export const MatterHeaderView: React.FC<IMatterHeaderViewProps> = ({ recordId, t
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const xrmPage = getXrmPage() as any;
     if (!xrmPage?.getAttribute) {
-       
       console.warn('[MatterHeader] Xrm.Page unavailable — text save skipped', fieldName);
       throw new Error('Form buffer unavailable');
     }
     const attr = xrmPage.getAttribute(fieldName);
     if (!attr) {
-       
       console.warn('[MatterHeader] attribute not on form', fieldName);
       throw new Error(`Field '${fieldName}' not on form`);
     }
     attr.setValue(newValue);
     setPendingText(prev => ({ ...prev, [fieldName]: newValue }));
-     
+
     console.info('[MatterHeader] staged text edit', { field: fieldName, dirty: !!attr.getIsDirty?.() });
   }, []);
 
@@ -220,13 +218,11 @@ export const MatterHeaderView: React.FC<IMatterHeaderViewProps> = ({ recordId, t
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const xrmPage = getXrmPage() as any;
     if (!xrmPage?.getAttribute) {
-       
       console.warn('[MatterHeader] Xrm.Page unavailable — lookup save skipped', key);
       return;
     }
     const attr = xrmPage.getAttribute(key);
     if (!attr) {
-       
       console.warn('[MatterHeader] lookup attribute not on form', key);
       return;
     }
@@ -234,7 +230,7 @@ export const MatterHeaderView: React.FC<IMatterHeaderViewProps> = ({ recordId, t
     const nextValue = item ? [{ id: item.id, name: item.name, entityType: meta.refEntity }] : null;
     attr.setValue(nextValue);
     setPendingLookup(prev => ({ ...prev, [key]: item }));
-     
+
     console.info('[MatterHeader] staged lookup edit', { field: key, item, dirty: !!attr.getIsDirty?.() });
   }, []);
 

--- a/tests/integration/Spe.Integration.Tests/PhaseC/CrossPillarIntegrationTests.cs
+++ b/tests/integration/Spe.Integration.Tests/PhaseC/CrossPillarIntegrationTests.cs
@@ -53,6 +53,7 @@
 
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Sprk.Bff.Api.Models.Workspace;
@@ -71,6 +72,30 @@ public sealed class CrossPillarIntegrationTests
     private const string TenantId = "tenant-cross-pillar";
     private static readonly DateTimeOffset DeterministicNow =
         new(2026, 6, 18, 12, 0, 0, TimeSpan.Zero);
+
+    // Ctor gained WorkspaceLayoutService + IDataverseUserClient during redesign-r1 P3
+    // (Workspace layout variant + R4-2 Compose pre-seed). These tests exercise the four
+    // artifact variants only, so both collaborators are inert: the layout service sees
+    // an empty Dataverse layout query (system layouts still resolve) and the user client
+    // is never invoked (no widgetData.documentId in any scenario here).
+    private static SendWorkspaceArtifactHandler CreateSendHandler(
+        IWorkspaceStateService workspaceStateService,
+        IGuidProvider guidProvider,
+        TimeProvider timeProvider)
+    {
+        var entityService = new Mock<Spaarke.Dataverse.IGenericEntityService>();
+        entityService
+            .Setup(s => s.RetrieveMultipleAsync(
+                It.IsAny<Microsoft.Xrm.Sdk.Query.QueryExpression>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Microsoft.Xrm.Sdk.EntityCollection());
+        return new SendWorkspaceArtifactHandler(
+            workspaceStateService,
+            guidProvider,
+            timeProvider,
+            new WorkspaceLayoutService(entityService.Object, NullLogger<WorkspaceLayoutService>.Instance),
+            new Mock<Sprk.Bff.Api.Services.Ai.Handlers.Dataverse.IDataverseUserClient>().Object,
+            NullLogger<SendWorkspaceArtifactHandler>.Instance);
+    }
 
     // ════════════════════════════════════════════════════════════════════════════════
     // TEST 1 — Pillar 6b → Pillar 6a → Pillar 9
@@ -96,11 +121,10 @@ public sealed class CrossPillarIntegrationTests
         var sessionId = sessionGuid.ToString("N");
         var matterGuid = new Guid("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
 
-        var sendHandler = new SendWorkspaceArtifactHandler(
-            workspaceStateService: sharedState,
-            guidProvider: new FixedGuidProvider(new Guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")),
-            timeProvider: new FixedTimeProvider(DeterministicNow),
-            logger: NullLogger<SendWorkspaceArtifactHandler>.Instance);
+        var sendHandler = CreateSendHandler(
+            sharedState,
+            new FixedGuidProvider(new Guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")),
+            new FixedTimeProvider(DeterministicNow));
 
         var factory = CreatePromptFactory();
 
@@ -183,11 +207,10 @@ public sealed class CrossPillarIntegrationTests
         var sessionId = sessionGuid.ToString("N");
         var tabGuid = new Guid("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 
-        var sendHandler = new SendWorkspaceArtifactHandler(
+        var sendHandler = CreateSendHandler(
             sharedState,
             new FixedGuidProvider(tabGuid),
-            new FixedTimeProvider(DeterministicNow),
-            NullLogger<SendWorkspaceArtifactHandler>.Instance);
+            new FixedTimeProvider(DeterministicNow));
 
         var updateHandler = new UpdateWorkspaceTabHandler(
             sharedState,
@@ -414,11 +437,10 @@ public sealed class CrossPillarIntegrationTests
             return new Guid($"cccccccc-cccc-cccc-cccc-cccccccccc{guidCounter:D2}");
         });
 
-        var sendHandler = new SendWorkspaceArtifactHandler(
+        var sendHandler = CreateSendHandler(
             sharedState,
             guidProvider,
-            new FixedTimeProvider(DeterministicNow),
-            NullLogger<SendWorkspaceArtifactHandler>.Instance);
+            new FixedTimeProvider(DeterministicNow));
 
         // Distinct matter GUIDs per variant so matterName flows through.
         var matterSummary = new Guid("11111111-1111-1111-1111-111111111111");

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/KnowledgeDeploymentServiceTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/KnowledgeDeploymentServiceTests.cs
@@ -560,10 +560,17 @@ public class KnowledgeDeploymentConfigTests
         // Arrange & Act
         var config = new KnowledgeDeploymentConfig();
 
-        // Assert
-        config.Model.Should().Be(RagDeploymentModel.Shared);
-        config.IndexName.Should().Be("spaarke-knowledge-index-v2");
-        config.IsActive.Should().BeTrue();
+        // Assert — protective value of these defaults: a tenant with NO
+        // sprk_aiknowledgedeployment row falls through to this record's defaults, so a
+        // drifting default routes Shared-model tenants to the wrong index / wrong model.
+        config.Model.Should().Be(RagDeploymentModel.Shared,
+            "tenants without an explicit deployment row must land on the Shared model");
+        // Canonical shared index per multi-container-multi-index-r1 task 030 (commit
+        // 9180e241b): the record default MUST stay aligned with
+        // AiSearchOptions.KnowledgeIndexName / appsettings.template.json
+        // ("spaarke-files-index") — the previous "spaarke-knowledge-index-v2" no longer exists.
+        config.IndexName.Should().Be("spaarke-files-index");
+        config.IsActive.Should().BeTrue("a default-constructed deployment must not be skipped by routing");
         config.TenantId.Should().BeEmpty();
     }
 

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/Narrators/DailyBriefingCollectorTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/Narrators/DailyBriefingCollectorTests.cs
@@ -9,7 +9,8 @@
 //   - Per-bullet entity-link metadata (RegardingEntityType + RegardingId) populated for
 //     ALL 6 entity types — sprk_event tasks reference sprk_matter; sprk_document references
 //     sprk_matter; sprk_matter / sprk_project self-regard; sprk_todo references sprk_matter
-//   - Membership filter is the EXCLUSIVE ownership gate (no inline FetchXml eq-userid bypass)
+//   - Ownership gate is owner-scoped QueryExpression (owninguser eq user) — resolver bypassed
+//     since 5ca115765 (R7 W12 cutover, DEF-NNN); no inline FetchXml and no unscoped fetch
 //   - Failure-soft per-channel: a single channel exception does not abort the briefing
 //
 // Per CLAUDE.md tests/CLAUDE.md anti-pattern bans:
@@ -234,16 +235,28 @@ public sealed class DailyBriefingCollectorTests
     }
 
     [Fact]
-    public async Task CollectAsync_RoutesMembershipQueriesToResolver_NotInlineFetchXml()
+    public async Task CollectAsync_OwnershipGate_UsesOwnerScopedQueryExpressions_ResolverBypassed()
     {
-        // Arrange — exhaustively cover the 3 entity types the resolver is called for.
-        var resolverMock = NewResolverMock(new Dictionary<string, MembershipResponse>
-        {
-            ["sprk_event"] = MembershipWith("sprk_event", EventId1),
-            ["sprk_matter"] = MembershipWith("sprk_matter", MatterId1),
-            ["sprk_project"] = MembershipWith("sprk_project", ProjectId1),
-        });
-        var entityMock = NewEntityServiceMock(new Dictionary<string, EntityCollection>());
+        // Since commit 5ca115765 (R7 W12 widget cutover, 2026-06-30) the collector BYPASSES
+        // IMembershipResolverService — the resolver returns 0 rows for records owned via the
+        // polymorphic Owner attribute (DEF-NNN) — and resolves candidate sets via direct
+        // owner-scoped QueryExpression queries (owninguser eq systemUserId).
+        //
+        // PROTECTIVE INTENT PRESERVED from the pre-cutover test: the ownership gate MUST be
+        // a structured, per-user-scoped query — never inline FetchXML and never an unscoped
+        // fetch that leaks other users' records into the briefing.
+        //
+        // When the resolver bug is fixed and ResolveMembershipsSafelyAsync is restored, this
+        // test MUST be flipped back to resolver-routing assertions (Times.Once per entity type).
+
+        // Arrange — capture every Dataverse query the collector issues.
+        var resolverMock = new Mock<IMembershipResolverService>(MockBehavior.Strict);
+        var capturedQueries = new List<QueryExpression>();
+        var entityMock = new Mock<IGenericEntityService>(MockBehavior.Strict);
+        entityMock
+            .Setup(s => s.RetrieveMultipleAsync(It.IsAny<QueryExpression>(), It.IsAny<CancellationToken>()))
+            .Callback<QueryExpression, CancellationToken>((q, _) => capturedQueries.Add(q))
+            .ReturnsAsync(new EntityCollection());
 
         var sut = new DailyBriefingCollector(
             entityMock.Object,
@@ -253,17 +266,39 @@ public sealed class DailyBriefingCollectorTests
         // Act
         _ = await sut.CollectAsync(SystemUserId, CancellationToken.None);
 
-        // Assert — resolver was called for the 3 candidate-set entity types (and ONLY those —
-        // sprk_document/sprk_todo are filtered downstream off the resolved sets).
+        // Assert — the resolver is NOT invoked at all on the current (bypassed) path.
         resolverMock.Verify(r => r.ResolveAsync(
-            SystemUserId, "sprk_event", It.IsAny<MembershipResolveOptions?>(), It.IsAny<CancellationToken>()),
-            Times.Once);
-        resolverMock.Verify(r => r.ResolveAsync(
-            SystemUserId, "sprk_matter", It.IsAny<MembershipResolveOptions?>(), It.IsAny<CancellationToken>()),
-            Times.Once);
-        resolverMock.Verify(r => r.ResolveAsync(
-            SystemUserId, "sprk_project", It.IsAny<MembershipResolveOptions?>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<MembershipResolveOptions?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "R7 W12 cutover bypasses IMembershipResolverService until DEF-NNN (polymorphic-Owner) is fixed");
+
+        // Each candidate-set entity type gets exactly ONE owner-scoped QueryExpression:
+        // owninguser eq {systemUserId}. QueryExpression (not a FetchXML string) keeps the
+        // ownership predicate structurally inspectable — the inline-FetchXml eq-userid
+        // bypass the original test guarded against stays banned.
+        foreach (var entityType in new[] { "sprk_event", "sprk_matter", "sprk_project" })
+        {
+            capturedQueries
+                .Where(q => q.EntityName == entityType)
+                .Should().ContainSingle(
+                    $"candidate-set resolution for {entityType} is a single owned-ID query " +
+                    "(channel queries early-return when the candidate set is empty)")
+                .Which.Criteria.Conditions.Should().Contain(c =>
+                    c.AttributeName == "owninguser" &&
+                    c.Operator == ConditionOperator.Equal &&
+                    c.Values.Contains((object)SystemUserId),
+                    "the ownership gate must scope to the acting user's systemuserid");
+        }
+
+        // The per-user to-dos channel also stays owner-scoped (no membership dependency).
+        capturedQueries
+            .Where(q => q.EntityName == "sprk_todo")
+            .Should().ContainSingle()
+            .Which.Criteria.Conditions.Should().Contain(c =>
+                c.AttributeName == "owninguser" &&
+                c.Operator == ConditionOperator.Equal &&
+                c.Values.Contains((object)SystemUserId),
+                "todos are per-user; an unscoped todo query would leak other users' items");
     }
 
     [Fact]

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/PlaybookTemplateContextBuilderTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/PlaybookTemplateContextBuilderTests.cs
@@ -76,14 +76,30 @@ public class PlaybookTemplateContextBuilderTests
     }
 
     [Fact]
-    public void Build_TextOnlyOutput_IsExposedAsString()
+    public void Build_TextOnlyOutput_IsExposedAsWrappedShapeWithLosslessText()
     {
         var runContext = CreateRunContext();
         runContext.StoreNodeOutput(TextOutput("rawText", "Plain narrative output"));
 
         var context = PlaybookTemplateContextBuilder.Build(runContext);
 
-        context["rawText"].Should().Be("Plain narrative output");
+        // Since commit 3789ce43c ("dual-shape node output exposure in Layer 1 template
+        // context", R7 W12) text-only outputs are exposed as the wrapped pre-Wave-11
+        // per-executor shape so canvas-authored playbooks can bind {{node.output}} /
+        // {{node.text}} / {{node.success}} (e.g. Document Profile binds
+        // {{output_aiAnalysis.output.sprk_filesummary}}). Protective intent preserved:
+        // the node's text MUST remain template-reachable and lossless via BOTH
+        // {{rawText.text}} and {{rawText.output}}, and the success flag must be honest.
+        var wrapped = context["rawText"].Should()
+            .BeAssignableTo<IDictionary<string, object?>>(
+                "text-only outputs surface as the wrapped {output, text, success} shape")
+            .Subject;
+        wrapped["text"].Should().Be("Plain narrative output",
+            "{{rawText.text}} is the canonical text binding for text-only node outputs");
+        wrapped["output"].Should().Be("Plain narrative output",
+            "{{rawText.output}} mirrors the text so wrapped-shape playbook bindings resolve");
+        wrapped["success"].Should().Be(true,
+            "a successful text-only node must expose success=true to gate-style templates");
     }
 
     [Fact]

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/SessionFilesCleanupJobTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/SessionFilesCleanupJobTests.cs
@@ -391,8 +391,16 @@ public class SessionFilesCleanupJobTests
     {
         // Arrange:
         //   Indexed sessions in spaarke-session-files: (TenantA, SessionId1), (TenantA, SessionId2)
-        //   Active Redis keys: only chat:session:TenantA:SessionId1 exists
+        //   Active Redis keys: only (TenantA, SessionId1) exists
         //   → orphan: (TenantA, SessionId2) — should be evicted
+        //
+        // Key format is owned by ChatSessionManager.BuildCacheKey (centralised as
+        // tenant:{tenantId}:session:{sessionId}:v1 by spaarke-redis-cache-remediation-r1
+        // FR-05, commit 8b2cdb676). The test uses the helper rather than a hardcoded
+        // literal so the liveness probe and the writer can never drift apart in the mock —
+        // a mismatch here previously made BOTH sessions look orphaned (2 deletes).
+        var activeSessionKey = (RedisKey)ChatSessionManager.BuildCacheKey(TenantA, SessionId1);
+        var orphanSessionKey = (RedisKey)ChatSessionManager.BuildCacheKey(TenantA, SessionId2);
         var indexedDocs = new List<SearchResult<SessionFilesCleanupRef>>
         {
             SearchModelFactory.SearchResult(
@@ -416,12 +424,12 @@ public class SessionFilesCleanupJobTests
         // Redis: only SessionId1 exists for TenantA
         _redisDatabaseMock
             .Setup(d => d.KeyExistsAsync(
-                It.Is<RedisKey>(k => k == (RedisKey)$"chat:session:{TenantA}:{SessionId1}"),
+                It.Is<RedisKey>(k => k == activeSessionKey),
                 It.IsAny<CommandFlags>()))
             .ReturnsAsync(true);
         _redisDatabaseMock
             .Setup(d => d.KeyExistsAsync(
-                It.Is<RedisKey>(k => k == (RedisKey)$"chat:session:{TenantA}:{SessionId2}"),
+                It.Is<RedisKey>(k => k == orphanSessionKey),
                 It.IsAny<CommandFlags>()))
             .ReturnsAsync(false);
 
@@ -445,13 +453,14 @@ public class SessionFilesCleanupJobTests
             "exactly one orphan session is evicted by the scheduled scan");
 
         // Active SessionId1 is NOT evicted — the absence of a second delete call confirms isolation.
-        // Active sessions are checked via Redis KeyExistsAsync; verify both keys were checked.
+        // Active sessions are checked via Redis KeyExistsAsync; verify both keys were checked
+        // using the SAME key builder the writer (ChatSessionManager) uses.
         _redisDatabaseMock.Verify(d => d.KeyExistsAsync(
-            It.Is<RedisKey>(k => k == (RedisKey)$"chat:session:{TenantA}:{SessionId1}"),
+            It.Is<RedisKey>(k => k == activeSessionKey),
             It.IsAny<CommandFlags>()),
             Times.Once);
         _redisDatabaseMock.Verify(d => d.KeyExistsAsync(
-            It.Is<RedisKey>(k => k == (RedisKey)$"chat:session:{TenantA}:{SessionId2}"),
+            It.Is<RedisKey>(k => k == orphanSessionKey),
             It.IsAny<CommandFlags>()),
             Times.Once);
     }

--- a/tests/unit/Sprk.Bff.Api.Tests/Sprk.Bff.Api.Tests.csproj
+++ b/tests/unit/Sprk.Bff.Api.Tests/Sprk.Bff.Api.Tests.csproj
@@ -33,6 +33,8 @@
     <!-- Security: Override vulnerable transitive dependencies -->
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0" />
+    <!-- GHSA-24c8-4792-22hx (HIGH) + GHSA-q6rr-fm2g-g5x8 / GHSA-6q7j-xr26-3h2c (Moderate, DoS): WireMock.Net 1.5.45 pins Scriban.Signed 5.5.0; all patched in 7.2.1. Test-only assembly; WireMock response templating unaffected in our fixtures. -->
+    <PackageReference Include="Scriban.Signed" Version="7.2.1" />
 
     <!-- Exclude MimeKitLite to avoid conflict with MimeKit -->
     <PackageReference Include="MimeKitLite" Version="4.15.1">


### PR DESCRIPTION
Follow-up to #551 (merged 2026-07-08 04:57Z before this fix landed on the branch).

## What
Master's post-merge CI Tier-1 **Changed-Surface Integration Smoke** fails to compile: `CrossPillarIntegrationTests.cs` constructs `SendWorkspaceArtifactHandler` with its pre-P3 four-argument signature. The handler gained `WorkspaceLayoutService` + `IDataverseUserClient` during redesign-r1 P3 (Workspace layout variant + R4-2 Compose pre-seed); the integration project wasn't compiled by the project's local unit-suite runs.

## Fix
Factory helper mirroring the unit-test fixture (`SendWorkspaceArtifactHandlerTests`): empty Dataverse layout query (system layouts still resolve), inert user client (no scenario here passes `widgetData.documentId`). All 6 CrossPillar tests green locally.

Also carries the CI bot's Prettier auto-format commit from the #551 branch.

## Not addressed (pre-existing, separate owner)
**Deploy SpaarkeAi** has been failing on master since 2026-07-05 — Rollup cannot resolve `@tiptap/react` from `Spaarke.Compose.Components/ComposeEditor.tsx` (compose-r1 surface; deps exist in that lib's package.json but the SpaarkeAi CI install doesn't cover it). Flagged to operator; belongs to the Compose project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)