### PR TITLE
fix(chat): session-cleanup Redis probe missing InstanceName prefix — live sessions' files evictable when Redis enabled (#559)

### DIFF
--- a/src/server/api/Sprk.Bff.Api/Services/Ai/Chat/SessionFilesCleanupJob.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Ai/Chat/SessionFilesCleanupJob.cs
@@ -20,7 +20,8 @@ namespace Sprk.Bff.Api.Services.Ai.Chat;
 ///   <see cref="SessionFilesCleanupOptions.IntervalHours"/> (default 6h).
 ///   The scheduled pass enumerates indexed session IDs (via facet query),
 ///   joins against the active Redis session-key set
-///   (<c>chat:session:{tenantId}:{sessionId}</c>), and evicts every
+///   (<c>{InstanceName}tenant:{tenantId}:session:{sessionId}:v1</c> — see
+///   <see cref="BuildProbeKey"/>), and evicts every
 ///   <c>sessionId</c> NOT present in the active set.</item>
 ///   <item><b>On-session-end (immediate)</b> — a
 ///   <see cref="System.Threading.Channels.Channel{T}"/> owned by
@@ -76,6 +77,7 @@ public sealed class SessionFilesCleanupJob : BackgroundService
     private readonly IServiceProvider _serviceProvider;
     private readonly SessionFilesCleanupOptions _options;
     private readonly SessionFilesCleanupSignal _signal;
+    private readonly string _redisInstancePrefix;
     private readonly ILogger<SessionFilesCleanupJob> _logger;
 
     /// <summary>
@@ -100,11 +102,18 @@ public sealed class SessionFilesCleanupJob : BackgroundService
     public SessionFilesCleanupJob(
         IServiceProvider serviceProvider,
         IOptions<SessionFilesCleanupOptions> options,
+        IOptions<Configuration.RedisOptions> redisOptions,
         SessionFilesCleanupSignal signal,
         ILogger<SessionFilesCleanupJob> logger)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        // Sessions are WRITTEN via ITenantCache → StackExchangeRedisCache, which
+        // prepends RedisOptions.InstanceName to every key ON THE WIRE. The active-set
+        // probe below reads raw Redis (IConnectionMultiplexer), so it must apply the
+        // same prefix or every live session looks orphaned and gets its files evicted
+        // (issue #559).
+        _redisInstancePrefix = redisOptions?.Value?.InstanceName ?? string.Empty;
         _signal = signal ?? throw new ArgumentNullException(nameof(signal));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -205,7 +214,7 @@ public sealed class SessionFilesCleanupJob : BackgroundService
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Active-session source-of-truth: Redis <c>chat:session:{tenantId}:{sessionId}</c>
+    /// Active-session source-of-truth: Redis <c>{InstanceName}tenant:{tenantId}:session:{sessionId}:v1</c>
     /// key pattern (set by <see cref="ChatSessionManager.CreateSessionAsync"/>;
     /// removed by <see cref="ChatSessionManager.DeleteSessionAsync"/> or
     /// 24h sliding-TTL expiry). The scheduled pass catches the implicit
@@ -521,7 +530,9 @@ public sealed class SessionFilesCleanupJob : BackgroundService
 
     /// <summary>
     /// For a tenant, returns the subset of <paramref name="candidateSessionIds"/>
-    /// whose Redis keys (<c>chat:session:{tenantId}:{sessionId}</c>) still exist.
+    /// whose Redis keys (<c>{InstanceName}tenant:{tenantId}:session:{sessionId}:v1</c> —
+    /// <see cref="ChatSessionManager.BuildCacheKey"/> with the
+    /// <c>StackExchangeRedisCache</c> instance prefix applied) still exist.
     /// Uses <see cref="IDatabase.KeyExistsAsync(RedisKey, CommandFlags)"/>
     /// per session — bounded per-tenant scan, no Redis SCAN pattern needed.
     /// </summary>
@@ -550,7 +561,7 @@ public sealed class SessionFilesCleanupJob : BackgroundService
                 break;
             }
 
-            var redisKey = ChatSessionManager.BuildCacheKey(tenantId, sessionId);
+            var redisKey = BuildProbeKey(tenantId, sessionId);
             var exists = await db.KeyExistsAsync(redisKey);
             if (exists)
             {
@@ -561,6 +572,15 @@ public sealed class SessionFilesCleanupJob : BackgroundService
 
         return active;
     }
+
+    /// <summary>
+    /// The exact on-wire Redis key for a session: <see cref="ChatSessionManager.BuildCacheKey"/>
+    /// prefixed with the configured <c>RedisOptions.InstanceName</c> — the same simple
+    /// concatenation <c>StackExchangeRedisCache</c> performs when the session is written.
+    /// Internal so tests pin the convention (issue #559 regression).
+    /// </summary>
+    internal string BuildProbeKey(string tenantId, string sessionId) =>
+        _redisInstancePrefix + ChatSessionManager.BuildCacheKey(tenantId, sessionId);
 
     /// <summary>
     /// Escapes a string for use in an OData filter expression (single-quote doubling).

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/SessionFilesCleanupJobTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Ai/SessionFilesCleanupJobTests.cs
@@ -76,10 +76,20 @@ public class SessionFilesCleanupJobTests
     // Factory
     // -------------------------------------------------------------------------
 
+    /// <summary>
+    /// Non-empty instance prefix so tests exercise the on-wire key shape
+    /// StackExchangeRedisCache actually writes (issue #559 regression).
+    /// </summary>
+    private const string RedisInstancePrefix = "spaarke:";
+
+    private static readonly IOptions<Sprk.Bff.Api.Configuration.RedisOptions> RedisOptionsValue =
+        Options.Create(new Sprk.Bff.Api.Configuration.RedisOptions { InstanceName = RedisInstancePrefix });
+
     private SessionFilesCleanupJob CreateJob(IServiceProvider services) =>
         new SessionFilesCleanupJob(
             services,
             _options,
+            RedisOptionsValue,
             _signal,
             _loggerMock.Object);
 
@@ -396,11 +406,13 @@ public class SessionFilesCleanupJobTests
         //
         // Key format is owned by ChatSessionManager.BuildCacheKey (centralised as
         // tenant:{tenantId}:session:{sessionId}:v1 by spaarke-redis-cache-remediation-r1
-        // FR-05, commit 8b2cdb676). The test uses the helper rather than a hardcoded
-        // literal so the liveness probe and the writer can never drift apart in the mock —
-        // a mismatch here previously made BOTH sessions look orphaned (2 deletes).
-        var activeSessionKey = (RedisKey)ChatSessionManager.BuildCacheKey(TenantA, SessionId1);
-        var orphanSessionKey = (RedisKey)ChatSessionManager.BuildCacheKey(TenantA, SessionId2);
+        // FR-05, commit 8b2cdb676) PLUS the StackExchangeRedisCache InstanceName prefix
+        // the writer applies on the wire (issue #559). The test derives keys from the
+        // job's own BuildProbeKey so probe and writer conventions can never drift apart
+        // in the mock — an unprefixed probe previously made BOTH sessions look orphaned.
+        var probeKeyJob = CreateJob(BuildScopedServices());
+        var activeSessionKey = (RedisKey)probeKeyJob.BuildProbeKey(TenantA, SessionId1);
+        var orphanSessionKey = (RedisKey)probeKeyJob.BuildProbeKey(TenantA, SessionId2);
         var indexedDocs = new List<SearchResult<SessionFilesCleanupRef>>
         {
             SearchModelFactory.SearchResult(
@@ -463,6 +475,28 @@ public class SessionFilesCleanupJobTests
             It.Is<RedisKey>(k => k == orphanSessionKey),
             It.IsAny<CommandFlags>()),
             Times.Once);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 6b: probe key convention (issue #559 regression)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void BuildProbeKey_PrependsRedisInstanceName_ToWriterCacheKey()
+    {
+        // The writer path is ITenantCache → StackExchangeRedisCache, which prepends
+        // RedisOptions.InstanceName to ChatSessionManager.BuildCacheKey on the wire.
+        // The raw-Redis liveness probe MUST produce that exact on-wire key — an
+        // unprefixed probe classifies every LIVE session as an orphan and evicts its
+        // files (issue #559).
+        var job = CreateJob(BuildScopedServices());
+
+        var probeKey = job.BuildProbeKey(TenantA, SessionId1);
+
+        probeKey.Should().Be(
+            RedisInstancePrefix + ChatSessionManager.BuildCacheKey(TenantA, SessionId1),
+            "the probe must read the same on-wire key StackExchangeRedisCache writes (InstanceName + cache key)");
+        probeKey.Should().StartWith(RedisInstancePrefix);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #559 (data-loss class, found during redesign-r1 close-out test adjudication).

## Bug
`SessionFilesCleanupJob.GetActiveSessionsForTenantAsync` probes raw Redis with the un-prefixed `ChatSessionManager.BuildCacheKey`, but sessions are WRITTEN via `ITenantCache` → `StackExchangeRedisCache`, which prepends `RedisOptions.InstanceName` (`spaarke:` default) on the wire. With Redis enabled, `KeyExistsAsync` returns false for every LIVE session → the scheduled orphan scan evicts live sessions' indexed files.

Not currently reachable in dev (Redis cutover Phase 3/4 deferred per redis-remediation-r1), but a time bomb for the cutover.

## Fix
- `BuildProbeKey` (internal) = `InstanceName + BuildCacheKey` — the exact concatenation StackExchangeRedisCache performs; probe uses it
- Ctor takes `IOptions<RedisOptions>` (already bound by `CacheModule`); DI-resolved, no registration change
- Stale pre-FR-05 `chat:session:` doc comments corrected
- Test fixture now uses a non-empty prefix so mocks exercise the real on-wire key shape; new regression test pins the convention

## Verification
- `SessionFilesCleanupJobTests` 9/9 green (incl. new `BuildProbeKey_PrependsRedisInstanceName_ToWriterCacheKey`)
- BFF build 0 errors

## Hot-path declaration
BFF Y (one service, no endpoints/packages/DI-shape changes) · SpaarkeAi N · ci-workflows N · skill-directives N · root-CLAUDE N

Related: spaarke-redis-cache-remediation-r1 FR-05 (`8b2cdb676`) · found during #551/#558 close-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)