### PR TITLE
fix(shared): restore Spaarke.DailyBriefing.Components standalone build + re-arm CI gate (supersedes #506)

### DIFF
--- a/scripts/Build-AllClientComponents.ps1
+++ b/scripts/Build-AllClientComponents.ps1
@@ -63,11 +63,12 @@ $RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
 
 # Shared libraries (build order matters — downstream deps must come after their dependencies)
 #
-# Spaarke.DailyBriefing.Components is intentionally EXCLUDED from this list. Its build script is
-# `tsc --noEmit` and its `@spaarke/*` deps are listed as peerDependencies (not regular deps),
-# so it cannot type-check standalone — the type-check is performed by each consumer's tsc pass
-# (SpaarkeAi, DailyBriefing). Tried adding it 2026-06-28 → orchestrator failed on TS2307
-# "Cannot find module '@spaarke/ui-components'" etc. Excluded by design.
+# Spaarke.DailyBriefing.Components is now INCLUDED (standalone build restored 2026-07-08 by
+# spaarke-daily-update-service-r5, superseding PR #506). Its `@spaarke/*` deps are declared as
+# `file:` dependencies + tsconfig `paths` (mirroring Spaarke.AI.Widgets), so `tsc --noEmit`
+# type-checks standalone. Re-added to the gate so future standalone breaks are caught in CI
+# rather than silently shipped (the 2026-06-28 TS2307 failure was the peer-only-deps root cause,
+# now fixed in the lib's package.json/tsconfig.json).
 #
 # Spaarke.LegalWorkspace is intentionally EXCLUDED on the same basis (added 2026-07-02 by
 # spaarke-dataset-grid-framework-r2 task 024 / FR-10). Task 020 scaffolded the package; task 021
@@ -85,6 +86,7 @@ $SharedLibs = @(
     @{ Name = "Spaarke.SmartTodo.Components"; Path = "$RepoRoot\src\client\shared\Spaarke.SmartTodo.Components" }
     @{ Name = "Spaarke.UI.Components";        Path = "$RepoRoot\src\client\shared\Spaarke.UI.Components" }        # depends on Auth, SdapClient
     @{ Name = "Spaarke.AI.Widgets";           Path = "$RepoRoot\src\client\shared\Spaarke.AI.Widgets" }           # depends on UI.Components, AI.Outputs
+    @{ Name = "Spaarke.DailyBriefing.Components"; Path = "$RepoRoot\src\client\shared\Spaarke.DailyBriefing.Components" } # depends on Auth + UI.Components; standalone build restored 2026-07-08 (supersedes PR #506)
     @{ Name = "Spaarke.Compose.Components";   Path = "$RepoRoot\src\client\shared\Spaarke.Compose.Components" }   # depends on Auth + DocumentOperations + AI.Widgets (PaneEventBus); MUST build AFTER AI.Widgets — re-ordered 2026-06-29 by spaarkeai-compose-r1 task 045 W4 when AI.Widgets dep was added
 )
 

--- a/src/client/shared/Spaarke.DailyBriefing.Components/package-lock.json
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "@spaarke/daily-briefing-components",
       "version": "0.1.0",
+      "dependencies": {
+        "@spaarke/auth": "file:../Spaarke.Auth",
+        "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+      },
       "devDependencies": {
         "@fluentui/react-components": "^9.46.2",
         "@fluentui/react-icons": "^2.0.200",
@@ -28,8 +32,102 @@
         "@fluentui/react-components": "^9.0.0",
         "@fluentui/react-icons": "^2.0.0",
         "@spaarke/auth": "^2.0.0",
+        "@spaarke/ui-components": "*",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "../Spaarke.Auth": {
+      "name": "@spaarke/auth",
+      "version": "2.0.0",
+      "license": "UNLICENSED",
+      "devDependencies": {
+        "@azure/msal-browser": "^3.27.0",
+        "@types/jest": "^30.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^8.57.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "ts-jest": "^29.4.4",
+        "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.0.0"
+      }
+    },
+    "../Spaarke.UI.Components": {
+      "name": "@spaarke/ui-components",
+      "version": "2.3.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@microsoft/applicationinsights-web": "^3.3.0",
+        "@spaarke/sdap-client": "file:../Spaarke.SdapClient",
+        "d3-force": "^3.0.0",
+        "diff": "^8.0.3",
+        "dompurify": "^3.4.0",
+        "mammoth": "^1.12.0",
+        "marked": "^17.0.4",
+        "pdfjs-dist": "^5.7.284",
+        "react-window": "^1.8.11"
+      },
+      "devDependencies": {
+        "@fluentui/react-components": "^9.73.2",
+        "@fluentui/react-icons": "^2.0.320",
+        "@hello-pangea/dnd": "^18.0.1",
+        "@lexical/html": "^0.41.0",
+        "@lexical/list": "^0.41.0",
+        "@lexical/react": "^0.41.0",
+        "@lexical/rich-text": "^0.41.0",
+        "@lexical/selection": "^0.41.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/d3-force": "^3.0.10",
+        "@types/diff": "^7.0.0",
+        "@types/dompurify": "^3.0.5",
+        "@types/jest": "^30.0.0",
+        "@types/powerapps-component-framework": "^1.3.4",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@types/react-window": "^1.8.8",
+        "eslint": "^9.17.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react-hooks": "^5.0.0",
+        "globals": "^15.14.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "lexical": "^0.41.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "ts-jest": "^29.4.4",
+        "typescript": "^5.3.3",
+        "typescript-eslint": "^8.20.0"
+      },
+      "peerDependencies": {
+        "@fluentui/react-button": "^9.6.7",
+        "@fluentui/react-dialog": "^9.15.3",
+        "@fluentui/react-icons": "^2.0.311",
+        "@fluentui/react-input": "^9.6.6",
+        "@fluentui/react-label": "^9.3.6",
+        "@fluentui/react-message-bar": "^9.6.8",
+        "@fluentui/react-progress": "^9.4.6",
+        "@fluentui/react-provider": "^9.22.6",
+        "@fluentui/react-spinner": "^9.7.6",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.6",
+        "@hello-pangea/dnd": "^17.0.0 || ^18.0.0",
+        "@lexical/html": "^0.17.0",
+        "@lexical/list": "^0.17.0",
+        "@lexical/react": "^0.17.0",
+        "@lexical/rich-text": "^0.17.0",
+        "@lexical/selection": "^0.17.0",
+        "lexical": "^0.17.0",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2957,6 +3055,14 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@spaarke/auth": {
+      "resolved": "../Spaarke.Auth",
+      "link": true
+    },
+    "node_modules/@spaarke/ui-components": {
+      "resolved": "../Spaarke.UI.Components",
+      "link": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",

--- a/src/client/shared/Spaarke.DailyBriefing.Components/package.json
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/package.json
@@ -23,10 +23,15 @@
     "test:coverage": "jest --coverage",
     "test:ci": "jest --ci --coverage --maxWorkers=2"
   },
+  "dependencies": {
+    "@spaarke/auth": "file:../Spaarke.Auth",
+    "@spaarke/ui-components": "file:../Spaarke.UI.Components"
+  },
   "peerDependencies": {
     "@fluentui/react-components": "^9.0.0",
     "@fluentui/react-icons": "^2.0.0",
     "@spaarke/auth": "^2.0.0",
+    "@spaarke/ui-components": "*",
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/src/client/shared/Spaarke.DailyBriefing.Components/tsconfig.json
+++ b/src/client/shared/Spaarke.DailyBriefing.Components/tsconfig.json
@@ -14,7 +14,16 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@spaarke/auth": ["../Spaarke.Auth/dist/index.d.ts"],
+      "@spaarke/auth/*": ["../Spaarke.Auth/dist/*"],
+      "@spaarke/ui-components": ["../Spaarke.UI.Components/dist/index.d.ts"],
+      "@spaarke/ui-components/*": ["../Spaarke.UI.Components/dist/*"],
+      "@fluentui/react-icons": ["./node_modules/@fluentui/react-icons"],
+      "@fluentui/react-icons/*": ["./node_modules/@fluentui/react-icons/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
Rebased-on-master successor to #506 (unmerged 10 days; stale build-script conflict). Permanently fixes `Spaarke.DailyBriefing.Components` standalone build **and re-arms the CI gate** that was switched off on 2026-06-28.

## Root cause
Cross-lib `@spaarke/*` deps were declared only in `peerDependencies`, so the lib couldn't type-check standalone. On 2026-06-28 it was **excluded** from `Build-AllClientComponents.ps1` to keep CI green — removing the guardrail, so the breakage silently recurred in every fresh worktree (and blocked the daily-update-r5 `/prototype` harness).

## Fix (mirrors Spaarke.AI.Widgets)
- `package.json`: `file:` deps for `@spaarke/auth` + `@spaarke/ui-components`
- `tsconfig.json`: sibling `dist` `paths` + `@fluentui` dedup
- `Build-AllClientComponents.ps1`: **re-include** the lib in the shared-lib gate (LegalWorkspace exclusion preserved)

## Verification
`Spaarke.DailyBriefing.Components` builds standalone (`tsc --noEmit`, PASS) via the orchestrator once deps are built.

Supersedes #506 (will close it). Unblocks daily-update-r5 task 020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)