### PR TITLE
feat(shared-lib): export cleanGuid from @spaarke/ui-components barrel

### DIFF
--- a/src/client/shared/Spaarke.UI.Components/src/services/index.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/services/index.ts
@@ -87,6 +87,11 @@ export type {
 export {
   resolveRecordType,
   buildRecordUrl,
+  // Canonical GUID normalizer for @odata.bind key predicates. Strips
+  // registry-format braces + lowercases (Xrm.Utility.lookupObjects /
+  // userSettings.userId / Xrm.WebApi.createRecord return braced GUIDs which
+  // Dataverse rejects as "Error in query syntax"). No-op on already-bare ids.
+  cleanGuid,
   findNavProp,
   // Shared nav-prop discovery — consolidated 2026-07-09 (task 011, Path A).
   // Used by the array-form wizard services + the field-mapping engine (task 012).


### PR DESCRIPTION
Re-exports `cleanGuid` (the canonical `@odata.bind` GUID normalizer from PR #603) from the package barrel so external projects can `import { cleanGuid } from '@spaarke/ui-components'` instead of deep-importing. One-line barrel add; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)