### PR TITLE
fix(ci): remove build-test job-level swallow + register 2 timing-sensitive tests (F-5 completion)

### DIFF
--- a/.github/workflows/sdap-ci.yml
+++ b/.github/workflows/sdap-ci.yml
@@ -73,7 +73,13 @@ jobs:
   build-test:
     name: Build & Test
     runs-on: windows-latest
-    continue-on-error: true  # 2026-06-24: CI informational-only until test-architecture-reset-r1 lands. See projects/test-architecture-reset-r1/design.md.
+    # 2026-07-10 (redesign-r2 audit F-5 completion): job-level continue-on-error
+    # REMOVED. The 2026-06-24 "informational-only" posture predated the two-pass
+    # classifier + reliability registry and silently swallowed the classifier's
+    # verdict (a failed job still produced a green run — observed live on master
+    # run 29126132011). The full solution is 0-failures as of ef5d098b4; genuine
+    # timing flakes belong in tests/.reliability-registry.json, not in a
+    # job-level swallow.
     strategy:
       # When one matrix configuration fails (e.g., a flaky timing test in
       # Release), the default fail-fast=true cancels the sibling Debug job

--- a/tests/.reliability-registry.json
+++ b/tests/.reliability-registry.json
@@ -1,7 +1,8 @@
 {
   "_documentation": "Reliability registry for SDAP CI's two-pass test runner. Tests in this file have wall-clock or concurrency-dependent assertions whose failures may reflect CI VM contention (noise) rather than real regressions. The CI workflow's classify-and-retry.ps1 reads this file: any pass-1 failure NOT in this registry fails the build immediately (deterministic = real bug); failures that ARE in this registry trigger a targeted pass-2 retry on a fresh runner. If pass 2 also fails, the build still fails (treated as real regression). Add a test here ONLY if its assertions are genuinely timing-sensitive. See docs/procedures/testing-and-code-quality.md for the developer protocol.",
-  "_lastUpdated": "2026-06-19",
+  "_lastUpdated": "2026-07-10",
   "TimingSensitive": [
+    "Spaarke.Scheduling.Tests.ScheduledJobHostTests.StopAsync_CancelsInFlightJobWithinDrainTimeout_NFR07",
     "Spe.Integration.Tests.SystemIntegrationTests.ApiPerformance_MeetsResponseTimeRequirements",
     "Spe.Integration.Tests.Api.Ai.UploadIntegrationTests.ProcessingTime_UnderFifteenSeconds",
     "Sprk.Bff.Api.Tests.Integration.JobStatusSseIntegrationTests.PublishStatusUpdate_LatencyUnder1Second_MeetsSpecRequirement",
@@ -13,6 +14,7 @@
     "Sprk.Bff.Api.Tests.Services.Ai.ScopeResolverServiceTests.SearchScopesAsync_PerformanceUnder1Second_ForTypicalQuery"
   ],
   "ConcurrencySensitive": [
+    "Spaarke.Scheduling.Tests.RetryAndIdempotencyTests.CancellationDuringRetryLoop_StopsImmediately_DoesNotSleepThroughToken",
     "Sprk.Bff.Api.Tests.Mocks.AsyncEnumerableHelpersTests.DelayedAsyncEnumerable_CancellationDuringDelay_Throws",
     "Sprk.Bff.Api.Tests.Infrastructure.Resilience.StorageRetryPolicyTests.ExecuteAsync_CancellationDuringRetry_StopsRetrying"
   ]


### PR DESCRIPTION
## Summary
Completes audit finding **F-5** (CI honesty). The TRX fix (#628) made the classifier see all 4 test projects — but the Build & Test job itself still carried a job-level `continue-on-error: true` from the 2026-06-24 "informational-only" posture, which predates the two-pass classifier and swallowed its verdict: master run 29126132011 had a FAILED Build & Test job and a green run conclusion.

## Changes
- Remove the job-level `continue-on-error` from `build-test` — the classifier's verdict now blocks, as designed.
- Register the two genuinely timing-sensitive Scheduling tests that flaked under CI VM contention on that run (`StopAsync_CancelsInFlightJobWithinDrainTimeout_NFR07` → TimingSensitive; `CancellationDuringRetryLoop_StopsImmediately_DoesNotSleepThroughToken` → ConcurrencySensitive). Both passed repeatedly on identical content (branch CI + local full runs); the third failure that run was already registered. Pass-2 retry semantics now cover them.

## Why now
compose-r2 is about to run "the now-honest CI" for the joint parity deploy — this makes that literally true. Full solution is 0-failures on `ef5d098b4`, so blocking is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
