### PR TITLE
compose-r2: portfolio register + archive (#647)

### DIFF
--- a/projects/spaarkeai-compose-r2/.archived
+++ b/projects/spaarkeai-compose-r2/.archived
@@ -1,0 +1,8 @@
+Archived: 2026-07-15
+Final status: Completed
+Project Issue: #647 (closed) — https://github.com/spaarke-dev/spaarke/issues/647
+Parent Epic: #421 (SPAARKE AI)
+Closing PRs: #644 (#615 OBO facade canonicalization), #645 (#629 FR-30 durable-memory capability), #646 (close-out checkpoint)
+Deferral issues (all resolved): #601 #604 #605 (stale-fixed), #602 (dev provisioned; prod→runbook), #615 (canonicalized), #629 (capability shipped; untrusted-origin gate deferred to the memory-governance project — issue narrowed, stays open)
+Worktree: C:/code_files/spaarke-wt-spaarkeai-compose-r2 (PRESERVED — not removed by archive; clean up separately when truly done)
+Remote branch: work/spaarkeai-compose-r2 (retained on origin)

--- a/projects/spaarkeai-compose-r2/README.md
+++ b/projects/spaarkeai-compose-r2/README.md
@@ -1,8 +1,10 @@
 # Spaarke Compose R2
 
-> **Last Updated**: 2026-07-08
+> **Portfolio**: [Project #647](https://github.com/spaarke-dev/spaarke/issues/647) · Epic [#421 SPAARKE AI](https://github.com/spaarke-dev/spaarke/issues/421) · [Board](https://github.com/users/spaarke-dev/projects/2)
+
+> **Last Updated**: 2026-07-15
 >
-> **Status**: In Progress (planning complete; implementation gated on core Phase A0 for AI-dependent tracks)
+> **Status**: ✅ Complete — merged to master. All 6 deferral issues (#601/#604/#605/#602/#615/#629) addressed; FR-30 durable-memory capability shipped (gate deferred to #629's governance project).
 
 ## Overview
 


### PR DESCRIPTION
Registers compose-r2 as Project #647 (Epic #421) and archives it Completed. Adds README portfolio pointer + `.archived` marker. Worktree preserved. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)