### PR TITLE
fix(messaging): ACS boot-safety + format

### DIFF
--- a/src/client/pcf/CommunicationConnections/CommunicationConnections/CommunicationConnectionsApp.tsx
+++ b/src/client/pcf/CommunicationConnections/CommunicationConnections/CommunicationConnectionsApp.tsx
@@ -491,8 +491,7 @@ export const CommunicationConnectionsApp: React.FC<ICommunicationConnectionsAppP
   // the quick-create form; full create-and-link is the Notification-Spine project.
   const handleCreateType = React.useCallback((entityType: string): void => {
     const xrm = getXrm();
-    const onLaunchError = (err: unknown) =>
-      console.warn('[CommunicationConnections] create-type launch failed:', err);
+    const onLaunchError = (err: unknown) => console.warn('[CommunicationConnections] create-type launch failed:', err);
     try {
       if (typeof xrm?.Navigation?.openForm === 'function') {
         Promise.resolve(xrm.Navigation.openForm({ entityName: entityType, useQuickCreateForm: true })).catch(

--- a/src/client/pcf/CommunicationConnections/CommunicationConnections/ConnectionsEditor.tsx
+++ b/src/client/pcf/CommunicationConnections/CommunicationConnections/ConnectionsEditor.tsx
@@ -257,9 +257,19 @@ const useStyles = makeStyles({
   },
   typeCell: { display: 'flex', alignItems: 'center', gap: tokens.spacingHorizontalXS, minWidth: 0 },
   slotIcon: { color: tokens.colorNeutralForeground3, display: 'flex', flexShrink: 0 },
-  slotLabel: { color: tokens.colorNeutralForeground2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  slotLabel: {
+    color: tokens.colorNeutralForeground2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
   target: { display: 'flex', flexDirection: 'column', minWidth: 0 },
-  targetName: { fontWeight: tokens.fontWeightSemibold, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  targetName: {
+    fontWeight: tokens.fontWeightSemibold,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
   confHigh: { color: tokens.colorPaletteGreenForeground1, whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' },
   confMedium: {
     color: tokens.colorPaletteMarigoldForeground1,
@@ -283,7 +293,13 @@ const useStyles = makeStyles({
   colStatus: { width: '120px' },
   colActions: { width: '120px' },
   actionsCell: { display: 'flex', gap: tokens.spacingHorizontalXS, justifyContent: 'flex-end', width: '100%' },
-  subCell: { color: tokens.colorNeutralForeground2, paddingLeft: tokens.spacingHorizontalL, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  subCell: {
+    color: tokens.colorNeutralForeground2,
+    paddingLeft: tokens.spacingHorizontalL,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
   newTag: { color: tokens.colorNeutralForeground3, fontStyle: 'italic' },
   emptyGrid: { color: tokens.colorNeutralForeground3, padding: tokens.spacingVerticalM },
   subRow: {
@@ -330,7 +346,11 @@ const STATUS_META: Record<Connection['status'], { label: string; color: 'success
 };
 
 /** The Status-column badge — Primary wins over the raw status when a confirmed slot is primary. */
-function StatusBadge({ status, isPrimary, isConfirmed }: {
+function StatusBadge({
+  status,
+  isPrimary,
+  isConfirmed,
+}: {
   status: Connection['status'];
   isPrimary: boolean;
   isConfirmed: boolean;
@@ -444,7 +464,9 @@ function ConnectionRow({
               icon={showOthers ? <ChevronUp16Regular /> : <ChevronDown16Regular />}
               onClick={() => setShowOthers(v => !v)}
             >
-              {showOthers ? 'Hide other candidates' : `${others.length} other candidate${others.length === 1 ? '' : 's'}`}
+              {showOthers
+                ? 'Hide other candidates'
+                : `${others.length} other candidate${others.length === 1 ? '' : 's'}`}
             </Button>
           )}
         </div>
@@ -522,10 +544,24 @@ function ConnectionRow({
       {hasOthers &&
         showOthers &&
         others.map((alt, i) => (
-          <SubRow key={`o${i}`} s={s} busy={busy} name={nameOf(alt)} confidence={alt.reinforcedConfidence} onFile={() => onConfirm(conn, alt)} />
+          <SubRow
+            key={`o${i}`}
+            s={s}
+            busy={busy}
+            name={nameOf(alt)}
+            confidence={alt.reinforcedConfidence}
+            onFile={() => onConfirm(conn, alt)}
+          />
         ))}
       {alternatives.map((alt, i) => (
-        <SubRow key={`a${i}`} s={s} busy={busy} name={nameOf(alt)} confidence={alt.reinforcedConfidence} onFile={() => onConfirm(conn, alt)} />
+        <SubRow
+          key={`a${i}`}
+          s={s}
+          busy={busy}
+          name={nameOf(alt)}
+          confidence={alt.reinforcedConfidence}
+          onFile={() => onConfirm(conn, alt)}
+        />
       ))}
     </>
   );

--- a/src/client/pcf/CommunicationConnections/CommunicationConnections/provenance.ts
+++ b/src/client/pcf/CommunicationConnections/CommunicationConnections/provenance.ts
@@ -247,9 +247,9 @@ const ENTITY_TO_SLOT: Record<string, { field: string; label: string; order: numb
  * `sprk_todo` TODO_REGARDING_CATALOG names (`sprk_regardingcontact`), which do not exist on
  * `sprk_communication`. Reading with the wrong names makes the whole $select throw.
  */
-export const COMMUNICATION_REGARDING_FIELDS: { field: string; entityType: string }[] = Object.entries(ENTITY_TO_SLOT).map(
-  ([entityType, meta]) => ({ entityType, field: meta.field })
-);
+export const COMMUNICATION_REGARDING_FIELDS: { field: string; entityType: string }[] = Object.entries(
+  ENTITY_TO_SLOT
+).map(([entityType, meta]) => ({ entityType, field: meta.field }));
 
 /** A regarding lookup that is actually populated on the host record (a filed association). */
 export interface FiledAssociation {
@@ -311,7 +311,10 @@ export interface AiSuggestedType {
  * provenance string (there is no dedicated structured field today). Surfaced in the grid
  * as a "Create <Type>" affordance so the reviewer can act on the AI's intent.
  */
-export function deriveAiSuggestedTypes(doc: ProvenanceDoc, existingEntityTypes: ReadonlySet<string>): AiSuggestedType[] {
+export function deriveAiSuggestedTypes(
+  doc: ProvenanceDoc,
+  existingEntityTypes: ReadonlySet<string>
+): AiSuggestedType[] {
   const out: AiSuggestedType[] = [];
   const seen = new Set<string>();
   for (const sig of doc.signals ?? []) {

--- a/src/client/pcf/CommunicationTimeline/CommunicationTimeline/CommunicationTimelineApp.tsx
+++ b/src/client/pcf/CommunicationTimeline/CommunicationTimeline/CommunicationTimelineApp.tsx
@@ -209,8 +209,8 @@ export const CommunicationTimelineApp: React.FC<ICommunicationTimelineAppProps> 
       <div className={s.notice}>
         <MessageBar intent="info">
           <MessageBarBody>
-            Timeline unavailable — place this control on the sprk_communicationthread form, or on a
-            sprk_communication record with a thread.
+            Timeline unavailable — place this control on the sprk_communicationthread form, or on a sprk_communication
+            record with a thread.
           </MessageBarBody>
         </MessageBar>
       </div>

--- a/src/server/api/Sprk.Bff.Api/Services/Communication/Acs/AcsIdentityService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Communication/Acs/AcsIdentityService.cs
@@ -25,13 +25,17 @@ public sealed class AcsIdentityService : IAcsIdentityService
     private static readonly TimeSpan MinValidity = TimeSpan.FromHours(1);
     private static readonly TimeSpan MaxValidity = TimeSpan.FromHours(24);
 
-    private readonly CommunicationIdentityClient _identityClient;
+    // Lazy so CONSTRUCTING this service never builds the ACS client (ADR-032 boot-safety): the client
+    // factory throws when Communication:Acs:Endpoint is unconfigured, and this service is pulled into the
+    // startup hosted-service graph (via MembershipReconciler → MembershipReconcileSweepService). Deferring
+    // the build to first use means a BFF with no ACS config still boots; only an actual ACS call fails.
+    private readonly Lazy<CommunicationIdentityClient> _identityClient;
     private readonly IGenericEntityService _dataverse;
     private readonly TimeSpan _defaultValidity;
     private readonly ILogger<AcsIdentityService> _logger;
 
     public AcsIdentityService(
-        CommunicationIdentityClient identityClient,
+        Lazy<CommunicationIdentityClient> identityClient,
         IGenericEntityService dataverse,
         IOptions<AcsOptions> options,
         ILogger<AcsIdentityService> logger)
@@ -73,7 +77,7 @@ public sealed class AcsIdentityService : IAcsIdentityService
 
         // 2. Create the ACS identity (trusted service) and persist the mapping via the canonical
         //    Dataverse interface (no direct SDK).
-        Response<CommunicationUserIdentifier> created = await _identityClient.CreateUserAsync(ct);
+        Response<CommunicationUserIdentifier> created = await _identityClient.Value.CreateUserAsync(ct);
         var communicationUserId = created.Value.Id;
 
         await _dataverse.UpdateAsync(
@@ -104,7 +108,7 @@ public sealed class AcsIdentityService : IAcsIdentityService
         var scopes = new[] { CommunicationTokenScope.Chat }; // chat scope ONLY (NFR — uniform minting)
         var expiresIn = ClampValidity(validity ?? _defaultValidity);
 
-        Response<AccessToken> token = await _identityClient.GetTokenAsync(user, scopes, expiresIn, ct);
+        Response<AccessToken> token = await _identityClient.Value.GetTokenAsync(user, scopes, expiresIn, ct);
 
         return new AcsChatToken
         {

--- a/src/server/api/Sprk.Bff.Api/Services/Communication/Acs/AcsServiceCollectionExtensions.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Communication/Acs/AcsServiceCollectionExtensions.cs
@@ -21,8 +21,9 @@ public static class AcsServiceCollectionExtensions
     /// (011/020/051) with no feature gate. The client is built via a lazy factory from the DI-injected
     /// central <see cref="TokenCredential"/> (ADR-028 / NFR-05) + the configured ACS endpoint — the
     /// factory is only invoked on first resolution, so no live ACS resource is required at startup.
-    /// No consumer maps the client eagerly at startup, so no Null-Object peer is required yet (when
-    /// 011/020/051 add endpoints that consume it, apply ADR-032 if the plane becomes feature-gated).
+    /// Consumers inject <c>Lazy&lt;CommunicationIdentityClient&gt;</c> (ADR-032 boot-safety), so even the
+    /// startup hosted-service graph (MembershipReconciler → MembershipReconcileSweepService) can be built
+    /// without ACS config — the endpoint check fires only on first actual ACS call.
     /// </summary>
     public static IServiceCollection AddAcsIdentityPlane(this IServiceCollection services, IConfiguration configuration)
     {
@@ -43,6 +44,13 @@ public static class AcsServiceCollectionExtensions
             var credential = sp.GetRequiredService<TokenCredential>();
             return new CommunicationIdentityClient(new Uri(endpoint), credential);
         });
+
+        // Boot-safety (ADR-032): consumers take Lazy<CommunicationIdentityClient>, so constructing them never
+        // invokes the throwing factory above. The endpoint check fires only on first actual use — a BFF with
+        // no ACS config still boots (AcsIdentityService is reachable from the startup hosted-service graph via
+        // MembershipReconciler → MembershipReconcileSweepService).
+        services.AddSingleton(sp => new Lazy<CommunicationIdentityClient>(
+            () => sp.GetRequiredService<CommunicationIdentityClient>()));
 
         services.AddSingleton<IAcsIdentityService, AcsIdentityService>();
 
@@ -84,6 +92,10 @@ public static class AcsServiceCollectionExtensions
 
             return new ChatClient(new Uri(endpoint), serviceCredential.CreateCredential());
         });
+
+        // Boot-safety (ADR-032): AcsThreadService takes Lazy<ChatClient>, so constructing it never invokes the
+        // throwing factory above; the endpoint check fires only on first actual ACS thread operation.
+        services.AddSingleton(sp => new Lazy<ChatClient>(() => sp.GetRequiredService<ChatClient>()));
 
         services.AddSingleton<IAcsThreadService, AcsThreadService>();
 

--- a/src/server/api/Sprk.Bff.Api/Services/Communication/Acs/AcsThreadService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Communication/Acs/AcsThreadService.cs
@@ -28,10 +28,14 @@ public sealed class AcsThreadService : IAcsThreadService
 
     private static readonly TimeSpan DefaultRetention = TimeSpan.FromDays(MinRetentionDays);
 
-    private readonly ChatClient _chatClient;
+    // Lazy so CONSTRUCTING this service never builds the ACS ChatClient (ADR-032 boot-safety): the client
+    // factory throws when Communication:Acs:Endpoint is unconfigured, and this service is reachable from the
+    // startup hosted-service graph. Deferring the build to first use lets a BFF with no ACS config boot; only
+    // an actual ACS thread operation fails.
+    private readonly Lazy<ChatClient> _chatClient;
     private readonly ILogger<AcsThreadService> _logger;
 
-    public AcsThreadService(ChatClient chatClient, ILogger<AcsThreadService> logger)
+    public AcsThreadService(Lazy<ChatClient> chatClient, ILogger<AcsThreadService> logger)
     {
         _chatClient = chatClient;
         _logger = logger;
@@ -62,7 +66,7 @@ public sealed class AcsThreadService : IAcsThreadService
 
         try
         {
-            Response<CreateChatThreadResult> response = await _chatClient.CreateChatThreadAsync(options, ct);
+            Response<CreateChatThreadResult> response = await _chatClient.Value.CreateChatThreadAsync(options, ct);
             var threadId = response.Value.ChatThread.Id;
 
             _logger.LogInformation(
@@ -89,7 +93,11 @@ public sealed class AcsThreadService : IAcsThreadService
         {
             return new AcsMembershipChange
             {
-                ChatThreadId = chatThreadId, Requested = 0, Applied = 0, NoOped = 0, BatchCount = 0,
+                ChatThreadId = chatThreadId,
+                Requested = 0,
+                Applied = 0,
+                NoOped = 0,
+                BatchCount = 0,
             };
         }
 
@@ -148,7 +156,11 @@ public sealed class AcsThreadService : IAcsThreadService
             await threadClient.RemoveParticipantAsync(new CommunicationUserIdentifier(mri), ct);
             return new AcsMembershipChange
             {
-                ChatThreadId = chatThreadId, Requested = 1, Applied = 1, NoOped = 0, BatchCount = 1,
+                ChatThreadId = chatThreadId,
+                Requested = 1,
+                Applied = 1,
+                NoOped = 0,
+                BatchCount = 1,
             };
         }
         catch (RequestFailedException ex) when (ex.Status == 429)
@@ -163,7 +175,11 @@ public sealed class AcsThreadService : IAcsThreadService
                 chatThreadId);
             return new AcsMembershipChange
             {
-                ChatThreadId = chatThreadId, Requested = 1, Applied = 0, NoOped = 1, BatchCount = 1,
+                ChatThreadId = chatThreadId,
+                Requested = 1,
+                Applied = 0,
+                NoOped = 1,
+                BatchCount = 1,
             };
         }
     }
@@ -199,7 +215,7 @@ public sealed class AcsThreadService : IAcsThreadService
     {
         if (string.IsNullOrWhiteSpace(chatThreadId))
             throw new ArgumentException("chatThreadId is required.", nameof(chatThreadId));
-        return _chatClient.GetChatThreadClient(chatThreadId);
+        return _chatClient.Value.GetChatThreadClient(chatThreadId);
     }
 
     private static int ClampRetention(TimeSpan retention)

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/AcsBootSafetyTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/AcsBootSafetyTests.cs
@@ -1,0 +1,84 @@
+using Azure.Communication.Chat;
+using Azure.Communication.Identity;
+using Azure.Core;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Spaarke.Dataverse;
+using Sprk.Bff.Api.Services.Communication.Acs;
+using Xunit;
+
+namespace Sprk.Bff.Api.Tests.Services.Communication;
+
+/// <summary>
+/// Regression guard for the 2026-07-17 production-down incident: the merged BFF crash-looped at startup
+/// (SIGABRT / exit 134) because the ACS client factories throw when <c>Communication:Acs:Endpoint</c> is
+/// unconfigured, and <see cref="AcsThreadService"/> / <see cref="AcsIdentityService"/> are reachable from the
+/// startup hosted-service graph (MembershipReconciler → MembershipReconcileSweepService). The fix (ADR-032
+/// boot-safety) makes those services inject <c>Lazy&lt;client&gt;</c> so CONSTRUCTION never builds the client —
+/// the endpoint check fires only on first actual ACS call.
+///
+/// <para>These tests pin the deferred-failure contract as BEHAVIOR (not a DI-registration smoke test): with no
+/// ACS endpoint configured, the services still construct (the whole BFF still boots); an actual ACS operation
+/// then fails with the clear config error.</para>
+/// </summary>
+public class AcsBootSafetyTests
+{
+    private static ServiceProvider BuildProviderWithNoAcsEndpoint()
+    {
+        // Empty configuration — Communication:Acs:Endpoint is intentionally absent (the crash scenario).
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Mock.Of<TokenCredential>());
+        services.AddSingleton(Mock.Of<IGenericEntityService>());
+
+        services.AddAcsIdentityPlane(configuration);
+        services.AddAcsThreadPlane();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AcsServices_WithNoEndpointConfigured_ConstructWithoutThrowing()
+    {
+        using var provider = BuildProviderWithNoAcsEndpoint();
+
+        // Constructing the services must NOT build the ACS clients (the throwing factories stay dormant),
+        // so the startup hosted-service graph — and therefore the whole BFF — boots with no ACS config.
+        var identity = () => provider.GetRequiredService<IAcsIdentityService>();
+        var thread = () => provider.GetRequiredService<IAcsThreadService>();
+
+        identity.Should().NotThrow("a BFF with no ACS config must still boot (ADR-032 boot-safety)");
+        thread.Should().NotThrow("a BFF with no ACS config must still boot (ADR-032 boot-safety)");
+    }
+
+    [Fact]
+    public async Task AcsThreadOperation_WithNoEndpointConfigured_ThrowsClearConfigError()
+    {
+        using var provider = BuildProviderWithNoAcsEndpoint();
+        var threadService = provider.GetRequiredService<IAcsThreadService>();
+
+        // The failure is DEFERRED to first use: building the ChatClient (via Lazy.Value) throws the clear,
+        // actionable config error rather than an opaque startup SIGABRT.
+        var act = async () => await threadService.CreateThreadAsync("topic", new[] { "8:acs:user" });
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("Communication:Acs:Endpoint must be configured");
+    }
+
+    [Fact]
+    public async Task AcsIdentityOperation_WithNoEndpointConfigured_ThrowsClearConfigError()
+    {
+        using var provider = BuildProviderWithNoAcsEndpoint();
+        var identityService = provider.GetRequiredService<IAcsIdentityService>();
+
+        var act = async () => await identityService.MintChatTokenAsync("8:acs:user");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("Communication:Acs:Endpoint must be configured");
+    }
+}

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/AcsIdentityServiceTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/AcsIdentityServiceTests.cs
@@ -32,7 +32,7 @@ public class AcsIdentityServiceTests
         Mock<IGenericEntityService> dataverse,
         int defaultValidityHours = 24)
         => new(
-            identityClient.Object,
+            new Lazy<CommunicationIdentityClient>(() => identityClient.Object),
             dataverse.Object,
             Options.Create(new AcsOptions { DefaultTokenValidityHours = defaultValidityHours }),
             Mock.Of<ILogger<AcsIdentityService>>());

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/AcsThreadServiceTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/AcsThreadServiceTests.cs
@@ -31,7 +31,7 @@ public class AcsThreadServiceTests
     private static Response<T> Resp<T>(T value) => Response.FromValue(value, Mock.Of<Response>());
 
     private static AcsThreadService BuildSut(Mock<ChatClient> chatClient)
-        => new(chatClient.Object, Mock.Of<ILogger<AcsThreadService>>());
+        => new(new Lazy<ChatClient>(() => chatClient.Object), Mock.Of<ILogger<AcsThreadService>>());
 
     private static CreateChatThreadResult ThreadResult(string threadId) =>
         ChatModelFactory.CreateChatThreadResult(

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/CommunicationThreadReadServiceTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/CommunicationThreadReadServiceTests.cs
@@ -236,13 +236,13 @@ public class CommunicationThreadReadServiceTests
 
     private static Dictionary<string, JsonElement> AttachmentRow(
         Guid attachmentId, Guid messageId, Guid docId, string name, int type) => new()
-    {
-        ["sprk_communicationattachmentid"] = El(attachmentId.ToString()),
-        ["_sprk_communication_value"] = El(messageId.ToString()),
-        ["_sprk_document_value"] = El(docId.ToString()),
-        ["sprk_name"] = El(name),
-        ["sprk_attachmenttype"] = El(type),
-    };
+        {
+            ["sprk_communicationattachmentid"] = El(attachmentId.ToString()),
+            ["_sprk_communication_value"] = El(messageId.ToString()),
+            ["_sprk_document_value"] = El(docId.ToString()),
+            ["sprk_name"] = El(name),
+            ["sprk_attachmenttype"] = El(type),
+        };
 
     private static JsonElement El<T>(T value) => JsonSerializer.SerializeToElement(value);
 }

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/Membership/MembershipReconcilerTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Communication/Membership/MembershipReconcilerTests.cs
@@ -57,7 +57,11 @@ public class MembershipReconcilerTests
             .Callback<string, IEnumerable<string>, CancellationToken>((_, ids, _) => _added.AddRange(ids))
             .ReturnsAsync((string t, IEnumerable<string> ids, CancellationToken _) => new AcsMembershipChange
             {
-                ChatThreadId = t, Requested = ids.Count(), Applied = ids.Count(), NoOped = 0, BatchCount = 1,
+                ChatThreadId = t,
+                Requested = ids.Count(),
+                Applied = ids.Count(),
+                NoOped = 0,
+                BatchCount = 1,
             });
 
         _acsThread
@@ -65,7 +69,11 @@ public class MembershipReconcilerTests
             .Callback<string, string, CancellationToken>((_, id, _) => _removed.Add(id))
             .ReturnsAsync((string t, string id, CancellationToken _) => new AcsMembershipChange
             {
-                ChatThreadId = t, Requested = 1, Applied = 1, NoOped = 0, BatchCount = 1,
+                ChatThreadId = t,
+                Requested = 1,
+                Applied = 1,
+                NoOped = 0,
+                BatchCount = 1,
             });
 
         _audit

--- a/tests/unit/Sprk.Bff.Api.Tests/Services/Registration/AcsBoundaryProvisioningTests.cs
+++ b/tests/unit/Sprk.Bff.Api.Tests/Services/Registration/AcsBoundaryProvisioningTests.cs
@@ -25,19 +25,19 @@ public class AcsBoundaryProvisioningTests
         string[]? eventTypes = null,
         string deadLetterStorageId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sprkacme",
         string deadLetterContainer = "acs-eventgrid-deadletter") => new()
-    {
-        DataLocation = dataLocation,
-        EventGrid = new AcsEventGridOptions
         {
-            WebhookEndpointUrl = webhook,
-            IncludedEventTypes = eventTypes ?? AcsChatEventTypes.Default,
-            DeadLetter = new AcsDeadLetterOptions
+            DataLocation = dataLocation,
+            EventGrid = new AcsEventGridOptions
             {
-                StorageAccountResourceId = deadLetterStorageId,
-                ContainerName = deadLetterContainer,
+                WebhookEndpointUrl = webhook,
+                IncludedEventTypes = eventTypes ?? AcsChatEventTypes.Default,
+                DeadLetter = new AcsDeadLetterOptions
+                {
+                    StorageAccountResourceId = deadLetterStorageId,
+                    ContainerName = deadLetterContainer,
+                },
             },
-        },
-    };
+        };
 
     private static AcsBoundaryProvisioningService Service(
         AcsProvisioningOptions options,


### PR DESCRIPTION
## Summary

Follow-up to PR #655 (ACS messaging channel). Two fixes:

- **(a) ACS boot-safety (ADR-032)** — fixes the production-down startup crash (SIGABRT/exit 134): the ACS client factories threw when `Communication:Acs:Endpoint` was unconfigured, and the ACS services are pulled into the startup hosted-service graph — so one missing optional-channel setting crash-looped the whole BFF. `AcsIdentityService`/`AcsThreadService` now inject `Lazy<client>` → construction never builds the client; the endpoint check fires only on first actual ACS call. A BFF with no ACS config now **boots** (read/timeline endpoints work); only live send/thread ops fail until configured. Regression test `AcsBootSafetyTests` pins the deferred-failure contract.
- **(b) `dotnet format whitespace`** across the messaging files — clears the Tier-2 "Format (dotnet format)" CI check. Whitespace-only, no behavior change.

## Verification

- Build: ✅ 0 errors.
- Communication+Acs suite: ✅ 501 passed / 8 skipped / 0 failed (incl. 3 new boot-safety tests).
- `dotnet format whitespace --verify-no-changes`: ✅ clean.

## Note

Environments still MUST set `Communication__Acs__Endpoint` to actually SEND over ACS — this change only ensures a missing setting no longer crashes the whole BFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
