### PR TITLE
ci: per-SHA tier2 concurrency to fix spurious CI/Router red

### DIFF
--- a/.github/workflows/ci-tier2-advisory.yml
+++ b/.github/workflows/ci-tier2-advisory.yml
@@ -74,7 +74,13 @@ permissions:
   pull-requests: write   # tier2-pr-comment writes ONE deduplicated comment
 
 concurrency:
-  group: ci-tier2-advisory-${{ github.ref }}
+  # Include the commit SHA so runs on DIFFERENT commits never cancel each other. Previously the group was
+  # keyed on github.ref alone, so on master (frequent merges from many projects) a newer run cancelled the
+  # in-flight tier2 run of the prior commit; the Router aggregator (alls-green) treats a *cancelled* tier2 as
+  # a hard fail (allowed-failures covers failure, not cancellation) → spurious red `CI / Router`. Per-SHA
+  # groups keep cancel-in-progress a literal boolean (avoids the ci-router.yml startup_failure class) while
+  # letting each commit's advisory tier run to completion.
+  group: ci-tier2-advisory-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary

Fixes the spurious red **`CI / Router`** check that hits master commits (unrelated to any project's code).

**Root cause:** `ci-tier2-advisory.yml` keyed its concurrency group on `github.ref` with `cancel-in-progress: true`. On master (frequent merges from many projects) a newer run **cancels** the in-flight tier2 run of the prior commit. The `Router` aggregator (`re-actors/alls-green`) treats a *cancelled* tier2 as a hard fail — `allowed-failures: tier2` covers a *failure* but not a *cancellation* — so superseded commits get a false-red `CI / Router` even though tier2 is advisory. Observed across many unrelated commits (`484e69f0b`, `85dd95159`, `2ce3ed416`, `0056fd0f5`, …).

**Fix:** append `github.sha` to the concurrency group so runs on different commits don't cancel each other. `cancel-in-progress` stays a literal boolean (avoids the ci-router.yml `startup_failure` class).

**Trade-off:** rapid pushes to the *same* ref no longer auto-cancel superseded tier2 runs — acceptable for an advisory tier, and it removes the false-red.

## Verification
- YAML parses (UTF-8); `cancel-in-progress` remains literal `true`.
- Single-line change to the concurrency `group:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)