### PR TITLE
messaging-r3: sender-name via sentby annotation + tenant config fallback

### DIFF
--- a/src/client/shared/Spaarke.Auth/src/resolveRuntimeConfig.ts
+++ b/src/client/shared/Spaarke.Auth/src/resolveRuntimeConfig.ts
@@ -358,11 +358,40 @@ export async function resolveRuntimeConfig(): Promise<IRuntimeConfig> {
   // Xrm.organizationSettings.tenantId is unreliable in Code Page contexts;
   // the customer-set env var is the source of truth.
   const envTenantId = envVars.get(ENV_VAR_NAMES.TENANT_ID);
-  const resolvedTenantId = envTenantId && envTenantId.trim() ? envTenantId.trim() : xrmTenantId;
+  let resolvedTenantId = envTenantId && envTenantId.trim() ? envTenantId.trim() : xrmTenantId;
+  let tenantSource = envTenantId && envTenantId.trim() ? 'env-var' : xrmTenantId ? 'xrm-fallback' : 'none';
+
+  const normalizedBffUrl = normalizeUrl(bffBaseUrl);
+
+  // 3b. Last-resort tenant fallback: the BFF's anonymous /api/config/client endpoint (backed by the BFF's
+  // AzureAd:TenantId app setting). This fires ONLY when neither the sprk_TenantId env var NOR Xrm yielded a
+  // tenant — the exact failure a deeply-nested Code Page iframe hits (Xrm.organizationSettings.tenantId is
+  // empty there, and if sprk_TenantId also has no value record the tenant is empty). An empty tenant makes the
+  // MSAL authority fall back to /organizations, which breaks ssoSilent in an iframe and forces an interactive
+  // popup loop (messaging-r3 2026-07-22). The BFF host is already known, so this needs no extra config and no
+  // token (the endpoint is anonymous). Non-fatal: a failure just leaves the tenant empty as before.
+  if (!resolvedTenantId) {
+    try {
+      const cfgResp = await fetch(`${normalizedBffUrl}/api/config/client`, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+      if (cfgResp.ok) {
+        const cfg = (await cfgResp.json()) as { tenantId?: string };
+        const bffTenant = cfg.tenantId?.trim();
+        if (bffTenant && bffTenant !== 'common' && bffTenant !== 'organizations') {
+          resolvedTenantId = bffTenant;
+          tenantSource = 'bff-config';
+        }
+      }
+    } catch (err) {
+      console.warn('[Spaarke.RuntimeConfig] /api/config/client tenant fallback failed (non-fatal):', err);
+    }
+  }
 
   // 4. Build config — normalize URL and construct OAuth scope
   const config: IRuntimeConfig = {
-    bffBaseUrl: normalizeUrl(bffBaseUrl),
+    bffBaseUrl: normalizedBffUrl,
     bffOAuthScope: `api://${bffAppId}/user_impersonation`,
     msalClientId,
     tenantId: resolvedTenantId,
@@ -372,8 +401,6 @@ export async function resolveRuntimeConfig(): Promise<IRuntimeConfig> {
   cachedConfig = config;
   cacheTimestamp = Date.now();
   saveToLocalStorage(config);
-
-  const tenantSource = envTenantId && envTenantId.trim() ? 'env-var' : xrmTenantId ? 'xrm-fallback' : 'none';
   console.log(
     `[Spaarke.RuntimeConfig] Resolved: bffBaseUrl=${config.bffBaseUrl}, ` +
       `scope=api://${bffAppId.substring(0, 8)}..., clientId=${msalClientId.substring(0, 8)}..., ` +

--- a/src/server/api/Sprk.Bff.Api/Services/Communication/CommunicationThreadReadService.cs
+++ b/src/server/api/Sprk.Bff.Api/Services/Communication/CommunicationThreadReadService.cs
@@ -64,7 +64,13 @@ public sealed class CommunicationThreadReadService
     // Sender-identity enrichment (R3 task 002 / FR-18) — projected metadata over the already-visible row.
     private const string DirectionField = "sprk_direction";            // choice: Incoming=100000000, Outgoing=100000001
     private const string SentByValue = "_sprk_sentby_value";           // systemuser lookup value
-    private const string SentByNameField = "sprk_sentbyname";          // denormalized sender display name
+    // Sender display name comes from the sprk_sentby lookup's FormattedValue annotation (the systemuser's
+    // display name), which rides the already-selected _sprk_sentby_value lookup when the impersonated query
+    // requests annotations (DataverseWebApiService.RetrieveMultipleImpersonatedAsync). This REPLACES the
+    // denormalized sprk_sentbyname column, which is in a broken metadata state in the env
+    // (IsValidODataAttribute=false → 400 on $select) and was never written by the send path anyway
+    // (messaging-r3 2026-07-22). Null when sprk_sentby is unset (e.g. an inbound message with no systemuser sender).
+    private const string SentByFormattedValue = "_sprk_sentby_value@OData.Community.Display.V1.FormattedValue";
 
     // sprk_communicationattachment columns (pre-existing intersection, task 070).
     private const string AttachmentPkField = "sprk_communicationattachmentid";
@@ -132,12 +138,9 @@ public sealed class CommunicationThreadReadService
         var select = string.Join(',', new[]
         {
             PkField, BodyField, BodyFormatField, TypeField, FromField, SubjectField, ToField,
-            // NOTE (2026-07-22 hotfix): SentByNameField (sprk_sentbyname) is intentionally NOT selected.
-            // The column is in a broken metadata state in the target env (IsValidODataAttribute=false —
-            // a partial/failed creation that cannot be published or deleted), so $select on it 400s and
-            // surfaces as a 500 on every thread that has messages. Nothing writes the column either, so
-            // SentByName is null regardless. Re-add here once the column is re-provisioned AND a writer
-            // populates it. Direction + SentBy (systemuserid) still drive the Teams-style bubble alignment.
+            // sprk_sentbyname is NOT selected — it is broken in the env (IsValidODataAttribute=false) and 400s the
+            // whole read. The sender display name instead comes from the _sprk_sentby_value lookup's FormattedValue
+            // annotation (the impersonated query requests annotations; ParseMessageRow reads it) — messaging-r3 2026-07-22.
             DirectionField, SentByValue,
             SentAtField, CreatedOnField, InReplyToField, InternalOnlyField, PrivilegeField, IsPrivateField,
         });
@@ -629,10 +632,9 @@ public sealed class CommunicationThreadReadService
         var select = string.Join(',', new[]
         {
             PkField, BodyField, BodyFormatField, TypeField, FromField, SubjectField, ToField,
-            // NOTE (2026-07-22 hotfix): SentByNameField (sprk_sentbyname) intentionally NOT selected —
-            // broken column in the target env (IsValidODataAttribute=false) that 400s $select → 500 on the
-            // by-regarding + filtered-query read paths. See the matching note in ReadThreadAsync. Nothing
-            // writes the column, so SentByName is null regardless. Re-add once re-provisioned + written.
+            // sprk_sentbyname is NOT selected — broken in the env (IsValidODataAttribute=false) → 400 → 500 on the
+            // by-regarding + filtered-query paths. Sender name comes from the _sprk_sentby_value FormattedValue
+            // annotation instead (see ReadThreadAsync + ParseMessageRow) — messaging-r3 2026-07-22.
             DirectionField, SentByValue,
             SentAtField, CreatedOnField, InReplyToField, InternalOnlyField, PrivilegeField, IsPrivateField, ThreadLookupValue,
         });
@@ -835,7 +837,7 @@ public sealed class CommunicationThreadReadService
             To = SplitRecipients(TryString(row, ToField)),
             Direction = TryInt(row, DirectionField),
             SentBy = TryGuid(row, SentByValue),
-            SentByName = TryString(row, SentByNameField),
+            SentByName = TryString(row, SentByFormattedValue),
             SentAt = TryDateTimeOffset(row, SentAtField),
             CreatedOn = TryDateTimeOffset(row, CreatedOnField),
             InReplyTo = TryString(row, InReplyToField),

--- a/src/server/shared/Spaarke.Dataverse/DataverseWebApiService.cs
+++ b/src/server/shared/Spaarke.Dataverse/DataverseWebApiService.cs
@@ -1925,7 +1925,17 @@ public class DataverseWebApiService : IDataverseService
         _logger.LogDebug(
             "[DATAVERSE-IMPERSONATE] GET {EntitySet} as caller {CallerSystemUserId}", entitySetName, callerSystemUserId);
 
-        var response = await SendGetAsync(url, ct, impersonateSystemUserId: callerSystemUserId);
+        // Request FormattedValue annotations so a lookup's display name (e.g. sprk_sentby → the sender's
+        // systemuser display name) rides the SAME impersonated row as the lookup value itself. This is the
+        // canonical Dataverse way to project a related record's name without a second query OR a broken/
+        // never-written denormalized name column (messaging-r3 2026-07-22 — replaced the unqueryable
+        // sprk_sentbyname column). Annotations are additive extra keys ("{field}@OData.Community.Display.
+        // V1.FormattedValue") that non-communication readers of this impersonated seam simply ignore.
+        using var request = await CreateAuthenticatedRequestAsync(
+            HttpMethod.Get, url, ct, impersonateSystemUserId: callerSystemUserId);
+        request.Headers.TryAddWithoutValidation(
+            "Prefer", "odata.include-annotations=\"OData.Community.Display.V1.FormattedValue\"");
+        var response = await _httpClient.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
 
         var data = await response.Content.ReadFromJsonAsync<ODataCollectionResponse>(cancellationToken: ct);


### PR DESCRIPTION
## Summary
Follow-up UAT hardening after the conversation-surface auth/500 fixes:

- **Sender name (replaces broken `sprk_sentbyname`)** — the impersonated read now requests FormattedValue annotations, so the `sprk_sentby` lookup's systemuser display name rides the already-selected `_sprk_sentby_value` on the same access-filtered row. `SentByName` reads that annotation instead of the denormalized `sprk_sentbyname` column, which is broken in-env (`IsValidODataAttribute=false`) and was never written. No schema surgery (its deletion is blocked by the SentBy relationship we need).
- **Tenant config fallback** — `resolveRuntimeConfig` falls back to the BFF anonymous `/api/config/client` (backed by `AzureAd:TenantId`) when neither `sprk_TenantId` nor Xrm yield a tenant — the exact failure a nested Code Page iframe hits that caused the `/organizations` popup loop.

## Verification
- BFF `dotnet build -c Release` — 0 errors
- `@spaarke/auth` — 44/44 tests pass
- Against spaarkedev1: the `sprk_sentby` FormattedValue annotation returns the sender name; `/api/config/client` returns the correct tenant + tenant-specific authority.

## Conflict resolution
None — clean merges with master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)