### PR TITLE
email-r5: UAT R3 — resolver type-label + true delete, link-card font/size, shared modal chrome

### DIFF
--- a/projects/email-communication-solution-r5/current-task.md
+++ b/projects/email-communication-solution-r5/current-task.md
@@ -1,8 +1,8 @@
 # Current Task State — `email-communication-solution-r5`
 
-> **Last Updated**: 2026-07-30 (by context-handoff)
-> **Recovery**: Read "Quick Recovery" first. This is a **UAT-iteration** session on the
-> shipped Email surface — owner-driven rapid iteration, NOT a fresh POML task.
+> **Last Updated**: 2026-07-31 (by context-handoff)
+> **Recovery**: Read "Quick Recovery" first. This is an **owner-driven UAT-iteration** session on the
+> shipped + deployed Email surface — NOT a fresh POML task.
 
 ---
 
@@ -10,78 +10,70 @@
 
 | Field | Value |
 |-------|-------|
-| **Work** | Email reading-pane + composer UAT iteration + Wave E (templates + AI drafting) + open-email-as-form wiring |
-| **Branch** | `work/email-communication-solution-r5` · **HEAD `394c62d6f`** · working tree CLEAN · all pushed to origin |
-| **vs master** | **8 commits ahead of `origin/master`** (the UAT batch below). NOT yet merged to master. |
-| **Status** | All owner UAT items #1–#13 + list dividers + per-user send + #8 DONE. Wave E in progress: BFF template endpoint DONE; **template picker (client) is the NEXT action**. |
-| **Next Action** | Build the **compose-toolbar template picker** — see "NEXT: Wave E template picker" below. Then AI sparkle, then wire Messages "open email" icon. |
-| **Harness** | `http://localhost:5175/` (may be stale) — `SPAARKE_REPO_ROOT="c:/code_files/spaarke-wt-email-communication-solution-r5" npm run dev` in `c:/code_files/spaarke-prototype/projects/email-communication-solution-r5-uat`. Native Xrm (lookup/upload/template/nav) NO-OPS in the harness — deploy-validated only. |
+| **Work** | Email reading-pane + composer UAT iteration (2 batches) + Wave E (templates/AI sparkle) + SPE sharing links + open-email-as-form |
+| **Branch** | `work/email-communication-solution-r5` · **HEAD `5e5286d51`** · working tree CLEAN · pushed |
+| **vs master** | **0 ahead / merged.** All work merged to master via **PR #702** + **PR #704** (merge commit `43a1b8f86`). Main repo `c:/code_files/spaarke` master synced. |
+| **Deployed** | ALL of it is live on **spaarkedev1**: BFF (`spaarke-bff-dev`), `sprk_emailpage` + `sprk_spaarkeai` web resources. |
+| **Status** | ✅ **Everything done, merged, deployed.** Nothing stranded, nothing pending code-side. |
+| **Next Action** | **Owner is running a UAT pass on spaarkedev1** (hard-refresh Ctrl+Shift+R first). If UAT finds issues → iterate on this branch → re-run `/merge-to-master`. Otherwise idle. |
 
 ### Verify/build commands (per package)
-- **UI.Components** engine/composer/launcher: `cd src/client/shared/Spaarke.UI.Components` → `npx tsc --noEmit -p tsconfig.json` · `npx jest EmailComposer SendEmailDialog openEmailRecord`
-- **Communication.Components** reading pane/workspace: `cd src/client/shared/Spaarke.Communication.Components` → `npx tsc --noEmit -p tsconfig.json` · `npx jest EmailWorkspace EmailCardList EmailConnectionsReview EmailReadingPaneShell EmailComposeActions`
-- **AI.Widgets**: `cd src/client/shared/Spaarke.AI.Widgets` → `npx tsc --noEmit -p tsconfig.json`
-- **BFF**: `dotnet build src/server/api/Sprk.Bff.Api/` · `dotnet test ... --filter CommunicationTemplateEndpointTests`
-- **CRITICAL cross-package build order**: edits to UI.Components require `npm run build` there BEFORE Communication.Components / AI.Widgets typecheck (they consume the built `dist/` .d.ts, not source). Order: UI.Components → Communication.Components. `dist/` is gitignored (never commit it).
-- Tests use **jest** (NOT vitest). Prettier gate is repo-wide (`npx prettier --write` then `--check` your changed files before commit).
+- **UI.Components** (composer engine): `cd src/client/shared/Spaarke.UI.Components` → `npx tsc --noEmit` · `npx jest EmailComposer SendEmailDialog shareLinks templatePicker aiSparkle uatR2Chrome`
+- **Communication.Components** (reading pane/list/widget): `cd src/client/shared/Spaarke.Communication.Components` → `npx tsc --noEmit` · `npx jest EmailWorkspace EmailCardList EmailReadingPaneShell EmailConnectionsReview EmailRecipients EmailComposeActions EmailAssociations`
+- **AI.Widgets**: `cd src/client/shared/Spaarke.AI.Widgets` → `npx tsc --noEmit`
+- **BFF**: `dotnet build src/server/api/Sprk.Bff.Api/` · `dotnet test tests/unit/Sprk.Bff.Api.Tests/ --filter "FullyQualifiedName~CommunicationDraftEndpointTests|FullyQualifiedName~CommunicationTemplateEndpointTests"`
+- **CRITICAL build order** (cross-package dist): edits to UI.Components require `npm run build` there BEFORE Communication.Components / AI.Widgets typecheck (they consume built `dist/`). Order: UI.Components → Communication.Components → AI.Widgets. `dist/` is gitignored.
+- Tests use **jest** (NOT vitest). Prettier gate repo-wide.
 
 ---
 
-## DONE this session — 8 commits (all pushed)
+## DEPLOY playbook (spaarkedev1) — proven this session
 
-| Commit | Items | Notes |
-|--------|-------|-------|
-| `967f17b30` | **#1** Email tab loads real widget | `WorkspacePane` FIX #10b intercept gated to the compose DRAFT hand-off only (payload has `mode`/`bodyText`/`attachmentFileName`); plain `email` tab falls through to registry → real `EmailWorkspaceWidget`. Stub kept for the draft hand-off. +regression test. SpaarkeAi-only (code page never had the stub). |
-| `884e809ae` | **#2,4,5,6,7,9,10** reading polish | pane 20/80 default; subject line above body; "Link another" card matches candidate cards; single-click opens type dropdown; Related-to collapses when 🟢 confirmed; primary green; reading title 18px. Communication.Components. |
-| `ca370e3fd` | **#3,10,11,12,13** compose polish | From row above To/Cc; compose title 18px; maximize/restore (fills app container); `modalType="alert"` (no light-dismiss → role `alertdialog`); space above quoted thread. UI.Components. |
-| `9d9d59690` | list dividers + search | `EmailCardList` Today/Yesterday/This Week/This Month/Older via pure `bucketEmailsByDate(items, now)`; search box filters sender/subject. Communication.Components. |
-| `719199430` | **#3** per-user send | Email surface defaults From to current user (new `defaultSendMode` seed keeps switcher interactive — do NOT use `sendMode` which LOCKS the switcher); resolves signed-in email via `resolveCurrentUserEmail()` (`systemuser.internalemailaddress`) at both mounts → `fromMailbox`. Threaded engine→SendEmailDialog→useEmailComposeActions→EmailWorkspace→mounts. |
-| `6daa4ca65` | **#8** compose single-primary | `associations[0]` = primary regarding (BFF `MapAssociationFields` writes `sprk_regardingrecord*` from index 0 — CLIENT-ONLY ordering, no send-contract change). "Link another" → picker → confirm "Set as primary / Will replace current" → `SET_PRIMARY_ASSOCIATION` promotes to index 0. Primary chip green. Inline label+chips+link, font parity. |
-| `f42061e9c` | Wave E template endpoint | `POST /api/communications/template/render { templateId, regardingEntityType?, regardingRecordId? } → { subject, body, isHtml }`. Reuses `EmailTemplateService.FetchAndRenderAsync` + `IGenericEntityService`. `CommunicationTemplateEndpoints.cs` + `EndpointMappingExtensions.cs` reg + 6 tests. App-only Dataverse read (OBO variant is a noted follow-up). |
-| `394c62d6f` | open-email-as-form | EmailPage resolves record id (Pattern B `data` param / `id` / Pattern A host-form context) → `initialSelectedId` + `hideList`. `hideList` single-record mode in `EmailWorkspace` + `EmailReadingPaneShell`. `openEmailRecord(id,{single})` launcher exported from `@spaarke/ui-components`. Tests 19+5. |
+**BFF**: `pwsh -File scripts/Deploy-BffApi.ps1` (hardened: hash-verify + health). Target `spaarke-bff-dev` / `rg-spaarke-dev`. Verify new endpoints return **401** (registered) not 404.
+
+**Code pages** (both alias shared libs to SOURCE — no dist rebuild needed, just clear vite cache):
+- `cd src/solutions/EmailPage && rm -rf dist node_modules/.vite .vite && npm run build` → `dist/sprk_emailpage.html`
+- `cd src/solutions/SpaarkeAi && rm -rf dist node_modules/.vite .vite && npm run build` → `dist/spaarkeai.html`
+- **SpaarkeAi deploy**: `pwsh -File scripts/Deploy-SpaarkeAi.ps1` (defaults to `https://spaarkedev1.crm.dynamics.com`; upserts `sprk_spaarkeai` webresource + publishes).
+- **EmailPage deploy**: NO dedicated script — same Web-API upsert pattern (find `sprk_emailpage` by name → PATCH base64 content → PublishXml). Inline PowerShell used this session (see transcript).
+- **ALWAYS verify server-side** after: GET webresourceset content, decode base64, grep for a marker. **`sprk_spaarkeai` is a SHARED resource** — other active worktrees deploy it too and CAN CLOBBER your deploy (happened once at "coming soon"). Re-verify + redeploy if it reverts; durable fix = deploy from master.
+- **Users must hard-refresh** (Ctrl+Shift+R) — Dataverse caches web resources aggressively even after publish.
+
+---
+
+## What shipped (full session inventory — all in master + deployed)
+
+### Batch 1 + Wave E (PR #702, merge `42ba5758b`)
+- UAT #1–#13 + list Today/Yesterday dividers + search + per-user send (#3) + single-primary Related-to (#8).
+- **Wave E templates**: `[document]` compose toolbar button → lists OOB `template` (Xrm) → `POST /api/communications/template/render` (reuses `IEmailTemplateService`, `{!entity.field}` merge from primary regarding) → fills subject/body.
+- **Wave E AI sparkle**: `[✨]` button, 6 presets + "Enter prompt" → `POST /api/communications/draft` via NEW `IEmailDraftAi` PublicContracts facade (real wraps `IChatClient`; `NullEmailDraftAi` mirror on the AzureOpenAI gate, ADR-032) → replaces body.
+- **Open-email-as-form**: Pattern A (embed on `sprk_communication` form) + Pattern B (`openEmailRecord` launcher); Messages "open email" icon → new Email surface.
+
+### Batch 2 (UAT round 2) — PR #704, merge `43a1b8f86`
+- **`991db15d5`** — 11 UX items: (#1) list-pane 280px min-width anchor; (#2) elevated widget view header; (#3) auto-load first email; (#4) collapsible right-aligned search icon; (#5) **restored review status dots** — root cause: `hasAssociationData` gate ignored denorm `sprk_regardingrecordname/number`; (#6) reading `From:` plain text; (#7) Related-to card alignment; (#8) removed compose modal X (kept maximize); (#9) compose `From:` plain text + switcher kept; (#10/#11) Related-to "Link another record" inline + in New modal.
+- **`63a339336`** — **#12 SPE sharing links**: emailed document "Link" now a recipient-openable file link. NEW `POST /api/documents/{id}/share-link` (OBO `DriveItemOperations.CreateSharingLinkAsUserAsync` → Graph createLink **view/anonymous**, on `SpeFileStore` facade). Client `onResolveShareLink` prop resolves at send (best-effort, NON-BLOCKING — failure keeps prior URL, never blocks send). Record links stay record links.
 
 ---
 
 ## Locked design decisions (do NOT re-litigate)
-
-- **Templates**: OOB Dataverse `template` entity (NOT a custom entity/designer). Merge `{!entity.field}` from the **confirmed primary regarding** via the existing BFF `EmailTemplateService`. Template LIST = client-side Xrm on `template`; RENDER = the new BFF endpoint. See memory `email-drafting-templates-and-ai-decisions`.
-- **AI drafting**: lightweight **email sparkle** on the compose toolbar → common prompts + "Enter prompt" → **BFF draft endpoint** (NOT the heavy `Spaarke.Compose` doc subsystem). Prompts sourced from the **prompt library** (admin-editable), not hardcoded. 6 starter prompts: *Draft a reply · Summarize the thread · Make it concise · Formal tone · Friendly tone · Fix grammar & tone* + Enter prompt.
-- **Per-user send (#3)**: email surface defaults to current-user send. ⚠️ **OPEN**: owner said "we need to test the per user" — confirm the sandbox/prod is configured for per-user (send-as) mail; if only the shared mailbox is provisioned, user-send will fail (fall back to shared default). BFF supports it (`CommunicationSendMode = 'sharedMailbox' | 'user'`).
-- **Word templates**: a SEPARATE future effort (OOB Dataverse Document Templates, pairs with the Compose subsystem). Do NOT couple email templates to it now. A unified Spaarke templating concept is a possible larger later project.
-- **SPE container** (attachments, item 9b earlier): ONE per deployment, resolved from the owner BU (`businessunit.sprk_containerid`). Memory `spe-single-container-per-deployment`.
-- **Form patterns**: BOTH Pattern A (embed as the `sprk_communication` form) AND Pattern B (`openEmailRecord` launcher for icons like the Messages "open email"). Foundation shipped in `394c62d6f`.
+- **Templates**: OOB Dataverse `template` entity; merge from confirmed primary regarding (`associations[0]`). Memory `email-drafting-templates-and-ai-decisions`.
+- **AI drafting**: lightweight sparkle → `IEmailDraftAi` facade → `IChatClient` (NOT the heavy Compose subsystem). Intent→instruction map server-side in `EmailDraftAi.cs` (prompt-library sourcing = future growth). NOT `IChatClient` injected into comms code (§10/ADR-013).
+- **Per-user send (#3)**: CONFIRMED working in tenant (owner sent real email from ralph.schroeder@spaarke.com). `defaultSendMode='user'` correct. Graph OBO `/me/sendMail`, not server-side sync. `EmailChannelSender.cs`.
+- **#12 sharing links**: owner chose **anonymous view** scope (external-recipient flexibility). ⚠️ Requires tenant SPE/SharePoint external-sharing policy to permit "Anyone" links; if disabled, createLink refused → send falls back to prior URL (never blocks). Switch to `organization` scope = one line in `FileAccessEndpoints.CreateShareLink`.
+- **SPE container** (attachments): ONE per deployment, from owner BU. Memory `spe-single-container-per-deployment`.
 
 ---
 
-## NEXT: Wave E template picker (the immediate next action)
-
-Build a `[📄]` template button in the compose body toolbar (`EmailComposer.tsx` toolbarSlot — same area as the paperclip/search/`| [template] [✨AI]` group). Flow:
-1. **List templates** client-side via the host: add a handler (mirror `createXrmEmailComposeHandlers` pattern) that queries the OOB `template` entity via Xrm.WebApi (email templates; filter by `templatetypecode`/appropriate). Thread it as an optional prop like `onListEmailTemplates` / a picker callback (additive, like `onLookupRecord`).
-2. **Render**: on pick, call `POST {bffBaseUrl}/api/communications/template/render` with `{ templateId, regardingEntityType, regardingRecordId }` = the **primary regarding** (`state.associations[0]`) via `authenticatedFetch`. Response `{ subject, body, isHtml }`.
-3. **Apply**: fill the composer `subject` (if empty or confirm-overwrite) + insert/replace `body` (respect `isHtml` → set bodyFormat). Reuse the engine's SET_FIELD / body set.
-- Thread any new prop through: `EmailComposer.types.ts` → `SendEmailDialog` (spread) → `useEmailComposeActions` → `EmailWorkspace` (+types) → both mounts (`EmailPage/main.tsx`, `EmailWorkspaceWidget.tsx`). Same threading pattern used for `onUploadLocalAttachment` / `fromMailbox` this session.
-- Then AI sparkle (needs a BFF DRAFT endpoint — `EmailDraftService.cs` exists but is matter/agent-specific; likely add a thin generic `POST /api/communications/draft { intent, userInstruction?, currentBody, thread?, regarding?, mode:generate|refine } → { text }` sourcing prompt text from the prompt library). Then a `[✨]` dropdown (6 prompts + Enter prompt) → call it → propose draft into body.
-- Then wire the **Messages "open email" icon** → `openEmailRecord(id)` (locate the Messages surface's email-open call site; replace OOB openForm/navigate with the launcher).
-
-### Key anchors for Wave E
-- BFF render endpoint: `src/server/api/Sprk.Bff.Api/Api/CommunicationTemplateEndpoints.cs`
-- Existing services: `Services/Ai/Delivery/EmailTemplateService.cs` (`FetchAndRenderAsync(templateId, variables, dataverseUrl, accessToken, ct)`); `Api/Agent/EmailDraftService.cs` (matter-specific — DON'T force-fit; add a generic draft endpoint); prompt library `Api/Ai/PromptLibraryEndpoints.cs` / `PlaybookEndpoints.cs`.
-- Compose toolbar: `EmailComposer.tsx` `toolbarSlot` (paperclip Menu + record SearchRegular Menu already there; add `| [template] [✨]`).
-- Launcher already exported: `openEmailRecord` from `@spaarke/ui-components`.
+## Key file anchors (for future iteration)
+- **Composer engine**: `src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx` (+ `.types.ts`, `.reducer.ts`, `createXrmEmailComposeHandlers.ts`, `wrappers/SendEmailDialog.tsx`). Send-time share-link resolve: `resolveAttachmentShareLinks` (exported). Toolbar (`[attach][search]|[template][✨]`): `toolbarSlot`.
+- **Reading pane/list/widget**: `src/client/shared/Spaarke.Communication.Components/src/components/` — `EmailWorkspace/` (composition root + `.mapping.ts` review-tone gate), `EmailReadingPaneShell/` (pane min-width + first-email adopt), `EmailCardList/` (search icon + dots + dividers), `EmailRecipients/` (From:), `EmailAssociationsAndTracking/EmailConnectionsReview` (Related-to cards), `EmailComposeActions/useEmailComposeActions.tsx` (compose dialog host + prop threading).
+- **Widget mount**: `src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/EmailWorkspaceWidget.tsx`. **Code-page mount**: `src/solutions/EmailPage/src/main.tsx`. Both build `createXrmEmailComposeHandlers` + pass all `on*` props.
+- **BFF**: `Api/CommunicationTemplateEndpoints.cs`, `Api/CommunicationDraftEndpoints.cs`, `Api/FileAccessEndpoints.cs` (`CreateShareLink`), `Services/Ai/PublicContracts/{IEmailDraftAi,EmailDraftAi,NullEmailDraftAi}.cs`, `Infrastructure/Graph/{DriveItemOperations,SpeFileStore}.cs` (`CreateSharingLinkAsUserAsync`), `Infrastructure/DI/AiModule.cs` (IEmailDraftAi gate), `Infrastructure/DI/EndpointMappingExtensions.cs`.
+- **Prop-threading pattern** (for any new compose capability): engine `IEmailComposerProps` → `SendEmailDialog` (spread) → `useEmailComposeActions` (deps type + destructure + pass) → `EmailWorkspace` (+ `.types.ts`) → both mounts. Xrm impl in `createXrmEmailComposeHandlers` (present only with `authenticatedFetch` + `bffBaseUrl`).
 
 ---
-
-## Verification status (all GREEN at handoff)
-- UI.Components / Communication.Components / AI.Widgets typecheck clean against rebuilt dists.
-- jest: composer 157–164, reading/workspace/shell 71+, EmailCardList 16, openEmailRecord 5, WorkspacePane email-stub 4. BFF: 6 template-endpoint tests. Prettier clean.
-- Pre-existing unrelated failures (documented, verified via git-stash baseline): `useEmailComposeActions` attachment-enum (reading side), some Compose/Timeline/WorkspaceShell suites, EmailPage cross-tree `tsc-surface-gate` reports 66 pre-existing shared-lib errors (canonical package typecheck is clean).
-
-## Memory files written this session (in `~/.claude/projects/.../memory/`)
-- `spe-single-container-per-deployment` · `email-drafting-templates-and-ai-decisions` · indexed in `MEMORY.md`.
-
-## Deploy / merge notes
-- Deploy is FRONTEND-only for the client waves (Email code page `sprk_emailpage` web resource + `@spaarke/communication-components` widget bundle) PLUS the BFF for the new template endpoint (`f42061e9c` — first BFF change this batch; publish-size negligible, no new deps).
-- Branch is 8 ahead of master, pushed but NOT merged. Merge-to-master path: branch protection OFF → direct FF `git push origin HEAD:master` + sync main repo (`c:/code_files/spaarke` → `git fetch && checkout master && merge --ff-only origin/master`). Run Prettier gate first.
 
 ## How to continue
-Say **"continue"** or **"build the template picker"**. Start at `EmailComposer.tsx` toolbarSlot; thread the new template-picker prop the same way `fromMailbox`/`onUploadLocalAttachment` were threaded this session; call the shipped `POST /api/communications/template/render`.
+- If owner UAT is **clean** → project effectively complete; nothing to do.
+- If owner UAT finds **issues** → iterate on this branch (use the file anchors + threading pattern above), verify per the commands, commit, redeploy to spaarkedev1 (deploy playbook), then `/merge-to-master` (update from master → PR → auto-merge; sync main repo). For parallel multi-item batches, partition by package (composer=UI.Components, reading=Communication.Components) to avoid file collisions — proven twice this session.
+- Harness for local dev (native Xrm NO-OPS there — deploy-validated only): `http://localhost:5175/`.

--- a/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/CreateAnalysisWizardWidget.tsx
+++ b/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/CreateAnalysisWizardWidget.tsx
@@ -288,7 +288,13 @@ interface ContactLookupControlProps {
   placeholder?: string;
 }
 
-const ContactLookupControl: React.FC<ContactLookupControlProps> = ({ value, onPick, onClear, disabled, placeholder }) => (
+const ContactLookupControl: React.FC<ContactLookupControlProps> = ({
+  value,
+  onPick,
+  onClear,
+  disabled,
+  placeholder,
+}) => (
   <Input
     readOnly
     value={value?.name ?? ''}

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailAssociationsAndTracking.types.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailAssociationsAndTracking.types.ts
@@ -32,6 +32,8 @@ export interface EmailConnectionsReviewProps {
   regardingRecordName?: string | null;
   /** Denormalized regarding record number (`sprk_regardingrecordnumber`) — used for the confirmed "{Type}: {number}" chip. */
   regardingRecordNumber?: string | null;
+  /** `sprk_regardingrecordtype` FormattedValue (e.g. "Matter") — the human type label for the confirmed chip when the primary is denorm-only. */
+  regardingRecordType?: string | null;
   /** The record's actually-filed regarding lookups (incl. manual "Link another" ones the engine never suggested) — merged into engine-derived slots so the surface shows every association, not just suggestions. */
   filedAssociations?: FiledAssociation[];
   /** Write context (webApi + hostEntity + hostRecordId) for the additive write path. `hostRecordId` MUST match `communicationId`. */

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.styles.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.styles.ts
@@ -37,7 +37,9 @@ export const useConnectionsReviewStyles = makeStyles({
     boxSizing: 'border-box',
     width: '100%',
     minWidth: 0,
-    minHeight: '64px',
+    // Match the candidate card's rendered height (2 short lines + padding) so all four
+    // cards line up on the row (owner UAT 2026-07-31 item 3).
+    minHeight: '72px',
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
@@ -49,6 +51,10 @@ export const useConnectionsReviewStyles = makeStyles({
     borderRadius: tokens.borderRadiusMedium,
     backgroundColor: tokens.colorNeutralBackground1,
     cursor: 'pointer',
+    // A native <button> does NOT inherit font-family (it defaults to the UA font,
+    // which rendered as Arial) — the sibling cards are <div>s that inherit Segoe UI.
+    // Force inheritance so the label matches the candidate cards (owner UAT item 3).
+    fontFamily: 'inherit',
     ':hover': { backgroundColor: tokens.colorNeutralBackground1Hover },
   },
   linkCardLabel: {
@@ -73,6 +79,8 @@ export const useConnectionsReviewStyles = makeStyles({
     flexDirection: 'column',
     gap: tokens.spacingVerticalXXS,
     minWidth: 0,
+    // Shared height floor so candidate / blank / link cards line up (owner UAT item 3).
+    minHeight: '72px',
     textAlign: 'left',
     paddingBlock: tokens.spacingVerticalS,
     paddingInline: tokens.spacingHorizontalM,
@@ -99,7 +107,7 @@ export const useConnectionsReviewStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    minHeight: '64px',
+    minHeight: '72px',
     paddingInline: tokens.spacingHorizontalM,
     border: `${tokens.strokeWidthThin} dashed ${tokens.colorNeutralStroke2}`,
     borderRadius: tokens.borderRadiusMedium,

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.styles.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.styles.ts
@@ -27,23 +27,21 @@ export const useConnectionsReviewStyles = makeStyles({
   // Right-hand column holding the "Link another record" affordance / picker.
   linkCol: { flexShrink: 0, alignSelf: 'flex-start', display: 'flex', alignItems: 'center', maxWidth: '100%' },
   // "Link another record" — a VISUAL SIBLING of the candidate cards (owner UAT
-  // #5): identical box (border / radius / padding / neutral surface), content
-  // TOP-aligned, the label at the same size + weight as a card's primary line,
-  // and the search icon CENTERED (not pushed to a corner). Clicking it opens the
-  // record-type dropdown directly (owner UAT #6).
-  // owner UAT 2026-07-30 R2 item 7 — a VISUAL SIBLING of the candidate `card`
-  // below: identical border / radius / padding / neutral surface / hover and the
-  // same inter-line `gap` (spacingVerticalXXS), so the "Link another record" tile
-  // matches the reference cards exactly. No explicit `fontFamily` anywhere in these
-  // cards — they inherit Fluent's default Segoe UI (there is no Arial to remove).
+  // #5; corrected 2026-07-31 R2 item "match the other cards"): identical box
+  // (border / radius / padding / neutral surface / hover) AND the same footprint
+  // as a sibling card — a SINGLE left-aligned row (search icon + label), vertically
+  // centered, at the same `minHeight` (64px) as the blank slots so all four cards
+  // line up on one row instead of the link tile standing taller. No explicit
+  // `fontFamily` — inherits Fluent's default Segoe UI (there is no Arial to remove).
   linkCard: {
     boxSizing: 'border-box',
     width: '100%',
     minWidth: 0,
+    minHeight: '64px',
     display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'stretch',
-    gap: tokens.spacingVerticalXXS,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
     textAlign: 'left',
     paddingBlock: tokens.spacingVerticalS,
     paddingInline: tokens.spacingHorizontalM,
@@ -55,6 +53,7 @@ export const useConnectionsReviewStyles = makeStyles({
   },
   linkCardLabel: {
     minWidth: 0,
+    flex: '1 1 auto',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -63,9 +62,9 @@ export const useConnectionsReviewStyles = makeStyles({
     fontWeight: tokens.fontWeightSemibold,
     color: tokens.colorNeutralForeground1,
   },
-  // Search icon centered within the card body (owner UAT #5).
-  linkCardIconRow: { display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%' },
-  linkCardIcon: { flexShrink: 0, color: tokens.colorNeutralForeground3, fontSize: '20px' },
+  // Search icon inline before the label (left-aligned row) — brand-toned to read as
+  // the one actionable "add" affordance among the muted candidate cards.
+  linkCardIcon: { flexShrink: 0, color: tokens.colorBrandForeground1, fontSize: '20px' },
   // One grid cell — the card itself plus its own Confirm slot directly beneath it.
   cardCell: { display: 'flex', flexDirection: 'column', gap: tokens.spacingVerticalXS, minWidth: 0 },
 

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.tsx
@@ -202,10 +202,8 @@ export function EmailConnectionsReview(props: EmailConnectionsReviewProps): Reac
             <Menu positioning="below-start">
               <MenuTrigger disableButtonEnhancement>
                 <button type="button" className={s.linkCard} disabled={busy} data-testid="link-another-record">
+                  <Search20Regular className={s.linkCardIcon} aria-hidden="true" />
                   <span className={s.linkCardLabel}>Link another record</span>
-                  <span className={s.linkCardIconRow}>
-                    <Search20Regular className={s.linkCardIcon} aria-hidden="true" />
-                  </span>
                 </button>
               </MenuTrigger>
               <MenuPopover>

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.tsx
@@ -62,6 +62,7 @@ export function EmailConnectionsReview(props: EmailConnectionsReviewProps): Reac
     associationProvenanceJson,
     regardingRecordName,
     regardingRecordNumber,
+    regardingRecordType,
     filedAssociations = [],
     writeContext,
     linkAnotherCatalog,
@@ -86,8 +87,16 @@ export function EmailConnectionsReview(props: EmailConnectionsReviewProps): Reac
       derivePrimaryReview(associationProvenanceJson, associationStatus, filedAssociations, {
         recordName: regardingRecordName,
         recordNumber: regardingRecordNumber,
+        recordTypeLabel: regardingRecordType,
       }),
-    [associationProvenanceJson, associationStatus, filedAssociations, regardingRecordName, regardingRecordNumber]
+    [
+      associationProvenanceJson,
+      associationStatus,
+      filedAssociations,
+      regardingRecordName,
+      regardingRecordNumber,
+      regardingRecordType,
+    ]
   );
 
   const catalog = linkAnotherCatalog ?? DEFAULT_LINK_CATALOG;

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReviewRows.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReviewRows.tsx
@@ -126,7 +126,10 @@ export function ConfirmedChip({
   onRemove: () => void;
   s: ConnectionsReviewStyles;
 }): React.ReactElement {
-  const type = primary.entity ? entityLabel(primary.entity) : 'Record';
+  // Prefer the denorm type label ("Matter") when the primary was filed via denorm
+  // fields only (no typed `entity` to resolve); else map the typed entity; else the
+  // generic fallback (owner UAT 2026-07-31 item 1). Feeds BOTH the chip and its tooltip.
+  const type = primary.typeLabel ?? (primary.entity ? entityLabel(primary.entity) : 'Record');
   const value = primary.recordNumber ?? primary.targetName;
   const title = `${type} · ${primary.targetName}${primary.recordNumber ? ' · ' + primary.recordNumber : ''}`;
   return (

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/EmailWorkspace.mapping.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/EmailWorkspace.mapping.ts
@@ -210,6 +210,8 @@ export interface EmailWorkspaceRecordState {
   sprk_body: string;
   regardingRecordName: string | null;
   regardingRecordNumber: string | null;
+  /** `sprk_regardingrecordtype` FormattedValue (e.g. "Matter") — human type label for the confirmed chip. */
+  regardingRecordType: string | null;
   associationStatus: number | null;
   associationProvenanceJson: string | null;
   filedAssociations: FiledAssociation[];
@@ -231,6 +233,12 @@ export function toWorkspaceRecordState(raw: RawCommunicationRecord): EmailWorksp
     sprk_body: asString(raw['sprk_body']),
     regardingRecordName: asNullableString(raw['sprk_regardingrecordname']),
     regardingRecordNumber: asNullableString(raw['sprk_regardingrecordnumber']),
+    // The `sprk_regardingrecordtype` lookup's FormattedValue (e.g. "Matter") from the
+    // no-$select retrieveRecord — the human record-type label for the confirmed chip
+    // when the primary is denorm-only (owner UAT 2026-07-31 item 1).
+    regardingRecordType: asNullableString(
+      raw['_sprk_regardingrecordtype_value@OData.Community.Display.V1.FormattedValue']
+    ),
     associationStatus: asNullableNumber(raw['sprk_associationstatus']),
     associationProvenanceJson: asNullableString(raw['sprk_associationprovenance']),
     filedAssociations: readFiledAssociations(raw),

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/EmailWorkspace.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/EmailWorkspace.tsx
@@ -49,7 +49,7 @@ import { EmailReadingHeader, EmailReadingAttachments } from '../EmailReadingHead
 import { EmailRecipients } from '../EmailRecipients';
 import { EmailConnectionsReview, ConfirmedChip, useConnectionsReviewStyles } from '../EmailAssociationsAndTracking';
 import { useEmailComposeActions } from '../EmailComposeActions';
-import { derivePrimaryReview, summarizePrimaryReview, unlinkRegarding } from '../../logic/connections';
+import { derivePrimaryReview, summarizePrimaryReview, clearPrimaryRegarding } from '../../logic/connections';
 import { launchCreate, type CreateKind } from '../../logic/actions';
 import { CollapsibleSection } from './CollapsibleSection';
 import { COMMUNICATION_ENTITY, mapRowToEmailCardItem } from './EmailWorkspace.mapping';
@@ -278,6 +278,7 @@ export const EmailWorkspace: React.FC<EmailWorkspaceProps> = ({
         {
           recordName: record.recordState?.regardingRecordName,
           recordNumber: record.recordState?.regardingRecordNumber,
+          recordTypeLabel: record.recordState?.regardingRecordType,
         }
       ),
     [record.recordState, filedAssociations]
@@ -292,7 +293,13 @@ export const EmailWorkspace: React.FC<EmailWorkspaceProps> = ({
     (entity: string, communicationId: string): void => {
       void (async () => {
         try {
-          await unlinkRegarding({ webApi, hostEntity: COMMUNICATION_ENTITY, hostRecordId: communicationId }, entity);
+          // Fully clear the single primary (denorm fields + typed lookup + status),
+          // NOT just a typed-lookup unlink — a denorm-only primary has no typed
+          // lookup to null, so plain unlink silently no-oped (owner UAT item 2).
+          await clearPrimaryRegarding(
+            { webApi, hostEntity: COMMUNICATION_ENTITY, hostRecordId: communicationId },
+            entity
+          );
           record.reload();
         } catch (err) {
           console.warn('[EmailWorkspace] remove association failed:', err);
@@ -385,6 +392,7 @@ export const EmailWorkspace: React.FC<EmailWorkspaceProps> = ({
                   associationProvenanceJson={record.recordState?.associationProvenanceJson ?? null}
                   regardingRecordName={record.recordState?.regardingRecordName ?? null}
                   regardingRecordNumber={record.recordState?.regardingRecordNumber ?? null}
+                  regardingRecordType={record.recordState?.regardingRecordType ?? null}
                   filedAssociations={filedAssociations}
                   writeContext={{ webApi, hostEntity: COMMUNICATION_ENTITY, hostRecordId: id }}
                   pickerWebApi={webApi}

--- a/src/client/shared/Spaarke.Communication.Components/src/logic/connections/ConnectionsWriteHandler.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/logic/connections/ConnectionsWriteHandler.ts
@@ -296,6 +296,60 @@ export async function unlinkRegarding(
   }
 }
 
+/**
+ * REMOVE the single primary regarding association from the reading-pane confirmed
+ * chip (owner UAT 2026-07-31 item 2). Unlike `unlinkRegarding` (which only nulls a
+ * typed lookup and deliberately preserves the denorm primary for the additive
+ * multi-lookup model), this fully clears the primary because the single-primary
+ * reading-pane model has exactly ONE:
+ *   - nulls the typed regarding lookup (when the primary carries a real `entityType`;
+ *     a denorm-only primary has none, which is why plain `unlinkRegarding` silently
+ *     no-ops and the chip could not be deleted),
+ *   - clears the 5 denormalized `sprk_regardingrecord*` fields (id / name / number /
+ *     url + the `sprk_RegardingRecordType` lookup),
+ *   - resets `sprk_associationstatus` to null so the section returns to the
+ *     requires-review / needs-confirmation state derived from provenance, letting the
+ *     reviewer re-pick.
+ * No-op success in CREATE mode (no host GUID).
+ */
+export async function clearPrimaryRegarding(
+  ctx: IResolverWriteContext,
+  entityType: string,
+  fetchImpl: typeof fetch = globalThis.fetch
+): Promise<IResolverWriteResult> {
+  const cleanId = ctx.hostRecordId?.replace(/[{}]/g, '');
+  if (!cleanId || cleanId.length !== 36) {
+    return { success: true }; // Nothing to clear without a persisted record.
+  }
+
+  const payload: Record<string, unknown> = {
+    sprk_regardingrecordid: null,
+    sprk_regardingrecordname: null,
+    sprk_regardingrecordnumber: null,
+    sprk_regardingrecordurl: null,
+    'sprk_RegardingRecordType@odata.bind': null,
+    sprk_associationstatus: null,
+  };
+
+  // Also null the entity-specific typed lookup when the primary is a real typed
+  // association (a denorm-only primary has entityType '' → nothing to null).
+  const target = entityType.trim().toLowerCase();
+  if (target) {
+    const navProps = await discoverHostNavProps(ctx.hostEntity, fetchImpl);
+    const navProp = navProps.find(n => n.referencedEntity?.toLowerCase() === target);
+    if (navProp) {
+      payload[`${navProp.navPropName}@odata.bind`] = null;
+    }
+  }
+
+  try {
+    await ctx.webApi.updateRecord(ctx.hostEntity, cleanId, payload);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : 'clear primary failed' };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public: advance association status (plain host-field write — NOT regarding logic)
 // ---------------------------------------------------------------------------

--- a/src/client/shared/Spaarke.Communication.Components/src/logic/connections/__tests__/clearPrimaryAndTypeLabel.test.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/logic/connections/__tests__/clearPrimaryAndTypeLabel.test.ts
@@ -1,0 +1,68 @@
+/**
+ * clearPrimaryAndTypeLabel.test.ts — owner UAT 2026-07-31 items 1 + 2.
+ *
+ * Item 1: a CONFIRMED primary filed via DENORM fields only (all typed lookups null,
+ *   so no `entity` logical name) carries the `sprk_regardingrecordtype` label
+ *   ("Matter") as `typeLabel` — that is what the confirmed chip shows instead of the
+ *   generic "Record".
+ * Item 2: removing that confirmed (denorm-only) primary must actually clear it —
+ *   `clearPrimaryRegarding` nulls the 5 denorm fields + resets the status, WITHOUT a
+ *   typed-lookup fetch (there is no typed lookup to null). Plain `unlinkRegarding`
+ *   only nulled a typed lookup, which silently no-oped for a denorm-only primary.
+ */
+import { clearPrimaryRegarding } from '../ConnectionsWriteHandler';
+import { derivePrimaryReview, ASSOCIATION_STATUS_RESOLVED_VALUE } from '../provenance';
+
+const GUID = '11111111-1111-1111-1111-111111111111';
+
+function ctx(updateRecord: jest.Mock) {
+  return { webApi: { updateRecord }, hostEntity: 'sprk_communication', hostRecordId: GUID };
+}
+
+describe('clearPrimaryRegarding (item 2 — delete a confirmed denorm-only primary)', () => {
+  it('clears the denorm fields + status for a denorm-only primary (entity "") with no typed-lookup fetch', async () => {
+    const updateRecord = jest.fn().mockResolvedValue({});
+    const fetchSpy = jest.fn();
+    const res = await clearPrimaryRegarding(ctx(updateRecord), '', fetchSpy as unknown as typeof fetch);
+
+    expect(res.success).toBe(true);
+    // Denorm-only primary → no typed lookup to null → no metadata fetch.
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    const [entity, id, payload] = updateRecord.mock.calls[0];
+    expect(entity).toBe('sprk_communication');
+    expect(id).toBe(GUID);
+    expect(payload).toMatchObject({
+      sprk_regardingrecordid: null,
+      sprk_regardingrecordname: null,
+      sprk_regardingrecordnumber: null,
+      sprk_regardingrecordurl: null,
+      'sprk_RegardingRecordType@odata.bind': null,
+      sprk_associationstatus: null,
+    });
+  });
+
+  it('is a no-op success in CREATE mode (no host guid) and never writes', async () => {
+    const updateRecord = jest.fn();
+    const res = await clearPrimaryRegarding(
+      { webApi: { updateRecord }, hostEntity: 'sprk_communication', hostRecordId: '' },
+      ''
+    );
+    expect(res.success).toBe(true);
+    expect(updateRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('derivePrimaryReview type label (item 1 — "Matter", not "Record")', () => {
+  it('a confirmed denorm-only primary carries recordTypeLabel as typeLabel', () => {
+    const model = derivePrimaryReview(null, ASSOCIATION_STATUS_RESOLVED_VALUE, [], {
+      recordName: 'Patent Application 19183531 - Elisa Liardo',
+      recordNumber: 'PAT-942665',
+      recordTypeLabel: 'Matter',
+    });
+    expect(model.state).toBe('confirmed');
+    expect(model.primary?.targetName).toBe('Patent Application 19183531 - Elisa Liardo');
+    expect(model.primary?.entity).toBe(''); // denorm-only: no typed entity
+    expect(model.primary?.typeLabel).toBe('Matter');
+  });
+});

--- a/src/client/shared/Spaarke.Communication.Components/src/logic/connections/provenance.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/logic/connections/provenance.ts
@@ -670,6 +670,13 @@ export interface PrimaryCandidate {
   recordNumber?: string;
   confidence: number;
   matchReason?: string;
+  /**
+   * Human record-type label for the confirmed chip (e.g. "Matter"), used when the
+   * primary was filed via the DENORM fields only (all typed lookups null) so there
+   * is no `entity` logical name to resolve. Sourced from the host record's
+   * `sprk_regardingrecordtype` lookup FormattedValue. Owner UAT 2026-07-31 item 1.
+   */
+  typeLabel?: string;
 }
 
 /** Denormalized primary fields read off the host record (for the confirmed chip + number resolution). */
@@ -677,6 +684,8 @@ export interface PrimaryDenorm {
   recordName?: string | null;
   recordNumber?: string | null;
   entityType?: string | null;
+  /** `sprk_regardingrecordtype` FormattedValue (e.g. "Matter") — the human type label for the confirmed chip. */
+  recordTypeLabel?: string | null;
 }
 
 export interface PrimaryReviewModel {
@@ -726,6 +735,7 @@ function resolveConfirmedPrimary(
       recordNumber: match?.recordNumber ?? denorm?.recordNumber ?? undefined,
       confidence: match?.confidence ?? 1,
       matchReason: match?.matchReason,
+      typeLabel: denorm?.recordTypeLabel ?? undefined,
     };
   }
   if (denorm?.recordName) {
@@ -735,6 +745,9 @@ function resolveConfirmedPrimary(
       targetName: denorm.recordName,
       recordNumber: denorm.recordNumber ?? undefined,
       confidence: 1,
+      // Denorm-only primary: no typed `entity` to resolve, so the chip type comes
+      // from the `sprk_regardingrecordtype` label ("Matter") (owner UAT item 1).
+      typeLabel: denorm.recordTypeLabel ?? undefined,
     };
   }
   return ranked[0];

--- a/src/client/shared/Spaarke.UI.Components/src/components/ConversationView/ConversationView.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/ConversationView/ConversationView.tsx
@@ -1086,7 +1086,7 @@ export const ConversationView = React.forwardRef<ConversationViewHandle, Convers
                         />
                       )}
 
-                  {/* Forward affordance (task 022 / FR-08) — rendered in the anchor
+                      {/* Forward affordance (task 022 / FR-08) — rendered in the anchor
                     wrapper so it applies uniformly to BOTH the chat bubble and
                     the email-in-flow block WITHOUT editing either subcomponent.
                     It only hands the message back to the host via
@@ -1098,7 +1098,7 @@ export const ConversationView = React.forwardRef<ConversationViewHandle, Convers
                     button that does nothing. The accessible name is
                     contextualized per message so N Forward buttons are
                     distinguishable to a screen reader. */}
-                  {/* Trailing per-message actions (Forward + Delete). Delete
+                      {/* Trailing per-message actions (Forward + Delete). Delete
                       (round 7 item 8) is offered for MESSAGE-type rows only — email
                       deletion is owned by the email surface (not here). Both are
                       revealed on row hover/focus (NFR-05) and kept in the DOM/tab

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
@@ -58,12 +58,11 @@ import {
   Search20Regular,
   ChevronDown20Regular,
   ChevronUp20Regular,
-  ArrowMaximize20Regular,
-  ArrowMinimize20Regular,
   DocumentText20Regular,
   Sparkle20Regular,
 } from '@fluentui/react-icons';
 import type { CommunicationSendMode } from '../../services/communicationApi';
+import { ModalWindowControls } from '../ModalWindowControls';
 
 import { sendCommunication, SendCommunicationError } from '../../services/communicationApi';
 import type { ICommunicationAssociation } from '../../services/communicationApi';
@@ -1329,22 +1328,16 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
                       ? 'Edit Draft'
                       : 'New Email')}
           </Text>
-          {/* Window controls cluster on the upper-RIGHT: maximize/restore only (owner UAT
-              2026-07-30 R2 item 8 — corrected to upper-right 2026-07-31). The close 'X' button
-              was REMOVED — the modal is closed via the Cancel/Close button in ComposerActionBar
-              (wired to the same `props.onCancel`). Maximize renders only when the host wires
+          {/* Standard Spaarke modal window controls (maximize/restore + close ×) in the
+              upper-RIGHT — the shared `ModalWindowControls` so every modal matches (owner
+              UAT 2026-07-31 item 4). Close routes to the SAME `props.onCancel` the
+              ComposerActionBar Cancel button uses. Maximize shows only when the host wires
               `onToggleMaximize` (e.g. SendEmailDialog, which owns the surface sizing). */}
-          {props.onToggleMaximize && (
-            <div className={styles.headerActions}>
-              <Button
-                appearance="subtle"
-                size="small"
-                icon={props.isMaximized ? <ArrowMinimize20Regular /> : <ArrowMaximize20Regular />}
-                aria-label={props.isMaximized ? 'Restore dialog size' : 'Maximize dialog'}
-                onClick={() => props.onToggleMaximize?.()}
-              />
-            </div>
-          )}
+          <ModalWindowControls
+            isMaximized={props.isMaximized}
+            onToggleMaximize={props.onToggleMaximize}
+            onClose={props.onCancel}
+          />
         </div>
       )}
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
@@ -243,7 +243,10 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'flex-start',
+    // Title on the left, window-controls cluster pushed to the upper-RIGHT
+    // (owner UAT 2026-07-30 R2 item 8 — corrected 2026-07-31: the maximize
+    // button belongs in the upper-right corner, Outlook-style, not the left).
+    justifyContent: 'space-between',
     gap: tokens.spacingHorizontalS,
   },
   headerActions: {
@@ -1314,22 +1317,6 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
     >
       {isChromed && (
         <div className={styles.header}>
-          {/* Window controls cluster on the upper-LEFT: maximize/restore only. The close 'X'
-              button was REMOVED (owner UAT 2026-07-30 R2 item 8) — the modal is closed via the
-              Cancel/Close button in ComposerActionBar (wired to the same `props.onCancel`).
-              Maximize renders only when the host wires `onToggleMaximize` (e.g. SendEmailDialog,
-              which owns the surface sizing). */}
-          {props.onToggleMaximize && (
-            <div className={styles.headerActions}>
-              <Button
-                appearance="subtle"
-                size="small"
-                icon={props.isMaximized ? <ArrowMinimize20Regular /> : <ArrowMaximize20Regular />}
-                aria-label={props.isMaximized ? 'Restore dialog size' : 'Maximize dialog'}
-                onClick={() => props.onToggleMaximize?.()}
-              />
-            </div>
-          )}
           <Text as="h2" weight="semibold" className={styles.headerTitle}>
             {props.titleOverride ??
               (state.mode === 'view'
@@ -1342,6 +1329,22 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
                       ? 'Edit Draft'
                       : 'New Email')}
           </Text>
+          {/* Window controls cluster on the upper-RIGHT: maximize/restore only (owner UAT
+              2026-07-30 R2 item 8 — corrected to upper-right 2026-07-31). The close 'X' button
+              was REMOVED — the modal is closed via the Cancel/Close button in ComposerActionBar
+              (wired to the same `props.onCancel`). Maximize renders only when the host wires
+              `onToggleMaximize` (e.g. SendEmailDialog, which owns the surface sizing). */}
+          {props.onToggleMaximize && (
+            <div className={styles.headerActions}>
+              <Button
+                appearance="subtle"
+                size="small"
+                icon={props.isMaximized ? <ArrowMinimize20Regular /> : <ArrowMaximize20Regular />}
+                aria-label={props.isMaximized ? 'Restore dialog size' : 'Maximize dialog'}
+                onClick={() => props.onToggleMaximize?.()}
+              />
+            </div>
+          )}
         </div>
       )}
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/uatR2Chrome.test.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/uatR2Chrome.test.tsx
@@ -1,8 +1,13 @@
 /**
- * uatR2Chrome.test.tsx — owner UAT 2026-07-30 R2 items 8 + 11.
+ * uatR2Chrome.test.tsx — owner UAT R2 items 8 + 11, with item 8 SUPERSEDED by
+ * 2026-07-31 item 4 (standard modal chrome).
  *
- * Item 8: the chromed header no longer renders a close 'X' button; the maximize/restore control
- *   stays (the modal is closed via ComposerActionBar's Cancel/Close, wired to the same onCancel).
+ * Item 8 → item 4: the chromed header renders the STANDARD Spaarke modal window
+ *   controls — maximize/restore AND a close 'X' — in the upper-right, via the shared
+ *   `ModalWindowControls`. (R2 had briefly removed the X; the owner reversed that to
+ *   standardize expand + X across all modals.) Close routes to the same onCancel the
+ *   action-bar Cancel uses. The maximize button appears only when onToggleMaximize is
+ *   wired; the close button only when onCancel (onClose) is wired.
  * Item 11: in compose ("New") mode with ZERO associations the "Related to" section still renders
  *   the "Link another record" affordance (reads "Link a record" in the empty state) and invoking
  *   it calls the host's onAddRelationship.
@@ -26,19 +31,23 @@ function renderComposer(overrides: Partial<IEmailComposerProps>) {
   );
 }
 
-describe('EmailComposer — chromed header window controls (R2 item 8)', () => {
-  it('renders the maximize control but NOT a close X in the header', () => {
-    renderComposer({ onToggleMaximize: jest.fn(), onCancel: jest.fn() });
+describe('EmailComposer — standard modal window controls (item 4, supersedes R2 item 8)', () => {
+  it('renders BOTH the maximize control and a close X in the header, and close calls onCancel', () => {
+    const onCancel = jest.fn();
+    renderComposer({ onToggleMaximize: jest.fn(), onCancel });
     expect(screen.getByRole('button', { name: /maximize dialog/i })).toBeInTheDocument();
-    // The close 'X' was removed — the modal is closed via the action-bar Cancel button.
-    expect(screen.queryByRole('button', { name: /close dialog/i })).toBeNull();
+    const closeBtn = screen.getByRole('button', { name: /^close$/i });
+    expect(closeBtn).toBeInTheDocument();
+    // The header close routes to the SAME onCancel the action-bar Cancel button uses.
+    fireEvent.click(closeBtn);
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  it('renders no header window-control cluster when only onCancel is wired (no maximize)', () => {
+  it('renders the close X (but no maximize) when only onCancel is wired', () => {
     renderComposer({ onCancel: jest.fn() });
     expect(screen.queryByRole('button', { name: /maximize dialog/i })).toBeNull();
-    expect(screen.queryByRole('button', { name: /close dialog/i })).toBeNull();
-    // onCancel still reaches the action-bar Cancel button.
+    expect(screen.getByRole('button', { name: /^close$/i })).toBeInTheDocument();
+    // onCancel still also reaches the action-bar Cancel button.
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 });

--- a/src/client/shared/Spaarke.UI.Components/src/components/ModalWindowControls/ModalWindowControls.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/ModalWindowControls/ModalWindowControls.tsx
@@ -1,0 +1,74 @@
+/**
+ * ModalWindowControls — the standard Spaarke modal window-controls cluster:
+ * a maximize/restore toggle and a close (×), right-aligned in a dialog header
+ * (owner UAT 2026-07-31 item 4 — "we are standardizing to use the expand/collapse
+ * buttons and 'x' on all modals; these should be in the shared UI components").
+ *
+ * Context-agnostic (ADR-012): the host owns surface sizing (`isMaximized` +
+ * `onToggleMaximize`) and lifecycle (`onClose`); this component only renders the
+ * two affordances and calls back. Either handler may be omitted — a modal that
+ * cannot be maximized passes only `onClose`, and vice-versa; when both are absent
+ * the cluster renders nothing. Fluent v9 semantic tokens only (ADR-021).
+ */
+import * as React from 'react';
+import { Button, makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
+import { ArrowMaximize20Regular, ArrowMinimize20Regular, Dismiss20Regular } from '@fluentui/react-icons';
+
+export interface IModalWindowControlsProps {
+  /** Current maximized state — flips the toggle icon + label between maximize and restore. */
+  isMaximized?: boolean;
+  /** Toggle maximize/restore. Omit → no maximize button (a non-resizable modal). */
+  onToggleMaximize?: () => void;
+  /** Close the modal. Omit → no close button. */
+  onClose?: () => void;
+  /** Optional extra class on the cluster wrapper. */
+  className?: string;
+}
+
+const useStyles = makeStyles({
+  cluster: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXXS,
+    flexShrink: 0,
+  },
+});
+
+/**
+ * The standard maximize/restore + close cluster for Spaarke modals. Render it in
+ * the upper-right of a dialog header (e.g. via `justify-content: space-between`
+ * with the title on the left).
+ */
+export const ModalWindowControls: React.FC<IModalWindowControlsProps> = ({
+  isMaximized,
+  onToggleMaximize,
+  onClose,
+  className,
+}) => {
+  const styles = useStyles();
+  if (!onToggleMaximize && !onClose) return null;
+  return (
+    <div className={mergeClasses(styles.cluster, className)}>
+      {onToggleMaximize && (
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={isMaximized ? <ArrowMinimize20Regular /> : <ArrowMaximize20Regular />}
+          aria-label={isMaximized ? 'Restore dialog size' : 'Maximize dialog'}
+          onClick={() => onToggleMaximize()}
+        />
+      )}
+      {onClose && (
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={<Dismiss20Regular />}
+          aria-label="Close"
+          onClick={() => onClose()}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ModalWindowControls;

--- a/src/client/shared/Spaarke.UI.Components/src/components/ModalWindowControls/__tests__/ModalWindowControls.test.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/ModalWindowControls/__tests__/ModalWindowControls.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * ModalWindowControls.test.tsx — the shared standard modal window controls
+ * (owner UAT 2026-07-31 item 4). Verifies each affordance renders only when its
+ * handler is wired, that the maximize icon/label flips on `isMaximized`, and that
+ * clicks call back.
+ */
+import * as React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../__mocks__/pcfMocks';
+import { ModalWindowControls } from '../ModalWindowControls';
+
+describe('ModalWindowControls (item 4 — standard modal chrome)', () => {
+  it('renders both maximize and close when both handlers are wired, and calls back on click', () => {
+    const onToggleMaximize = jest.fn();
+    const onClose = jest.fn();
+    renderWithProviders(<ModalWindowControls onToggleMaximize={onToggleMaximize} onClose={onClose} />);
+
+    const maximize = screen.getByRole('button', { name: /maximize dialog/i });
+    const close = screen.getByRole('button', { name: /^close$/i });
+    expect(maximize).toBeInTheDocument();
+    expect(close).toBeInTheDocument();
+
+    fireEvent.click(maximize);
+    fireEvent.click(close);
+    expect(onToggleMaximize).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the restore label when maximized', () => {
+    renderWithProviders(<ModalWindowControls isMaximized onToggleMaximize={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.getByRole('button', { name: /restore dialog size/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /maximize dialog/i })).toBeNull();
+  });
+
+  it('renders only the close button when maximize is not wired', () => {
+    renderWithProviders(<ModalWindowControls onClose={jest.fn()} />);
+    expect(screen.queryByRole('button', { name: /maximize dialog/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /^close$/i })).toBeInTheDocument();
+  });
+
+  it('renders nothing when neither handler is wired', () => {
+    const { container } = renderWithProviders(<ModalWindowControls />);
+    expect(container.querySelector('button')).toBeNull();
+  });
+});

--- a/src/client/shared/Spaarke.UI.Components/src/components/ModalWindowControls/index.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/ModalWindowControls/index.ts
@@ -1,0 +1,2 @@
+export { ModalWindowControls, default } from './ModalWindowControls';
+export type { IModalWindowControlsProps } from './ModalWindowControls';

--- a/src/client/shared/Spaarke.UI.Components/src/components/index.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/index.ts
@@ -248,6 +248,11 @@ export * from './MessageQuickView';
 // omitted — the shipped endpoint persists neither (§6.5 Path A, see task-024 notes).
 export * from './NewThreadModal';
 
+// ModalWindowControls - the standard Spaarke modal window-controls cluster
+// (maximize/restore + close ×), right-aligned in a dialog header. Shared so all
+// modals standardize on the same chrome (owner UAT 2026-07-31 item 4).
+export * from './ModalWindowControls';
+
 // TrackingFieldTrio - Entity-agnostic Monitor/High-Priority/Access-Permission
 // flag trio, lifted from the TrackingFieldTrio PCF (task 023, FR-14). Options
 // (segments + field labels) are injected via props — no `sprk_communication`


### PR DESCRIPTION
## Summary
Owner UAT round 3 on the Email surface (4 items), plus the durability fix for the shared-web-resource clobber.

- **Item 1** — Confirmed "Related to" chip now shows the real record type (**"Matter:"** not "Record:") + matching tooltip. Root cause: primary filed via denorm fields only (typed lookups null) → generic branch. Threads `sprk_regardingrecordtype` FormattedValue through as `PrimaryCandidate.typeLabel`.
- **Item 2** — Confirmed association can now be **deleted** (not just replaced). New `clearPrimaryRegarding` nulls the 5 denorm fields + `sprk_RegardingRecordType` + resets `sprk_associationstatus`; plain `unlinkRegarding` only nulled a typed lookup (which a denorm-only primary lacks → silent no-op).
- **Item 3** — Reading-pane "Link another record" card: fixed Arial font (native `<button>` doesn't inherit font-family → `fontFamily: inherit`) and unified card heights (72px) so all four cards align.
- **Item 4** — New shared `ModalWindowControls` (maximize/restore + close ×) in `@spaarke/ui-components`, wired into the composer header **upper-right**. Standardizes modal chrome; supersedes the R2 "remove X" decision per owner. Close routes to `onCancel`.

## Verification
- `tsc --noEmit` clean: Spaarke.UI.Components + Spaarke.Communication.Components
- Jest green: `uatR2Chrome` 4/4, `EmailAssociationsAndTracking` 14/14, `ModalWindowControls` 4/4, `clearPrimaryAndTypeLabel` 3/3
- Deployed + structurally verified server-side on spaarkedev1 (`sprk_spaarkeai` + `sprk_emailpage`)

## Clobber note
The two prior R3 fixes were clobbered on the shared `sprk_spaarkeai` web resource by a parallel worktree's redeploy ~8 min post-deploy. Merging to master makes the shared-resource baseline durable.

## Conflict resolution
None expected — additive changes on shared email components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)