### PR TITLE
email-r5: UAT R3.2 — state-driven resolver card set

### DIFF
--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/EmailConnectionsReview.tsx
@@ -44,7 +44,6 @@ import {
   derivePrimaryReview,
   applyRegardingSelection,
   advanceAssociationStatus,
-  PRIMARY_CANDIDATE_SLOTS,
   type PrimaryCandidate,
 } from '../../logic/connections';
 import type { EmailConnectionsReviewProps } from './EmailAssociationsAndTracking.types';
@@ -108,6 +107,9 @@ export function EmailConnectionsReview(props: EmailConnectionsReviewProps): Reac
   const greenKey = model.primary ? candidateKey(model.primary) : undefined;
   const confirmedKey = model.state === 'confirmed' && model.primary ? candidateKey(model.primary) : undefined;
   const activeSelectedKey = selectedKey ?? greenKey;
+  // Confirmed → the primary is the header chip, so the cards row shows ONLY the
+  // "Link another record" tile (owner UAT 2026-07-31).
+  const isConfirmed = model.state === 'confirmed';
 
   const confirmCandidate = React.useCallback(
     async (c: PrimaryCandidate): Promise<void> => {
@@ -176,31 +178,40 @@ export function EmailConnectionsReview(props: EmailConnectionsReviewProps): Reac
         </MessageBar>
       )}
 
-      {/* Candidate cards + the "Link another record" tile share ONE grid, so the
-          link tile sits directly AFTER the last card (owner UAT). Always render the
-          fixed candidate-slot count; a slot is blank below 70%. */}
+      {/* Candidate cards + the "Link another record" tile share ONE grid, so the link
+          tile sits directly AFTER the last card. Card set depends on state (owner UAT
+          2026-07-31):
+            • confirmed  → NO candidate cards (the confirmed record is the header chip);
+              only "Link another record" shows.
+            • has matches → only the actual candidate cards (no "No confident match"
+              filler slots).
+            • no matches → a single "No confident match" card.
+          The "Link another record" tile renders in every non-read-only state. */}
       <div className={s.cards}>
-        {Array.from({ length: PRIMARY_CANDIDATE_SLOTS }, (_, i) => {
-          const c = model.candidates[i];
-          if (!c) return <BlankCard key={`blank-${i}`} s={s} />;
-          const k = candidateKey(c);
-          const isGreen = k === greenKey;
-          const isSelected = k === activeSelectedKey;
-          return (
-            <CandidateCard
-              key={k}
-              candidate={c}
-              selected={isSelected || isGreen}
-              tone={isGreen ? 'primary' : 'select'}
-              showConfirm={isSelected && k !== confirmedKey}
-              busy={busy}
-              readOnly={readOnly}
-              onSelect={() => setSelectedKey(k)}
-              onConfirm={() => void confirmCandidate(c)}
-              s={s}
-            />
-          );
-        })}
+        {!isConfirmed &&
+          (model.candidates.length > 0 ? (
+            model.candidates.map(c => {
+              const k = candidateKey(c);
+              const isGreen = k === greenKey;
+              const isSelected = k === activeSelectedKey;
+              return (
+                <CandidateCard
+                  key={k}
+                  candidate={c}
+                  selected={isSelected || isGreen}
+                  tone={isGreen ? 'primary' : 'select'}
+                  showConfirm={isSelected && k !== confirmedKey}
+                  busy={busy}
+                  readOnly={readOnly}
+                  onSelect={() => setSelectedKey(k)}
+                  onConfirm={() => void confirmCandidate(c)}
+                  s={s}
+                />
+              );
+            })
+          ) : (
+            <BlankCard key="blank" s={s} />
+          ))}
 
         {/* Link another record — a tile that is a VISUAL SIBLING of the candidate
             cards (owner UAT #5). A SINGLE click opens the record-type dropdown

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/__tests__/EmailAssociationsAndTracking.test.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailAssociationsAndTracking/__tests__/EmailAssociationsAndTracking.test.tsx
@@ -206,7 +206,7 @@ describe('EmailConnectionsReview (single-primary redesign 2026-07-29)', () => {
     expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
   });
 
-  it('CONFIRMED: a Resolved + filed primary renders its card but NO Confirm (the chip + Remove live in the section header)', () => {
+  it('CONFIRMED: shows ONLY the "Link another record" tile — no candidate cards or blank slots (the chip lives in the section header) (owner UAT 2026-07-31)', () => {
     renderWithProvider(
       <EmailConnectionsReview
         {...baseProps({
@@ -222,8 +222,37 @@ describe('EmailConnectionsReview (single-primary redesign 2026-07-29)', () => {
       />
     );
 
-    expect(screen.getByRole('radio', { name: /Acme v Beta/ })).toBeInTheDocument();
+    // Confirmed → the primary is the section-header chip (rendered by the parent), so
+    // the cards row shows NO candidate card, no Confirm, and no "No confident match".
+    expect(screen.queryByRole('radio', { name: /Acme v Beta/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/No confident match/i)).not.toBeInTheDocument();
+    // Only the link tile remains.
+    expect(screen.getByRole('button', { name: /Link another record/i })).toBeInTheDocument();
+  });
+
+  it('HAS MATCHES: renders only the actual candidate cards + Link tile — NO "No confident match" fillers (owner UAT 2026-07-31)', () => {
+    renderWithProvider(
+      <EmailConnectionsReview
+        {...baseProps({
+          associationProvenanceJson: provenance([
+            cand('sprk_regardingmatter', 'sprk_matter', 'mtr-1', 'Acme v Beta', 0.95, { number: 'MAT-1' }),
+          ]),
+        })}
+      />
+    );
+
+    expect(screen.getByRole('radio', { name: /Acme v Beta/ })).toBeInTheDocument();
+    // A single match → no blank filler slots padding the row to a fixed count.
+    expect(screen.queryByText(/No confident match/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Link another record/i })).toBeInTheDocument();
+  });
+
+  it('NO MATCHES: renders a single "No confident match" card + the Link tile (owner UAT 2026-07-31)', () => {
+    renderWithProvider(<EmailConnectionsReview {...baseProps({ associationProvenanceJson: provenance([]) })} />);
+
+    expect(screen.getAllByText(/No confident match/i)).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /Link another record/i })).toBeInTheDocument();
   });
 
   it('offers a "Link another record" tile (interactive) and hides it in readOnly', () => {


### PR DESCRIPTION
## Summary
Owner UAT 2026-07-31 — the reading-pane "Related to" cards row now reflects state instead of always padding to 3 fixed slots:
- **Confirmed** → only the "Link another record" tile (the confirmed record is the section-header chip).
- **Has matches** → only the actual candidate cards + Link tile (no "No confident match" filler slots).
- **No matches** → a single "No confident match" card + Link tile.

## Verification
- `tsc` clean (Spaarke.Communication.Components)
- Jest: `EmailAssociationsAndTracking` 16/16 (updated CONFIRMED test + added HAS-MATCHES / NO-MATCHES cases)
- Deployed + published on spaarkedev1 (`sprk_spaarkeai` + `sprk_emailpage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)