### PR TITLE
email-r5: UAT R3.3 — compose Related-to is an in-memory multi-association list

### DIFF
--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
@@ -65,7 +65,6 @@ import type { CommunicationSendMode } from '../../services/communicationApi';
 import { ModalWindowControls } from '../ModalWindowControls';
 
 import { sendCommunication, SendCommunicationError } from '../../services/communicationApi';
-import type { ICommunicationAssociation } from '../../services/communicationApi';
 
 import {
   emailComposerReducer,
@@ -190,16 +189,6 @@ function isSafeHref(url: string): boolean {
 /** Escape a plain string for safe interpolation into HTML (record-link label/href). */
 function escapeHtml(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
-/**
- * Humanizes a Dataverse logical entity name for display (e.g. `sprk_matter` → `Matter`) — used
- * as the replace-confirm's fallback when the current primary association has no `entityName`.
- * Mirrors the same helper in `AssociationChips.tsx`.
- */
-function humanizeEntityType(entityType: string): string {
-  const stripped = entityType.startsWith('sprk_') ? entityType.slice(5) : entityType;
-  return stripped.charAt(0).toUpperCase() + stripped.slice(1);
 }
 
 // ---------------------------------------------------------------------------
@@ -459,7 +448,6 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
   // Single-primary "Related to" model (owner UAT 2026-07-30, item 8): a freshly-picked record is
   // NOT appended silently — it is held here pending a "set as primary regarding?" confirmation.
   // Non-null → the replace-confirm Dialog is open. Confirming promotes it to associations[0].
-  const [pendingPrimary, setPendingPrimary] = React.useState<ICommunicationAssociation | null>(null);
 
   // Compose template picker (Wave E, owner UAT 2026-07-30). Templates load lazily when the
   // menu opens; picking one whose apply would overwrite existing subject/body prompts a confirm.
@@ -542,12 +530,12 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
     [state.attachments.length]
   );
 
-  // "Link another record" → pick a record via the host polymorphic picker, then CONFIRM it as the
-  // primary regarding (owner UAT 2026-07-30, item 8). The pick is NOT appended silently: it is
-  // staged in `pendingPrimary`, which opens a "set as primary regarding?" replace-confirm Dialog.
-  // On confirm the record becomes associations[0] (the BFF maps associations[0] as the primary
-  // regarding at send time — CLIENT-ONLY ordering, no new send field). On cancel the pick is
-  // discarded (nothing added).
+  // "Link another record" → pick a record via the host polymorphic picker and APPEND it to the
+  // in-memory "Related to" list (owner UAT 2026-07-31). No record exists yet in compose/reply/
+  // forward, so associations are held in reducer state and ride the send payload; the user can add
+  // SEVERAL and remove any (the chip ×). `ADD_ASSOCIATION` dedups on entityType+entityId. The BFF
+  // maps associations[0] as the primary regarding at send time (CLIENT-ONLY ordering). No
+  // replace-confirm — adding is additive, not a single-primary swap.
   const onAddRelationship = props.onAddRelationship;
   const handleAddRelationship = React.useCallback(() => {
     if (!onAddRelationship) return;
@@ -555,22 +543,18 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
     void onAddRelationship()
       .then(picked => {
         if (!picked) return;
-        setPendingPrimary({
-          entityType: picked.entityType,
-          entityId: picked.id,
-          entityName: picked.name,
-          entityUrl: picked.url,
+        dispatch({
+          type: 'ADD_ASSOCIATION',
+          association: {
+            entityType: picked.entityType,
+            entityId: picked.id,
+            entityName: picked.name,
+            entityUrl: picked.url,
+          },
         });
       })
       .catch(err => console.warn('[EmailComposer] add relationship failed:', err));
   }, [onAddRelationship]);
-
-  const confirmPrimary = React.useCallback(() => {
-    if (pendingPrimary) dispatch({ type: 'SET_PRIMARY_ASSOCIATION', association: pendingPrimary });
-    setPendingPrimary(null);
-  }, [pendingPrimary]);
-
-  const cancelPrimary = React.useCallback(() => setPendingPrimary(null), []);
 
   // ── Attach-on-compose: local-file → Document resolution (task 042 / FR-20) ──
   // A picked local file (already passed the CHAT-ATTACHMENT-POLICY 25 MB + MIME
@@ -1132,13 +1116,13 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
         />
       </div>
 
-      {/* Related to — what this email is associated to (owner UAT 2026-07-24). Single-primary
-          model (owner UAT 2026-07-30, item 8): the label, the chips (index 0 is the GREEN
-          PRIMARY regarding), and the "Link another record" affordance flow on ONE wrapping row.
-          "Link another record" opens a replace-confirm before promoting a pick to primary.
-          Owner UAT 2026-07-30 R2 items 10 + 11: the "Link another record" tile renders INLINE with
-          the chips, and the section shows whenever the host can add a relationship (`canLinkRecord`)
-          — even in compose/New mode with ZERO associations, so the user can add the first regarding. */}
+      {/* Related to — what this email is associated to. In compose/reply/forward NO record exists
+          yet, so associations are held IN MEMORY (reducer state) and ride the send payload (owner
+          UAT 2026-07-31). The user can ADD several via "Link another record" (each pick is appended,
+          deduped) and REMOVE any via the chip ×. Index 0 is the GREEN primary regarding (the BFF
+          maps associations[0] onto sprk_regardingrecord* at send). The label, chips, and the "Link
+          another record" tile flow on ONE wrapping row; the tile renders whenever the host can add a
+          relationship (`canLinkRecord`) — even with ZERO associations, so the first can be added. */}
       {(showAssociations || canLinkRecord) && (
         <div className={styles.section} role="region" aria-label="Related to">
           <div className={styles.relatedRow}>
@@ -1190,39 +1174,6 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
           </div>
         </div>
       )}
-
-      {/* Replace-confirm for the single-primary regarding (owner UAT 2026-07-30, item 8). Opens
-          when a record is picked via "Link another record". The second line renders ONLY when a
-          primary already exists (state.associations.length > 0) — the empty state has nothing to
-          replace. Confirm → promote to associations[0]; Cancel → discard the pick. */}
-      <Dialog
-        open={pendingPrimary !== null}
-        onOpenChange={(_e, data) => {
-          if (!data.open) cancelPrimary();
-        }}
-      >
-        <DialogSurface>
-          <DialogBody>
-            <DialogTitle>Set as primary regarding record</DialogTitle>
-            <DialogContent>
-              {state.associations.length > 0 && (
-                <Text>
-                  Will replace the currently selected record:{' '}
-                  {state.associations[0].entityName ?? humanizeEntityType(state.associations[0].entityType)}
-                </Text>
-              )}
-            </DialogContent>
-            <DialogActions>
-              <Button appearance="primary" onClick={confirmPrimary}>
-                Set as primary
-              </Button>
-              <Button appearance="secondary" onClick={cancelPrimary}>
-                Cancel
-              </Button>
-            </DialogActions>
-          </DialogBody>
-        </DialogSurface>
-      </Dialog>
 
       {/* Template overwrite confirm (Wave E) — only shown when applying would replace
           existing subject/body. modalType="alert" disables light-dismiss so a stray click

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/relatedPrimary.test.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/relatedPrimary.test.tsx
@@ -1,24 +1,23 @@
 /**
- * relatedPrimary.test.tsx — owner UAT 2026-07-30 (item 8): single-primary "Related to".
+ * relatedPrimary.test.tsx — compose "Related to" is an IN-MEMORY, MULTI-association list
+ * (owner UAT 2026-07-31 — supersedes the R2 single-primary replace-confirm).
  *
- * The "Related to" section models a SINGLE primary regarding record (associations[0], which the
- * BFF maps onto sprk_regardingrecord* at send time). Picking a record via "Link another record"
- * does NOT append silently — it opens a "set as primary regarding?" replace-confirm Dialog. On
- * confirm the pick is promoted to associations[0] (the GREEN primary chip); on cancel it is
- * discarded. This exercises the render/interaction wiring end-to-end (the reducer transition
- * itself is covered in EmailComposer.reducer.test.ts).
+ * No `sprk_communication` record exists yet in compose/reply/forward, so associations live in
+ * reducer state and ride the send payload. "Link another record" APPENDS each pick (deduped by
+ * entityType+entityId); the chip × REMOVES one. index 0 is the primary the BFF maps onto
+ * sprk_regardingrecord* at send. There is NO replace-confirm dialog anymore.
  */
 import * as React from 'react';
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../../__mocks__/pcfMocks';
 import { EmailComposer } from '../EmailComposer';
 import type { ICommunicationAssociation } from '../../../services/communicationApi';
-import type { IEmailComposerProps, IPickedRecord } from '../EmailComposer.types';
+import type { IEmailComposerProps, IPickedRecord, IEmailComposerHandle } from '../EmailComposer.types';
 
 const noopFetch = jest.fn();
 
 function renderComposer(overrides: Partial<IEmailComposerProps>) {
-  const ref = React.createRef<import('../EmailComposer.types').IEmailComposerHandle>();
+  const ref = React.createRef<IEmailComposerHandle>();
   const utils = renderWithProviders(
     <EmailComposer
       ref={ref}
@@ -31,67 +30,62 @@ function renderComposer(overrides: Partial<IEmailComposerProps>) {
   return { ref, ...utils };
 }
 
-describe('EmailComposer — single-primary "Related to" replace-confirm (item 8)', () => {
-  const existingPrimary: ICommunicationAssociation = {
+describe('EmailComposer — in-memory multi "Related to" (owner UAT 2026-07-31)', () => {
+  const existing: ICommunicationAssociation = {
     entityType: 'sprk_matter',
     entityId: 'm-old',
     entityName: 'Old Matter',
   };
+  const second: ICommunicationAssociation = { entityType: 'sprk_matter', entityId: 'm-2', entityName: 'Second Matter' };
   const picked: IPickedRecord = { entityType: 'sprk_matter', id: 'm-new', name: 'New Matter' };
 
-  it('picking a record opens the replace-confirm, and confirming promotes it to the GREEN primary', async () => {
+  it('shows the "Link another record" tile even when an association already exists', () => {
+    renderComposer({ associations: [existing], onAddRelationship: jest.fn().mockResolvedValue(null) });
+    expect(screen.getByRole('button', { name: /link another record/i })).toBeInTheDocument();
+  });
+
+  it('picking a record APPENDS it to the in-memory list (both kept, no replace-confirm)', async () => {
     const onAddRelationship = jest.fn().mockResolvedValue(picked);
-    const { ref, container } = renderComposer({ associations: [existingPrimary], onAddRelationship });
+    const { ref } = renderComposer({ associations: [existing], onAddRelationship });
 
-    // Existing primary is rendered as the green (data-primary) chip.
-    expect(container.querySelector('[data-primary="true"]')?.textContent).toContain('Old Matter');
-
-    // Pick another record via "Link another record".
     fireEvent.click(screen.getByRole('button', { name: /link another record/i }));
 
-    // The replace-confirm Dialog opens and names the CURRENT primary it will replace.
-    await screen.findByText('Set as primary regarding record');
-    const replaceLine = screen.getByText(/Will replace the currently selected record/);
-    expect(replaceLine.textContent).toContain('Old Matter');
-
-    // Confirm → the pick becomes the primary (index 0); the old primary is dropped.
-    fireEvent.click(screen.getByRole('button', { name: 'Set as primary' }));
-
-    await waitFor(() => {
-      const primary = container.querySelector('[data-primary="true"]');
-      expect(primary?.textContent).toContain('New Matter');
-    });
-    // Single-primary model: the old primary was replaced, not kept.
-    const associations = ref.current?.getState().associations ?? [];
-    expect(associations).toHaveLength(1);
-    expect(associations[0].entityId).toBe('m-new');
+    await waitFor(() => expect(ref.current?.getState().associations).toHaveLength(2));
+    const ids = (ref.current?.getState().associations ?? []).map(a => a.entityId);
+    expect(ids).toEqual(['m-old', 'm-new']); // appended; the existing one is NOT replaced
+    expect(screen.queryByText(/Set as primary/i)).not.toBeInTheDocument();
     expect(ref.current?.getState().isDirty).toBe(true);
   });
 
-  it('cancelling the confirm discards the pick (nothing added)', async () => {
-    const onAddRelationship = jest.fn().mockResolvedValue(picked);
-    const { ref } = renderComposer({ associations: [existingPrimary], onAddRelationship });
+  it('the chip × removes that association from the in-memory list', async () => {
+    const { ref } = renderComposer({ associations: [existing, second], onAddRelationship: jest.fn() });
+    expect(ref.current?.getState().associations).toHaveLength(2);
 
-    fireEvent.click(screen.getByRole('button', { name: /link another record/i }));
-    await screen.findByText('Set as primary regarding record');
-    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getAllByLabelText('Remove')[0]);
 
-    await waitFor(() => {
-      expect(screen.queryByText('Set as primary regarding record')).not.toBeInTheDocument();
-    });
-    const associations = ref.current?.getState().associations ?? [];
-    expect(associations).toHaveLength(1);
-    expect(associations[0].entityId).toBe('m-old'); // unchanged
+    await waitFor(() => expect(ref.current?.getState().associations).toHaveLength(1));
+    expect(ref.current?.getState().associations[0].entityId).toBe('m-2');
   });
 
-  it('empty state: no primary yet → the confirm omits the "will replace" line', async () => {
+  it('empty state reads "Link a record" and appends the first pick', async () => {
     const onAddRelationship = jest.fn().mockResolvedValue(picked);
-    renderComposer({ associations: [], onAddRelationship });
+    const { ref } = renderComposer({ associations: [], onAddRelationship });
 
-    // With no associations the affordance reads "Link a record".
     fireEvent.click(screen.getByRole('button', { name: /link a record/i }));
-    await screen.findByText('Set as primary regarding record');
-    // Nothing to replace → no replace line.
-    expect(screen.queryByText(/Will replace the currently selected record/)).not.toBeInTheDocument();
+
+    await waitFor(() => expect(ref.current?.getState().associations).toHaveLength(1));
+    expect(ref.current?.getState().associations[0].entityId).toBe('m-new');
+  });
+
+  it('appending the SAME record twice dedups (no duplicate)', async () => {
+    const onAddRelationship = jest.fn().mockResolvedValue(picked);
+    const { ref } = renderComposer({ associations: [], onAddRelationship });
+
+    fireEvent.click(screen.getByRole('button', { name: /link a record/i }));
+    await waitFor(() => expect(ref.current?.getState().associations).toHaveLength(1));
+
+    fireEvent.click(screen.getByRole('button', { name: /link another record/i }));
+    await waitFor(() => expect(onAddRelationship).toHaveBeenCalledTimes(2));
+    expect(ref.current?.getState().associations).toHaveLength(1); // deduped
   });
 });


### PR DESCRIPTION
## Summary
Owner UAT 2026-07-31 — in compose/reply/forward there was no clear way to add/change the "Related to" record. No `sprk_communication` exists yet, so associations are held in memory (reducer state) and ride the send payload.

- "Link another record" now **appends** each pick (`ADD_ASSOCIATION`, deduped) — relate an email to several records — instead of the single-primary **replace-confirm** dialog.
- The chip × removes any association (already in-memory).
- Removed the "Set as primary regarding" confirm dialog + `pendingPrimary` state + unused `humanizeEntityType`.
- `associations[0]` stays the primary the BFF maps at send.

## Verification
- `tsc` + `eslint` clean (only 2 pre-existing exhaustive-deps warnings)
- Jest: `relatedPrimary` 5/5 (rewritten for multi-add + tile-visibility + chip-remove + dedup), `uatR2Chrome` + reducer 48/48
- Deployed + verified server-side ("Set as primary" gone) on spaarkedev1

🤖 Generated with [Claude Code](https://claude.com/claude-code)