### PR TITLE
email-r5: UAT R3.4 — wire compose handlers in LegalWorkspace email section (widget parity)

### DIFF
--- a/src/solutions/LegalWorkspace/src/sections/email.registration.ts
+++ b/src/solutions/LegalWorkspace/src/sections/email.registration.ts
@@ -48,6 +48,9 @@ import {
   XrmDataverseClient,
   createXrmDataService,
   createXrmNavigationService,
+  createXrmEmailComposeHandlers,
+  resolveCurrentUserEmail,
+  searchUsersAndContacts,
   getXrm,
 } from "@spaarke/ui-components";
 import { EmailWorkspace } from "@spaarke/communication-components";
@@ -79,6 +82,34 @@ const EmailSectionMount: React.FC<EmailSectionMountProps> = ({ bffBaseUrl }) => 
   // PCF host passes as `context.webAPI`.
   const webApi = React.useMemo(() => getXrm()?.WebApi, []);
 
+  // Composer parity wiring — WITHOUT these the compose modal (reply/forward/new)
+  // loses recipient lookup, the "Related to" Link-another-record tile, templates,
+  // the AI sparkle, and send-time share links. The standalone EmailPage code page
+  // wires the SAME handlers; this section mount must match so BOTH surfaces behave
+  // identically (owner UAT 2026-07-31 — widget-vs-code-page parity).
+  const composeHandlers = React.useMemo(
+    () => createXrmEmailComposeHandlers({ authenticatedFetch, bffBaseUrl: bffBaseUrl || undefined }),
+    [bffBaseUrl],
+  );
+  const handleSearchRecipients = React.useCallback(
+    (query: string) => searchUsersAndContacts(dataService, query),
+    [dataService],
+  );
+  const dataverseUrl = React.useMemo(
+    () => getXrm()?.Utility?.getGlobalContext?.()?.getClientUrl?.() ?? "",
+    [],
+  );
+  const [fromMailbox, setFromMailbox] = React.useState<string | undefined>();
+  React.useEffect(() => {
+    let cancelled = false;
+    void resolveCurrentUserEmail().then((email) => {
+      if (!cancelled) setFromMailbox(email);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   if (!webApi) {
     // No Dataverse host available. EmailWorkspace's required host props
     // cannot be resolved — fail closed rather than mount a partially-wired
@@ -94,6 +125,18 @@ const EmailSectionMount: React.FC<EmailSectionMountProps> = ({ bffBaseUrl }) => 
     webApi,
     authenticatedFetch,
     bffBaseUrl,
+    onSearchRecipients: handleSearchRecipients,
+    onLookupRecipients: composeHandlers.onLookupRecipients,
+    recordLookupCatalog: composeHandlers.recordLookupCatalog,
+    onLookupRecord: composeHandlers.onLookupRecord,
+    onAddRelationship: composeHandlers.onAddRelationship,
+    onUploadLocalAttachment: composeHandlers.onUploadLocalAttachment,
+    onResolveShareLink: composeHandlers.onResolveShareLink,
+    onListEmailTemplates: composeHandlers.onListEmailTemplates,
+    onRenderEmailTemplate: composeHandlers.onRenderEmailTemplate,
+    onDraftWithAi: composeHandlers.onDraftWithAi,
+    fromMailbox,
+    dataverseUrl,
   });
 };
 


### PR DESCRIPTION
## Summary
Owner UAT 2026-07-31 — the compose modal behaved differently in the SpaarkeAi **widget** vs the EmailPage **code page**: the widget had no "Link another record" tile (and lacked recipient lookup / templates / AI / share links in compose).

**Root cause**: SpaarkeAi renders the Email tab via the LegalWorkspace `email` **section** (`email.registration.ts`), whose mount forwarded only the data adapters to `EmailWorkspace` — never the compose handlers. The EmailPage code page wired them, so only it worked.

**Fix**: `EmailSectionMount` now builds `createXrmEmailComposeHandlers` + recipient search + current-user mailbox + dataverse URL and forwards all compose props (`onAddRelationship`, `onLookupRecord`, `onListEmailTemplates`, `onRenderEmailTemplate`, `onDraftWithAi`, `onResolveShareLink`, `onUploadLocalAttachment`, `onSearchRecipients`, `onLookupRecipients`, `recordLookupCatalog`, `fromMailbox`, `dataverseUrl`) — mirroring `EmailWorkspaceWidget` + EmailPage so all three mounts behave identically (dual-mount parity, NFR-06).

## Verification
- SpaarkeAi vite build clean; `email.registration.ts` tsc-clean
- Deployed to spaarkedev1 (`sprk_spaarkeai`) — `onAddRelationship` prop wiring 9 → 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)