### PR TITLE
email-r5: UAT R3.5 — single-record email open hides all list chrome

### DIFF
--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/EmailWorkspace.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/EmailWorkspace.tsx
@@ -311,15 +311,21 @@ export const EmailWorkspace: React.FC<EmailWorkspaceProps> = ({
 
   return (
     <div className={s.root} data-testid="email-workspace">
-      <div className={s.viewSelectorRow}>
-        <EmailViewSelector
-          views={views}
-          activeViewId={selectedViewId}
-          onViewChange={setSelectedViewId}
-          isLoading={isLoading}
-          error={error}
-        />
-      </div>
+      {/* Single-record ("form") mode hides the whole list chrome — both the card list
+          AND this view-selector row ("All Incoming Email") — so opening one email via
+          `openEmailRecord(id, { single: true })` reads as a clean single email, not the
+          list+reading workspace (owner UAT 2026-07-31). List mode renders it unchanged. */}
+      {!hideListPane && (
+        <div className={s.viewSelectorRow}>
+          <EmailViewSelector
+            views={views}
+            activeViewId={selectedViewId}
+            onViewChange={setSelectedViewId}
+            isLoading={isLoading}
+            error={error}
+          />
+        </div>
+      )}
 
       <div className={s.body}>
         <EmailReadingPaneShell

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/__tests__/EmailWorkspace.test.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailWorkspace/__tests__/EmailWorkspace.test.tsx
@@ -172,6 +172,22 @@ describe('EmailWorkspace', () => {
     expect(screen.queryByText('Select an email')).not.toBeInTheDocument();
   });
 
+  it('single-record mode (hideList + id) hides ALL list chrome — the list pane AND the view-selector row — so it reads as one email, not the workspace (owner UAT 2026-07-31)', async () => {
+    renderWorkspace({ hideList: true, initialSelectedId: COMMUNICATION_ID });
+
+    // The reading pane still renders the pre-selected email...
+    expect(await screen.findByTestId('email-reading-pane')).toBeInTheDocument();
+    // ...but the list chrome is gone: no card list AND no "Email — Inbox" view selector.
+    expect(screen.queryByTestId('email-list-pane')).not.toBeInTheDocument();
+    expect(screen.queryByText('Email — Inbox')).not.toBeInTheDocument();
+  });
+
+  it('list mode still renders the view-selector row (regression guard for the single-mode hide)', async () => {
+    renderWorkspace();
+    expect(await screen.findByText('Email — Inbox')).toBeInTheDocument();
+    expect(await screen.findByTestId('email-list-pane')).toBeInTheDocument();
+  });
+
   it('auto-selects the FIRST of several rows and drives the per-selection read for it (owner UAT R2 item 3)', async () => {
     const ROW_A = {
       ...VIEW_ROW,


### PR DESCRIPTION
## Summary
Owner UAT 2026-07-31 — opening one email via `openEmailRecord(id, { single: true })` still showed the "All Incoming Email" view-selector row, so it read as the whole Email Workspace, not a single email. The list pane was already hidden in single mode; now the view-selector row is too. List mode unchanged.

## Verification
- `tsc` clean; `EmailWorkspace.test` 12/12 (added single-mode hides-list-chrome + list-mode regression guard)
- Deployed to spaarkedev1 (`sprk_spaarkeai` + `sprk_emailpage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)