### PR TITLE
email-r5: openEmailCompose launcher — standalone New/Reply/Forward from anywhere

### DIFF
--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailComposeActions/EmailComposeActions.types.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailComposeActions/EmailComposeActions.types.ts
@@ -148,6 +148,13 @@ export interface EmailComposeActionsDeps {
   onSent?: (communicationId: string) => void;
   /** Fired on a send error (surfacing — e.g. a MessageBar — is the host's responsibility). */
   onError?: (err: SendCommunicationError) => void;
+  /**
+   * Fired whenever the composer dialog CLOSES — on Cancel OR after a successful Send.
+   * The reading-pane host omits this (the dialog simply unmounts in place); a STANDALONE
+   * compose launcher (e.g. the `sprk_emailpage` compose mode opened via `openEmailCompose`)
+   * uses it to close its own host window once the compose is done.
+   */
+  onClose?: () => void;
 }
 
 export interface UseEmailComposeActionsResult {

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailComposeActions/useEmailComposeActions.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailComposeActions/useEmailComposeActions.tsx
@@ -81,6 +81,7 @@ export function useEmailComposeActions(deps: EmailComposeActionsDeps): UseEmailC
     associations,
     onSent,
     onError,
+    onClose,
   } = deps;
 
   const [dialogState, setDialogState] = React.useState<DialogState | null>(null);
@@ -138,7 +139,12 @@ export function useEmailComposeActions(deps: EmailComposeActionsDeps): UseEmailC
     [dataService, dataverseUrl]
   );
 
-  const handleClose = React.useCallback(() => setDialogState(null), []);
+  const handleClose = React.useCallback(() => {
+    setDialogState(null);
+    // Standalone hosts (the sprk_emailpage compose mode) close their window here;
+    // the reading-pane host omits `onClose` and the dialog just unmounts in place.
+    onClose?.();
+  }, [onClose]);
 
   const actions = React.useMemo(
     () => ({

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/openEmailCompose.test.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/openEmailCompose.test.ts
@@ -1,0 +1,92 @@
+/**
+ * openEmailCompose.test.ts
+ *
+ * Focused unit tests for the compose launcher (`openEmailCompose`). Asserts the
+ * `Xrm.Navigation.navigateTo` `data` envelope per mode (`compose=<mode>` +
+ * optional `&id=<source>`), the modal navigation options, and the best-effort
+ * no-op paths (reply/forward without a source; no MDA host).
+ */
+import { openEmailCompose } from '../openEmailCompose';
+import { EMAIL_PAGE_WEBRESOURCE_NAME } from '../openEmailRecord';
+
+type XrmLike = {
+  WebApi: { retrieveMultipleRecords: jest.Mock };
+  Navigation: { navigateTo: jest.Mock };
+};
+
+let mockNavigateTo: jest.Mock;
+
+function installXrm(): void {
+  mockNavigateTo = jest.fn().mockResolvedValue(undefined);
+  const xrm: XrmLike = {
+    WebApi: { retrieveMultipleRecords: jest.fn() },
+    Navigation: { navigateTo: mockNavigateTo },
+  };
+  (globalThis as unknown as { Xrm?: XrmLike }).Xrm = xrm;
+  (window as unknown as { Xrm?: XrmLike }).Xrm = xrm;
+}
+
+function uninstallXrm(): void {
+  delete (globalThis as unknown as { Xrm?: XrmLike }).Xrm;
+  delete (window as unknown as { Xrm?: XrmLike }).Xrm;
+}
+
+const SOURCE_ID = '11111111-1111-1111-1111-111111111111';
+
+describe('openEmailCompose (compose launcher)', () => {
+  afterEach(() => {
+    uninstallXrm();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('New (default): opens sprk_emailpage with compose=new and no id, as a centered modal', async () => {
+    installXrm();
+
+    await openEmailCompose();
+
+    expect(mockNavigateTo).toHaveBeenCalledTimes(1);
+    const [pageInput, navOptions] = mockNavigateTo.mock.calls[0];
+    expect(pageInput).toEqual({
+      pageType: 'webresource',
+      webresourceName: EMAIL_PAGE_WEBRESOURCE_NAME,
+      data: 'compose=new',
+    });
+    expect(navOptions).toEqual({
+      target: 2,
+      position: 1,
+      width: { value: 60, unit: '%' },
+      height: { value: 80, unit: '%' },
+    });
+  });
+
+  it.each(['reply', 'replyAll', 'forward'] as const)(
+    '%s: folds the normalised source id into the data envelope',
+    async mode => {
+      installXrm();
+
+      await openEmailCompose({ mode, sourceCommunicationId: `{${SOURCE_ID.toUpperCase()}}` });
+
+      const [pageInput] = mockNavigateTo.mock.calls[0];
+      expect(pageInput.data).toBe(`compose=${mode}&id=${SOURCE_ID}`);
+    }
+  );
+
+  it('no-ops (console.warn) for reply/forward without a source id', async () => {
+    installXrm();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await openEmailCompose({ mode: 'reply' });
+
+    expect(mockNavigateTo).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('no-ops (console.warn) outside an MDA host (no Xrm)', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(openEmailCompose({ mode: 'new' })).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/index.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/index.ts
@@ -41,6 +41,8 @@ export type { XrmEmailComposeHandlers } from './createXrmEmailComposeHandlers';
 // `Xrm.Navigation.openForm`.
 export { openEmailRecord, EMAIL_PAGE_WEBRESOURCE_NAME } from './openEmailRecord';
 export type { OpenEmailRecordOptions } from './openEmailRecord';
+export { openEmailCompose } from './openEmailCompose';
+export type { OpenEmailComposeOptions, OpenEmailComposeMode } from './openEmailCompose';
 
 // Sub-components (exported for advanced/direct composition + task 023 unit tests)
 export { RecipientField } from './subcomponents/RecipientField';

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/openEmailCompose.ts
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/openEmailCompose.ts
@@ -1,0 +1,93 @@
+/**
+ * openEmailCompose.ts
+ *
+ * Pattern B launcher for opening the email COMPOSER standalone — a "New email",
+ * "Reply", "Reply All", or "Forward" — from anywhere in the app (e.g. the
+ * Messages surface) WITHOUT hosting the whole Email Workspace.
+ *
+ * It opens the `sprk_emailpage` web resource as a centered modal in COMPOSE mode:
+ * the code page (`main.tsx`) reads the `compose=<mode>` (+ optional `&id=<source>`)
+ * envelope and mounts ONLY the composer dialog — reply/forward prefill, recipient
+ * lookup, template picker, AI sparkle, "Related to", and SPE share links all work
+ * because the code page wires the same Xrm handlers the reading-pane surface uses.
+ * The composer closes its own host window on Cancel or after a successful Send.
+ *
+ * Sibling of {@link openEmailRecord} (which opens the READING surface for one
+ * record). Both are Xrm-coupled by design and best-effort: outside a Model-Driven
+ * App host they no-op with a `console.warn` rather than throwing.
+ *
+ * @example
+ * import { openEmailCompose } from '@spaarke/ui-components';
+ * openEmailCompose();                                              // New email
+ * openEmailCompose({ mode: 'reply', sourceCommunicationId: id });  // Reply
+ * openEmailCompose({ mode: 'replyAll', sourceCommunicationId: id });
+ * openEmailCompose({ mode: 'forward', sourceCommunicationId: id });
+ *
+ * @see src/solutions/EmailPage/src/main.tsx — the receiving code page (compose mode).
+ */
+import { getXrm } from '../../services/xrmGlobal';
+import { EMAIL_PAGE_WEBRESOURCE_NAME } from './openEmailRecord';
+
+/** Compose entry points. `new` needs no source; the rest require a source communication. */
+export type OpenEmailComposeMode = 'new' | 'reply' | 'replyAll' | 'forward';
+
+export interface OpenEmailComposeOptions {
+  /** Which composer to open. Default `'new'`. */
+  mode?: OpenEmailComposeMode;
+  /**
+   * `sprk_communication` GUID of the email being replied to / forwarded. REQUIRED
+   * for `reply` / `replyAll` / `forward`; ignored for `new`. Braces + casing are
+   * normalised here.
+   */
+  sourceCommunicationId?: string;
+}
+
+/**
+ * Open the email composer as a centered modal dialog (Pattern B).
+ *
+ * Best-effort: no-ops with a `console.warn` when there is no
+ * `Xrm.Navigation.navigateTo` (non-MDA host) or when a reply/forward mode is
+ * requested without a `sourceCommunicationId`.
+ */
+export async function openEmailCompose(options?: OpenEmailComposeOptions): Promise<void> {
+  const mode: OpenEmailComposeMode = options?.mode ?? 'new';
+  const sourceId = (options?.sourceCommunicationId ?? '').replace(/[{}]/g, '').trim().toLowerCase();
+
+  if (mode !== 'new' && !sourceId) {
+    console.warn(`[openEmailCompose] mode "${mode}" requires a sourceCommunicationId — nothing to open.`);
+    return;
+  }
+
+  const xrm = getXrm();
+  if (typeof xrm?.Navigation?.navigateTo !== 'function') {
+    console.warn(
+      '[openEmailCompose] Xrm.Navigation.navigateTo is unavailable — this launcher only works inside a Model-Driven App host. No-op.'
+    );
+    return;
+  }
+
+  // Compose `data` envelope: `compose=<mode>` with an optional `&id=<source>` for
+  // reply/replyAll/forward. `main.tsx` reads `compose` first (compose mode short-
+  // circuits the reading-surface launch) then the folded source id.
+  const data = sourceId ? `compose=${mode}&id=${sourceId}` : `compose=${mode}`;
+
+  try {
+    // Call navigateTo DIRECTLY on Xrm.Navigation — never via an extracted local
+    // alias (that strips the `this` binding and makes the call a silent no-op).
+    await xrm.Navigation.navigateTo(
+      {
+        pageType: 'webresource',
+        webresourceName: EMAIL_PAGE_WEBRESOURCE_NAME,
+        data,
+      },
+      {
+        target: 2, // modal dialog
+        position: 1, // centered
+        width: { value: 60, unit: '%' },
+        height: { value: 80, unit: '%' },
+      }
+    );
+  } catch (err) {
+    console.warn('[openEmailCompose] navigateTo failed:', err);
+  }
+}

--- a/src/solutions/EmailPage/src/main.tsx
+++ b/src/solutions/EmailPage/src/main.tsx
@@ -42,9 +42,14 @@ import {
   searchUsersAndContacts,
   XrmDataverseClient,
   getXrm,
+  type OpenEmailComposeMode,
 } from '@spaarke/ui-components';
 import { resolveRuntimeConfig, getAuthProvider } from '@spaarke/auth';
-import { EmailWorkspace, type EmailWorkspaceWebApi } from '@spaarke/communication-components';
+import {
+  EmailWorkspace,
+  useEmailComposeActions,
+  type EmailWorkspaceWebApi,
+} from '@spaarke/communication-components';
 import { setRuntimeConfig, getBffBaseUrl } from './config/runtimeConfig';
 import { ensureAuthInitialized, authenticatedFetch } from './services/authInit';
 
@@ -146,13 +151,38 @@ interface HostFormXrm {
  * `hideList` is only meaningful when an id resolves. When nothing resolves →
  * list mode (id `undefined`, `hideList` false) — i.e. behaves exactly as before.
  */
-function resolveEmailLaunch(): { initialSelectedId?: string; hideList: boolean } {
+function resolveEmailLaunch(): {
+  initialSelectedId?: string;
+  hideList: boolean;
+  compose?: { mode: OpenEmailComposeMode; sourceId?: string };
+} {
   const normalizeId = (raw: string | null | undefined): string | undefined => {
     const v = (raw ?? '').replace(/[{}]/g, '').trim().toLowerCase();
     return v.length > 0 ? v : undefined;
   };
   const isSingleFlag = (params: URLSearchParams): boolean =>
     params.get('single') === '1' || params.get('view') === 'record';
+
+  // (0) COMPOSE mode (Pattern B via `openEmailCompose`) — short-circuits the reading
+  //     surface entirely. `compose=<mode>` (+ optional `&id=<source>`) arrives either
+  //     as its own top-level param or folded into `data`. Parsing `data` as
+  //     URLSearchParams is safe for the record case too: a bare-guid `data` yields no
+  //     `compose` key.
+  try {
+    const search = typeof window !== 'undefined' ? window.location.search : '';
+    const top = new URLSearchParams(search);
+    const rawData = top.get('data');
+    const dataParams = rawData ? new URLSearchParams(rawData) : null;
+    const rawCompose = top.get('compose') ?? dataParams?.get('compose') ?? '';
+    if (rawCompose) {
+      const valid: OpenEmailComposeMode[] = ['new', 'reply', 'replyAll', 'forward'];
+      const mode = (valid as string[]).includes(rawCompose) ? (rawCompose as OpenEmailComposeMode) : 'new';
+      const sourceId = normalizeId(top.get('id') ?? dataParams?.get('id'));
+      return { hideList: false, compose: { mode, sourceId } };
+    }
+  } catch {
+    /* URL parse failure → fall through to record/list resolution */
+  }
 
   let id: string | undefined;
   let single = false;
@@ -234,6 +264,100 @@ const EmailPageAuthError: React.FC<{ onRetry: () => void }> = ({ onRetry }) => {
   );
 };
 EmailPageAuthError.displayName = 'EmailPageAuthError';
+
+interface EmailComposeStandaloneProps {
+  compose: { mode: OpenEmailComposeMode; sourceId?: string };
+  bffBaseUrl: string;
+  dataService: ReturnType<typeof createXrmDataService>;
+  navigationService: ReturnType<typeof createXrmNavigationService>;
+  composeHandlers: ReturnType<typeof createXrmEmailComposeHandlers>;
+  fromMailbox?: string;
+  dataverseUrl: string;
+}
+
+/**
+ * Standalone compose host for the `openEmailCompose` launcher. Mounts ONLY the
+ * composer dialog (no reading surface), auto-triggers the requested action
+ * (New / Reply / Reply All / Forward) once on mount — `useEmailComposeActions`
+ * fetches the reply/forward source itself — and closes its own web-resource modal
+ * window on Cancel or after a successful Send (via the `onClose` hook).
+ */
+const EmailComposeStandalone: React.FC<EmailComposeStandaloneProps> = ({
+  compose,
+  bffBaseUrl,
+  dataService,
+  navigationService,
+  composeHandlers,
+  fromMailbox,
+  dataverseUrl,
+}) => {
+  const closedRef = React.useRef(false);
+  const closeWindow = React.useCallback(() => {
+    if (closedRef.current) return;
+    closedRef.current = true;
+    // Modal target=2 responds to window.close; postMessage is the host fallback
+    // (mirrors NotepadShell's documented two-strategy close mechanism).
+    try {
+      window.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      window.parent?.postMessage({ type: 'email-compose-close' }, '*');
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const handleSearchRecipients = React.useCallback(
+    (query: string) => searchUsersAndContacts(dataService, query),
+    [dataService]
+  );
+
+  const { actions, composerDialog } = useEmailComposeActions({
+    authenticatedFetch,
+    bffBaseUrl,
+    dataService,
+    navigationService,
+    onSearchRecipients: handleSearchRecipients,
+    onLookupRecipients: composeHandlers.onLookupRecipients,
+    recordLookupCatalog: composeHandlers.recordLookupCatalog,
+    onLookupRecord: composeHandlers.onLookupRecord,
+    onAddRelationship: composeHandlers.onAddRelationship,
+    onUploadLocalAttachment: composeHandlers.onUploadLocalAttachment,
+    onResolveShareLink: composeHandlers.onResolveShareLink,
+    onListEmailTemplates: composeHandlers.onListEmailTemplates,
+    onRenderEmailTemplate: composeHandlers.onRenderEmailTemplate,
+    onDraftWithAi: composeHandlers.onDraftWithAi,
+    fromMailbox,
+    dataverseUrl,
+    onClose: closeWindow,
+  });
+
+  // Auto-open the requested composer ONCE on mount.
+  const triggeredRef = React.useRef(false);
+  React.useEffect(() => {
+    if (triggeredRef.current) return;
+    triggeredRef.current = true;
+    // `useEmailComposeActions` always populates all four handlers; the toolbar-actions
+    // type marks them optional, so optional-chain the calls (safe no-op if ever absent).
+    const { mode, sourceId } = compose;
+    if (mode === 'reply' && sourceId) actions.onReply?.(sourceId);
+    else if (mode === 'replyAll' && sourceId) actions.onReplyAll?.(sourceId);
+    else if (mode === 'forward' && sourceId) actions.onForward?.(sourceId);
+    else actions.onNew?.();
+  }, [actions, compose]);
+
+  // A subtle loading state shows behind the dialog during the reply/forward source
+  // fetch; the composer dialog's own modal backdrop covers it once it opens.
+  return (
+    <>
+      <EmailPageLoading />
+      {composerDialog}
+    </>
+  );
+};
+EmailComposeStandalone.displayName = 'EmailComposeStandalone';
 
 function Root() {
   const [theme, setTheme] = React.useState(resolveCodePageTheme);
@@ -318,6 +442,19 @@ function Root() {
     body = <EmailPageAuthError onRetry={handleRetry} />;
   } else if (bffBaseUrl === null) {
     body = <EmailPageLoading />;
+  } else if (launch.compose) {
+    // Compose mode (openEmailCompose) — mount ONLY the composer, not the workspace.
+    body = (
+      <EmailComposeStandalone
+        compose={launch.compose}
+        bffBaseUrl={bffBaseUrl}
+        dataService={dataService}
+        navigationService={navigationService}
+        composeHandlers={composeHandlers}
+        fromMailbox={fromMailbox}
+        dataverseUrl={dataverseUrl}
+      />
+    );
   } else {
     body = (
       <EmailWorkspace


### PR DESCRIPTION
## Summary
Callers (e.g. Messages) need to open the email **composer** — not the whole Email Workspace — for new mail and reply/forward. Adds a shared Pattern-B launcher + a compose mode in the `sprk_emailpage` code page that mounts ONLY the composer.

- **`openEmailCompose({ mode, sourceCommunicationId })`** in `@spaarke/ui-components` (sibling of `openEmailRecord`). `mode` = `new | reply | replyAll | forward`. Opens `sprk_emailpage` as a centered modal with a `compose=<mode>[&id=<source>]` envelope. Xrm-coupled, best-effort no-op off-MDA.
- **EmailPage main.tsx**: `resolveEmailLaunch` detects compose mode → `EmailComposeStandalone` mounts only the composer (reuses `useEmailComposeActions`, which fetches the reply/forward source), auto-opens the requested composer, and closes its own window on Cancel/Send (`window.close` + postMessage).
- `useEmailComposeActions` gains an optional **`onClose`** hook (Cancel or post-Send); reading-pane host omits it (unchanged).
- Renamed `sprk_emailpage` display name **"Email Workspace" → "Email"** so the modal title reads cleanly.

### Caller wiring
```ts
import { openEmailCompose } from '@spaarke/ui-components';
openEmailCompose();                                                // New
openEmailCompose({ mode: 'reply',    sourceCommunicationId: id });
openEmailCompose({ mode: 'replyAll', sourceCommunicationId: id });
openEmailCompose({ mode: 'forward',  sourceCommunicationId: id });
```

## Verification
- `tsc` clean across all 3 packages (main.tsx 0 errors)
- Jest: `openEmailCompose` 6/6, `openEmailRecord` 5/5, `useEmailComposeActions` 13/13
- Deployed to spaarkedev1 (`sprk_spaarkeai` + `sprk_emailpage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)