### PR TITLE
email-r5: UAT R4 — Send in From row, New→list pane, restore list association dots

### DIFF
--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailCardList/EmailCardList.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailCardList/EmailCardList.tsx
@@ -42,7 +42,7 @@ import {
   type InputOnChangeData,
   type SearchBoxChangeEvent,
 } from '@fluentui/react-components';
-import { Search20Regular } from '@fluentui/react-icons';
+import { Compose20Regular, Search20Regular } from '@fluentui/react-icons';
 import {
   EMAIL_COMMUNICATION_TYPE,
   type EmailCardItem,
@@ -156,16 +156,17 @@ const useStyles = makeStyles({
     minWidth: 0,
     backgroundColor: tokens.colorNeutralBackground1,
   },
-  // Slim list toolbar. owner UAT 2026-07-30 R2 item 4 — collapsed by default to a
-  // right-aligned search ICON; clicking it reveals the full-width search field.
-  // `justifyContent: flex-end` keeps the collapsed icon on the right; when the
-  // field is open it grows (`flex: 1`) and fills the row.
+  // Slim list toolbar. owner UAT 2026-07-30 R2 item 4 — search collapses to an
+  // ICON on the RIGHT; clicking it reveals the full-width search field. owner
+  // UAT 2026-08-03 Item 2 — the optional "New email" (+) button sits on the
+  // LEFT, so `justifyContent: space-between` keeps New left and search right;
+  // when the field opens it grows (`flex: 1`) and fills the row.
   toolbar: {
     flexShrink: 0,
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
     gap: tokens.spacingHorizontalS,
     paddingTop: tokens.spacingVerticalS,
     paddingBottom: tokens.spacingVerticalS,
@@ -179,8 +180,14 @@ const useStyles = makeStyles({
     flex: '1 1 auto',
     minWidth: 0,
   },
-  // Collapsed-state trigger — a right-aligned magnifier that expands the field.
+  // Collapsed-state trigger — a magnifier that expands the field. `marginInlineStart: auto`
+  // keeps it hard-right even when the leading "New email" (+) button is absent.
   searchToggle: {
+    flexShrink: 0,
+    marginInlineStart: 'auto',
+  },
+  // Leading "New email" (+) button (owner UAT 2026-08-03 Item 2) — left of the search.
+  newButton: {
     flexShrink: 0,
   },
   list: {
@@ -324,6 +331,7 @@ export const EmailCardList: React.FC<EmailCardListProps> = ({
   isLoading = false,
   skeletonCount = DEFAULT_SKELETON_COUNT,
   onSelect,
+  onCreateNew,
 }) => {
   const styles = useStyles();
   const [focusedId, setFocusedId] = React.useState<string | undefined>(undefined);
@@ -486,6 +494,18 @@ export const EmailCardList: React.FC<EmailCardListProps> = ({
        * sender OR subject, case-insensitive substring.
        */}
       <div className={styles.toolbar}>
+        {onCreateNew ? (
+          <Button
+            className={styles.newButton}
+            appearance="subtle"
+            icon={<Compose20Regular />}
+            aria-label="New email"
+            title="New email"
+            onClick={() => onCreateNew()}
+          >
+            New email
+          </Button>
+        ) : null}
         {searchOpen ? (
           <SearchBox
             ref={searchInputRef}

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailCardList/EmailCardList.types.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailCardList/EmailCardList.types.ts
@@ -64,6 +64,8 @@ export interface EmailCardListProps {
   skeletonCount?: number;
   /** Fired when a card is clicked or keyboard-activated (Enter/Space). */
   onSelect: (id: string) => void;
+  /** Invoked by the list toolbar's "New email" (+) button — opens the compose form. Omit → no New button. */
+  onCreateNew?: () => void;
 }
 
 /**

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailCardList/__tests__/EmailCardList.test.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailCardList/__tests__/EmailCardList.test.tsx
@@ -141,4 +141,24 @@ describe('EmailCardList', () => {
     expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });
+
+  it('renders a "New email" list-toolbar button that fires onCreateNew when the handler is provided (owner UAT 2026-08-03 Item 2)', () => {
+    const onCreateNew = jest.fn();
+    const items: EmailCardItem[] = [makeItem({ id: 'e1' })];
+
+    renderWithProvider(<EmailCardList items={items} onSelect={jest.fn()} onCreateNew={onCreateNew} />);
+
+    const newEmail = screen.getByRole('button', { name: 'New email' });
+    expect(newEmail).toBeInTheDocument();
+    fireEvent.click(newEmail);
+    expect(onCreateNew).toHaveBeenCalledWith();
+  });
+
+  it('omits the "New email" button when no onCreateNew handler is provided', () => {
+    const items: EmailCardItem[] = [makeItem({ id: 'e1' })];
+
+    renderWithProvider(<EmailCardList items={items} onSelect={jest.fn()} />);
+
+    expect(screen.queryByRole('button', { name: 'New email' })).not.toBeInTheDocument();
+  });
 });

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailReadingPaneShell/EmailReadingPaneShell.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailReadingPaneShell/EmailReadingPaneShell.tsx
@@ -19,10 +19,13 @@
  * recipients + collapsible Attachments/Related-to sections + body region,
  * rendered BELOW the toolbar) — see `EmailReadingPaneShell.types.ts` for the
  * full slot contract. The full-width `<EmailToolbar/>` spans the reading-pane width and
- * dispatches Reply/Reply All/Forward/New plus the icon-only Save-to-SharePoint/
+ * dispatches Reply/Reply All/Forward plus the icon-only Save-to-SharePoint/
  * Create-Event/Create-To-Do/Link-Invoice/Open-full-form actions through the
  * host-supplied `actions` handlers — the shell never re-implements action-bar/
- * compose logic itself (the host wires the real dispatch).
+ * compose logic itself (the host wires the real dispatch). "New" now lives in
+ * the LEFT email-list toolbar (`EmailCardList`'s `onCreateNew`, wired to the
+ * same `actions.onNew`) so composing never stacks a modal on an opened email
+ * record (owner UAT 2026-08-03).
  *
  * When nothing is selected, the right pane shows the "Select an email"
  * placeholder (FR-19 empty state).
@@ -241,7 +244,13 @@ const EmailReadingPaneShellInner: React.FC<EmailReadingPaneShellProps> = ({
             style={{ width: primaryWidth, minWidth: minListWidth }}
             data-testid="email-list-pane"
           >
-            <EmailCardList items={items} isLoading={isLoading} selectedId={selectedId} onSelect={handleSelect} />
+            <EmailCardList
+              items={items}
+              isLoading={isLoading}
+              selectedId={selectedId}
+              onSelect={handleSelect}
+              onCreateNew={actions?.onNew}
+            />
           </div>
 
           <PanelSplitter

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailReadingPaneShell/EmailToolbar.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailReadingPaneShell/EmailToolbar.tsx
@@ -4,8 +4,10 @@
  * Full-width action toolbar for the reading-pane shell (email-communication-
  * solution-r5, reading-pane MAIN-AREA redesign, section #2). Spans the
  * reading-pane width, rendered BELOW the title bar. Layout:
- *   - LEFT — the email verbs Reply / Reply All / Forward / New as icon+text,
- *     left-aligned (unchanged intent; opens the ONE canonical composer).
+ *   - LEFT — the email verbs Reply / Reply All / Forward as icon+text,
+ *     left-aligned (unchanged intent; opens the ONE canonical composer). "New"
+ *     was moved to the email LIST pane's toolbar (`EmailCardList`) per owner UAT
+ *     (2026-08-03) so composing never stacks a modal on an opened email record.
  *   - RIGHT — a right-aligned group of ICON-ONLY buttons with tooltips:
  *     Save to SharePoint, Create Event, Create To Do, Link Invoice, and the
  *     demoted Open full form. The create/save actions operate on the email's
@@ -32,7 +34,6 @@ import {
   ArrowReply20Regular,
   ArrowReplyAll20Regular,
   ArrowForward20Regular,
-  Mail20Regular,
   CloudArrowUp20Regular,
   CalendarLtr20Regular,
   CheckmarkCircle20Regular,
@@ -93,11 +94,6 @@ export const EmailToolbar: React.FC<EmailToolbarProps> = ({ selectedId, actions 
     [selectedId]
   );
 
-  const handleNew = React.useCallback(() => {
-    if (actions?.onNew) actions.onNew();
-    else warnPendingIntegration('New');
-  }, [actions]);
-
   return (
     <div className={s.root}>
       <Toolbar size="small" className={s.bar} aria-label="Email actions">
@@ -122,9 +118,6 @@ export const EmailToolbar: React.FC<EmailToolbarProps> = ({ selectedId, actions 
           onClick={() => dispatch('Forward', actions?.onForward)}
         >
           Forward
-        </ToolbarButton>
-        <ToolbarButton icon={<Mail20Regular />} onClick={handleNew}>
-          New
         </ToolbarButton>
 
         {/* Divider + icon-only cluster pushed to the far right. */}

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailReadingPaneShell/__tests__/EmailReadingPaneShell.test.tsx
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailReadingPaneShell/__tests__/EmailReadingPaneShell.test.tsx
@@ -175,7 +175,7 @@ describe('EmailReadingPaneShell', () => {
   });
 
   describe('full-width toolbar (FR-08)', () => {
-    it('renders the four email verbs (icon+text) + the right-aligned icon-only action group once a card is selected', () => {
+    it('renders the three email verbs (icon+text) + the right-aligned icon-only action group once a card is selected', () => {
       renderShell();
       fireEvent.click(screen.getByText('Email one'));
 
@@ -184,7 +184,10 @@ describe('EmailReadingPaneShell', () => {
       expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Reply All' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Forward' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument();
+      // "New" was moved off the reading-pane toolbar to the email LIST toolbar
+      // (owner UAT 2026-08-03) so composing never stacks a modal on the opened
+      // email record — it must NOT be a reading-pane toolbar verb anymore.
+      expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument();
       // Right group — icon-only (aria-label / tooltip).
       expect(screen.getByRole('button', { name: 'Save to SharePoint' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Create Event' })).toBeInTheDocument();
@@ -211,7 +214,6 @@ describe('EmailReadingPaneShell', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
       fireEvent.click(screen.getByRole('button', { name: 'Reply All' }));
       fireEvent.click(screen.getByRole('button', { name: 'Forward' }));
-      fireEvent.click(screen.getByRole('button', { name: 'New' }));
       fireEvent.click(screen.getByRole('button', { name: 'Save to SharePoint' }));
       fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
       fireEvent.click(screen.getByRole('button', { name: 'Create To Do' }));
@@ -220,28 +222,32 @@ describe('EmailReadingPaneShell', () => {
       expect(actions.onReply).toHaveBeenCalledWith('e1');
       expect(actions.onReplyAll).toHaveBeenCalledWith('e1');
       expect(actions.onForward).toHaveBeenCalledWith('e1');
-      expect(actions.onNew).toHaveBeenCalledWith();
       expect(actions.onSaveToSharePoint).toHaveBeenCalledWith('e1');
       expect(actions.onCreateEvent).toHaveBeenCalledWith('e1');
       expect(actions.onCreateTodo).toHaveBeenCalledWith('e1');
       expect(actions.onLinkInvoice).toHaveBeenCalledWith('e1');
     });
 
-    it('New is always enabled (not record-scoped); record-scoped buttons enable only once a card is selected', () => {
+    it('places "New email" in the LEFT list toolbar (wired to actions.onNew) — reachable with nothing selected, and never a reading-pane toolbar verb', () => {
       const onNew = jest.fn();
       renderShell({ actions: { onNew } });
 
-      // Nothing selected — the toolbar itself isn't rendered (right pane shows
-      // the placeholder per FR-19), so no button (including New) exists yet.
+      // The compose entry point lives in the LIST toolbar from the start — no
+      // selection needed (the reading-pane toolbar only renders once a card is
+      // selected). This keeps "New" off the opened-email modal (owner UAT
+      // 2026-08-03) so composing never stacks a modal on an opened record.
+      const newEmail = screen.getByRole('button', { name: 'New email' });
+      expect(newEmail).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument();
 
-      fireEvent.click(screen.getByText('Email one'));
-      // Once a card is selected, ALL six buttons — including the record-scoped
-      // ones — are enabled (New always was; Reply/Reply All/Forward/Archive/
-      // Create only disable when selectedId is unset, which can't happen here
-      // since the toolbar itself doesn't render without a selection).
-      expect(screen.getByRole('button', { name: 'Reply' })).toBeEnabled();
-      expect(screen.getByRole('button', { name: 'New' })).toBeEnabled();
+      fireEvent.click(newEmail);
+      expect(onNew).toHaveBeenCalledWith();
+    });
+
+    it('omits the list "New email" button when no onNew handler is wired', () => {
+      renderShell({ actions: {} });
+
+      expect(screen.queryByRole('button', { name: 'New email' })).not.toBeInTheDocument();
     });
 
     it('falls back to a no-op (no throw) when a handler is not wired (pending task-036 integration)', () => {

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/__tests__/ensureAssociationColumns.test.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/__tests__/ensureAssociationColumns.test.ts
@@ -1,0 +1,52 @@
+/**
+ * ensureAssociationColumns.test.ts
+ *
+ * Unit tests for the FetchXML augmentation helper that keeps the left-list
+ * association status dot (🔴/🟡/🟢) resolvable regardless of a maker's column
+ * set (email-communication-solution-r5, owner UAT 2026-08-03 Item 3). jsdom
+ * supplies `DOMParser`/`XMLSerializer`. Covers: injection into a view that
+ * omits the columns, idempotence when a column is already present, the
+ * `<all-attributes/>` no-op, and the malformed-XML degrade-to-original path.
+ */
+import { ensureAssociationColumns } from '../ensureAssociationColumns';
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe('ensureAssociationColumns', () => {
+  it('injects the association columns into a view that omits them', () => {
+    const fetchXml = `<fetch><entity name="sprk_communication"><attribute name="sprk_subject" /><attribute name="sprk_from" /></entity></fetch>`;
+
+    const result = ensureAssociationColumns(fetchXml);
+
+    // Denormalized name + raw status + at least one typed regarding lookup.
+    expect(result).toContain('sprk_regardingrecordname');
+    expect(result).toContain('sprk_associationstatus');
+    expect(result).toContain('sprk_regardingmatter');
+    // Original columns are preserved.
+    expect(result).toContain('sprk_subject');
+    expect(result).toContain('sprk_from');
+  });
+
+  it('does not duplicate an association column that is already selected', () => {
+    const fetchXml = `<fetch><entity name="sprk_communication"><attribute name="sprk_regardingrecordname" /></entity></fetch>`;
+
+    const result = ensureAssociationColumns(fetchXml);
+
+    expect(countOccurrences(result, 'name="sprk_regardingrecordname"')).toBe(1);
+  });
+
+  it('returns an <all-attributes/> fetch unchanged (every column already selected)', () => {
+    const fetchXml = `<fetch><entity name="sprk_communication"><all-attributes /></entity></fetch>`;
+
+    expect(ensureAssociationColumns(fetchXml)).toBe(fetchXml);
+  });
+
+  it('returns malformed XML unchanged (degrade to the maker view, never throw)', () => {
+    const malformed = `<fetch><entity name="sprk_communication"><attribute name="sprk_subject"></fetch>`;
+
+    expect(ensureAssociationColumns(malformed)).toBe(malformed);
+  });
+});

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/__tests__/useEmailViews.test.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/__tests__/useEmailViews.test.ts
@@ -20,6 +20,7 @@ import type {
   FetchMultipleResult,
 } from '@spaarke/ui-components';
 import { useEmailViews, EMAIL_INBOX_VIEW_NAME } from '../useEmailViews';
+import { ensureAssociationColumns } from '../ensureAssociationColumns';
 
 /** Builds a stub `IDataverseClient` — only the 3 methods `useEmailViews` calls are exercised. */
 function makeStubClient(overrides: {
@@ -51,7 +52,12 @@ function makeStubClient(overrides: {
     async (_entityName: string, fetchXml: string): Promise<FetchMultipleResult<Record<string, unknown>>> => {
       if (overrides.retrieveMultipleError) throw overrides.retrieveMultipleError;
       // Find which view this fetchXml belongs to so the stub returns matching rows.
-      const viewId = Object.entries(overrides.fetchXmlByViewId ?? {}).find(([, xml]) => xml === fetchXml)?.[0];
+      // The hook injects the association columns via `ensureAssociationColumns`
+      // before running the view, so match the stored FetchXML through the SAME
+      // augmentation (the augmentation is deterministic for a given input).
+      const viewId = Object.entries(overrides.fetchXmlByViewId ?? {}).find(
+        ([, xml]) => ensureAssociationColumns(xml) === fetchXml
+      )?.[0];
       const entities = (viewId && overrides.rowsByViewId?.[viewId]) ?? [];
       return { entities, moreRecords: false };
     }
@@ -97,10 +103,16 @@ describe('useEmailViews', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.views.map(v => v.id)).toEqual(expect.arrayContaining([inboxId, sentId]));
-    // Passes the view's FetchXML through UNMODIFIED — no client-added Email predicate.
+    // Preserves the view's own Email predicate — the hook injects the association
+    // columns (for the card status dot) but never adds its own Email filter.
     expect(client.retrieveMultipleRecords).toHaveBeenCalledWith(
       'sprk_communication',
       expect.stringContaining('sprk_communicationtype')
+    );
+    // The association columns the card status dot needs are injected into the run.
+    expect(client.retrieveMultipleRecords).toHaveBeenCalledWith(
+      'sprk_communication',
+      expect.stringContaining('sprk_associationstatus')
     );
   });
 
@@ -152,8 +164,12 @@ describe('useEmailViews', () => {
     await waitFor(() => expect(result.current.selectedViewId).toBe(sentId));
     await waitFor(() => expect(result.current.rows).toEqual([{ sprk_communicationid: 'row-9' }]));
 
-    // The Sent view's FetchXML is passed through unmodified — no extra Email predicate added on top.
-    expect(client.retrieveMultipleRecords).toHaveBeenLastCalledWith('sprk_communication', sentFetchXml);
+    // The Sent view's own filter/sort/columns are preserved — only the association
+    // columns are injected (no extra Email predicate added on top).
+    expect(client.retrieveMultipleRecords).toHaveBeenLastCalledWith(
+      'sprk_communication',
+      ensureAssociationColumns(sentFetchXml)
+    );
   });
 
   it('surfaces a view-list load failure via `error` instead of throwing', async () => {

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/ensureAssociationColumns.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/ensureAssociationColumns.ts
@@ -1,0 +1,88 @@
+/**
+ * ensureAssociationColumns.ts
+ *
+ * Injects the association columns the left-list status dot (🔴/🟡/🟢) depends on
+ * into a saved view's FetchXML BEFORE it runs (email-communication-solution-r5,
+ * owner UAT 2026-08-03 Item 3). A maker-authored inbox view ("All Incoming
+ * Email", "Email — Inbox", …) frequently selects only envelope columns and
+ * omits the association status/provenance/typed-lookup columns — so
+ * `deriveCardReviewTone` (`EmailWorkspace.mapping.ts`) had no data and returned
+ * `undefined`, dropping the dot. Rather than force makers to hand-edit every
+ * view, this hook augments the FetchXML at run time so the dot always resolves,
+ * regardless of the maker's column set.
+ *
+ * Pure + defensive: never throws. Any parse/serialize failure (or a
+ * `<parsererror>` from malformed XML) degrades to the ORIGINAL `fetchXml`
+ * unchanged — the maker's view still runs, just without the injected columns.
+ *
+ * No React import (safe to unit-test without a DOM/provider — jsdom supplies
+ * `DOMParser`/`XMLSerializer`).
+ */
+import { COMMUNICATION_REGARDING_FIELDS } from '../../logic/connections';
+
+/**
+ * The association attribute names the card status dot resolves from. Beyond the
+ * denormalized name/number + raw status/provenance + `sprk_regardingrecordtype`
+ * lookup, every typed regarding lookup (`sprk_regardingmatter`,
+ * `sprk_regardingperson`, …) is included so `readFiledAssociations` can see the
+ * filed record on a view that only surfaces those.
+ */
+const REQUIRED_ATTRIBUTES: ReadonlyArray<string> = [
+  'sprk_regardingrecordname',
+  'sprk_regardingrecordnumber',
+  'sprk_associationstatus',
+  'sprk_associationprovenance',
+  'sprk_regardingrecordtype',
+  ...COMMUNICATION_REGARDING_FIELDS.map(f => f.field),
+];
+
+/**
+ * Return `fetchXml` with the association columns the card status dot needs
+ * appended to its first `<entity>`, so the dot resolves regardless of the
+ * maker's column set. Idempotent (never duplicates an already-selected column)
+ * and a no-op when the entity uses `<all-attributes/>`. On ANY parse/serialize
+ * error — or malformed XML that yields a `<parsererror>` — the ORIGINAL string
+ * is returned unchanged (degrade to the maker's view, never throw).
+ *
+ * @param fetchXml The saved view's raw FetchXML.
+ */
+export function ensureAssociationColumns(fetchXml: string): string {
+  try {
+    const doc = new DOMParser().parseFromString(fetchXml, 'application/xml');
+
+    // DOMParser emits a <parsererror> element in the doc on malformed XML —
+    // treat that as a parse failure and degrade to the maker's view.
+    if (doc.getElementsByTagName('parsererror').length > 0) {
+      return fetchXml;
+    }
+
+    const entity = doc.getElementsByTagName('entity')[0];
+    if (!entity) {
+      return fetchXml;
+    }
+
+    // `<all-attributes/>` already selects every column — nothing to inject.
+    if (entity.getElementsByTagName('all-attributes').length > 0) {
+      return fetchXml;
+    }
+
+    const present = new Set(
+      Array.from(entity.getElementsByTagName('attribute'))
+        .map(attr => attr.getAttribute('name'))
+        .filter((name): name is string => name != null)
+    );
+
+    for (const name of REQUIRED_ATTRIBUTES) {
+      if (present.has(name)) continue;
+      const attr = doc.createElement('attribute');
+      attr.setAttribute('name', name);
+      entity.appendChild(attr);
+      present.add(name);
+    }
+
+    return new XMLSerializer().serializeToString(doc);
+  } catch {
+    // Never throw — a maker's view must still run if augmentation fails.
+    return fetchXml;
+  }
+}

--- a/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/useEmailViews.ts
+++ b/src/client/shared/Spaarke.Communication.Components/src/components/EmailViewSelector/useEmailViews.ts
@@ -9,8 +9,11 @@
  * surface, works under both the Xrm host-context adapter and the BFF
  * `authenticatedFetch` adapter), defaults the selection to the "Email —
  * Inbox" saved view (falling back to the entity's default view when absent),
- * and re-runs the selected view's FetchXML — UNMODIFIED — whenever the
- * selection changes.
+ * and re-runs the selected view's FetchXML whenever the selection changes —
+ * preserving the maker's filter/sort/columns verbatim but INJECTING the
+ * association columns the left-list status dot depends on (via
+ * `ensureAssociationColumns`), so the dot always resolves regardless of the
+ * maker's column set.
  *
  * The Email filter lives entirely in each maker-authored view's FetchXML
  * (`sprk_communicationtype = Email`) — this hook does NOT add its own Email
@@ -33,6 +36,7 @@
  */
 import * as React from 'react';
 import type { IDataverseClient, SavedView } from '@spaarke/ui-components';
+import { ensureAssociationColumns } from './ensureAssociationColumns';
 
 /** Entity this surface's view picker is scoped to. */
 const COMMUNICATION_ENTITY = 'sprk_communication';
@@ -122,8 +126,14 @@ export function useEmailViews<T = Record<string, unknown>>(client: IDataverseCli
     };
   }, [client]);
 
-  // Re-run the selected view's FetchXML — UNMODIFIED — whenever the
-  // selection changes (initial resolution included).
+  // Re-run the selected view's FetchXML whenever the selection changes (initial
+  // resolution included). The view's own Email filter/sort/columns are preserved
+  // verbatim — we only INJECT the association columns the left-list status dot
+  // depends on (via `ensureAssociationColumns`) so the dot always resolves
+  // regardless of the maker's column set. A maker inbox view commonly omits the
+  // association status/provenance/typed-lookup columns, which previously left the
+  // dot undefined; augmenting here restores it without forcing makers to edit
+  // every view.
   React.useEffect(() => {
     if (!selectedViewId) return;
     let cancelled = false;
@@ -132,7 +142,12 @@ export function useEmailViews<T = Record<string, unknown>>(client: IDataverseCli
 
     client
       .retrieveSavedQuery(selectedViewId)
-      .then(view => client.retrieveMultipleRecords<T>(view.entityName || COMMUNICATION_ENTITY, view.fetchXml))
+      .then(view =>
+        client.retrieveMultipleRecords<T>(
+          view.entityName || COMMUNICATION_ENTITY,
+          ensureAssociationColumns(view.fetchXml)
+        )
+      )
       .then(result => {
         if (cancelled) return;
         setRows(result.entities);

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
@@ -91,6 +91,7 @@ import { BodyEditor } from './subcomponents/BodyEditor';
 import { AttachmentList } from './subcomponents/AttachmentList';
 import { AssociationChips } from './subcomponents/AssociationChips';
 import { ComposerActionBar } from './subcomponents/ComposerActionBar';
+import { ComposerSendButton } from './subcomponents/ComposerSendButton';
 
 // The Dataverse logical name for a governed Document — the paperclip's "Link documents"
 // picks this type and ATTACHES it, so it's intentionally excluded from the record-search
@@ -992,10 +993,23 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
 
       {/* From: — Outlook-style sender line ABOVE To/Cc (owner UAT 2026-07-30, item 3). Shows the
           current sender; a dropdown switches between the user's mailbox and the Spaarke shared
-          mailbox. Wired to the engine's existing `sendMode` state (same store the bottom Send
-          selector reads). Hidden in read-only (view) mode — there is nothing to send. */}
+          mailbox. Wired to the engine's existing `sendMode` state. Hidden in read-only (view)
+          mode — there is nothing to send. The primary Send control lives HERE, left of "From:"
+          (owner UAT 2026-08-03 item 1 — Outlook-style Send in the address section, not a bottom bar). */}
       {!state.readOnly && (
         <div className={styles.fromRow} role="group" aria-label="From">
+          <ComposerSendButton
+            isSending={state.isSending}
+            canSend={canSend}
+            sendMode={state.sendMode}
+            showSendModeChoice={showSendModeRadio && !state.readOnly}
+            onSendModeChange={value => dispatch({ type: 'SET_SEND_MODE', value })}
+            onSend={() => {
+              send().catch(() => {
+                /* onError already notified; swallow so the click doesn't reject. */
+              });
+            }}
+          />
           {/* "From:" as plain semibold text, not a boxed label (owner UAT 2026-07-30 R2 item 9);
               the mailbox value beside it stays a subtle switcher (user ↔ Spaarke shared mailbox). */}
           <span className={styles.fromLabel} aria-hidden="true">
@@ -1302,17 +1316,7 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
         mode={state.mode}
         isSending={state.isSending}
         isSavingDraft={state.isSavingDraft}
-        canSend={canSend}
         isDraftRecord={props.isDraftRecord}
-        sendMode={state.sendMode}
-        showSendModeChoice={showSendModeRadio && !state.readOnly}
-        onSendModeChange={value => dispatch({ type: 'SET_SEND_MODE', value })}
-        onSend={() => {
-          send().catch(() => {
-            /* onError callback already notified; swallow here so the button
-               click doesn't produce an unhandled promise rejection. */
-          });
-        }}
         onSaveDraft={() => {
           saveDraft().catch(() => {
             /* surfaced via onSaveDraft/props.onError-equivalent is not

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/SendEmailDialog.characterize.test.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/SendEmailDialog.characterize.test.tsx
@@ -165,11 +165,15 @@ describe('SendEmailDialog — prop contract (task 020 extends additively)', () =
     expect(screen.getByRole('region', { name: 'Composer actions' })).toBeInTheDocument();
   });
 
-  it('defaults mode to "compose" when mode is omitted (Send + Save Draft + Cancel, not Close/Reply/Forward)', () => {
+  it('defaults mode to "compose" when mode is omitted (Send + Save Draft + Cancel, not Reply/Forward)', () => {
     renderDialog();
+    // Send moved to the header From row (owner UAT 2026-08-03 item 1); Cancel + Save Draft stay
+    // in the bottom action bar. View-mode-only buttons (Reply/Forward) are absent in compose.
     expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save Draft' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reply' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Forward' })).toBeNull();
   });
 });
 

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/composerSendPlacement.test.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/__tests__/composerSendPlacement.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * composerSendPlacement.test.tsx — owner UAT 2026-08-03 item 1.
+ *
+ * The primary Send control lives in the compose header's "From:" row (Outlook-style),
+ * NOT in the bottom "Composer actions" bar. The bottom bar keeps Cancel + Save Draft.
+ */
+import * as React from 'react';
+import { within, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../__mocks__/pcfMocks';
+import { EmailComposer } from '../EmailComposer';
+import type { IEmailComposerProps } from '../EmailComposer.types';
+
+const noopFetch = jest.fn();
+
+function renderComposer(overrides: Partial<IEmailComposerProps> = {}) {
+  return renderWithProviders(
+    <EmailComposer
+      mode="compose"
+      mount="dialog"
+      authenticatedFetch={noopFetch as unknown as IEmailComposerProps['authenticatedFetch']}
+      onCancel={jest.fn()}
+      {...overrides}
+    />
+  );
+}
+
+describe('EmailComposer — Send button placement (item 1)', () => {
+  it('renders Send inside the "From" group, not the bottom action bar', () => {
+    renderComposer();
+
+    const fromGroup = screen.getByRole('group', { name: 'From' });
+    expect(within(fromGroup).getByRole('button', { name: /send/i })).toBeInTheDocument();
+
+    // The bottom "Composer actions" bar has Cancel + Save Draft but NO Send.
+    const actionBar = screen.getByRole('region', { name: 'Composer actions' });
+    expect(within(actionBar).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(within(actionBar).getByRole('button', { name: 'Save Draft' })).toBeInTheDocument();
+    expect(within(actionBar).queryByRole('button', { name: /send/i })).toBeNull();
+  });
+});

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/subcomponents/ComposerActionBar.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/subcomponents/ComposerActionBar.tsx
@@ -13,37 +13,17 @@
  * (design §5.6.7).
  */
 import * as React from 'react';
-import {
-  Button,
-  SplitButton,
-  Menu,
-  MenuTrigger,
-  MenuPopover,
-  MenuList,
-  MenuItemRadio,
-  Spinner,
-  makeStyles,
-  tokens,
-  type MenuButtonProps,
-} from '@fluentui/react-components';
+import { Button, Spinner, makeStyles, tokens } from '@fluentui/react-components';
 import type { EmailComposerMode, EmailComposerMount } from '../EmailComposer.types';
-import type { CommunicationSendMode } from '../../../services/communicationApi';
 
 export interface IComposerActionBarProps {
   mount: EmailComposerMount;
   mode: EmailComposerMode;
+  /** Drives the busy state that disables Cancel / Save Draft while a send is in flight. */
   isSending: boolean;
   isSavingDraft: boolean;
-  canSend: boolean;
   /** View mode only — whether the underlying record is still a Draft (enables Edit). */
   isDraftRecord?: boolean;
-  /** Current send-from selection (drives the SplitButton caret menu). */
-  sendMode?: CommunicationSendMode;
-  /** True when the host lets the user choose the sender — renders the caret menu. */
-  showSendModeChoice?: boolean;
-  /** Called when the user picks a different sender from the caret menu. */
-  onSendModeChange?: (value: CommunicationSendMode) => void;
-  onSend: () => void;
   onSaveDraft: () => void;
   onCancel: () => void;
   onEdit?: () => void;
@@ -75,22 +55,12 @@ const useStyles = makeStyles({
   },
 });
 
-const SEND_FROM_LABEL: Record<CommunicationSendMode, string> = {
-  sharedMailbox: 'Send from Spaarke',
-  user: 'Send from my mailbox',
-};
-
 export const ComposerActionBar: React.FC<IComposerActionBarProps> = ({
   mount,
   mode,
   isSending,
   isSavingDraft,
-  canSend,
   isDraftRecord,
-  sendMode = 'sharedMailbox',
-  showSendModeChoice,
-  onSendModeChange,
-  onSend,
   onSaveDraft,
   onCancel,
   onEdit,
@@ -102,14 +72,6 @@ export const ComposerActionBar: React.FC<IComposerActionBarProps> = ({
   if (mount === 'inline') return null;
 
   const busy = isSending || isSavingDraft;
-  const sendLabel = isSending ? (
-    <span className={styles.spinnerRow}>
-      <Spinner size="tiny" />
-      Sending...
-    </span>
-  ) : (
-    'Send'
-  );
 
   if (mode === 'view') {
     return (
@@ -138,6 +100,8 @@ export const ComposerActionBar: React.FC<IComposerActionBarProps> = ({
     );
   }
 
+  // Send moved to the compose header's From row (owner UAT 2026-08-03 item 1 —
+  // `ComposerSendButton`). This bar now owns Cancel (left) + Save Draft (right) only.
   return (
     <div className={styles.bar} role="region" aria-label="Composer actions">
       <Button appearance="secondary" onClick={onCancel} disabled={busy}>
@@ -154,44 +118,6 @@ export const ComposerActionBar: React.FC<IComposerActionBarProps> = ({
             'Save Draft'
           )}
         </Button>
-
-        {showSendModeChoice && onSendModeChange ? (
-          <Menu
-            positioning="below-end"
-            checkedValues={{ sendFrom: [sendMode] }}
-            onCheckedValueChange={(_e, data) => {
-              const next = data.checkedItems[0] as CommunicationSendMode | undefined;
-              if (next) onSendModeChange(next);
-            }}
-          >
-            <MenuTrigger disableButtonEnhancement>
-              {(triggerProps: MenuButtonProps) => (
-                <SplitButton
-                  menuButton={{ ...triggerProps, 'aria-label': 'Choose mailbox' }}
-                  primaryActionButton={{ onClick: onSend, disabled: busy || !canSend }}
-                  appearance="primary"
-                  disabled={busy || !canSend}
-                >
-                  {sendLabel}
-                </SplitButton>
-              )}
-            </MenuTrigger>
-            <MenuPopover>
-              <MenuList>
-                <MenuItemRadio name="sendFrom" value="sharedMailbox">
-                  {SEND_FROM_LABEL.sharedMailbox}
-                </MenuItemRadio>
-                <MenuItemRadio name="sendFrom" value="user">
-                  {SEND_FROM_LABEL.user}
-                </MenuItemRadio>
-              </MenuList>
-            </MenuPopover>
-          </Menu>
-        ) : (
-          <Button appearance="primary" onClick={onSend} disabled={busy || !canSend}>
-            {sendLabel}
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/subcomponents/ComposerSendButton.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/subcomponents/ComposerSendButton.tsx
@@ -1,0 +1,117 @@
+/**
+ * ComposerSendButton.tsx
+ *
+ * The primary Send control, relocated to the compose header's "From:" row
+ * (Outlook-style — owner UAT 2026-08-03 item 1: Send sits in the address section
+ * next to From:, not in a bottom action bar). A `SplitButton` whose caret menu
+ * carries the send-from choice (Spaarke shared mailbox vs the user's mailbox)
+ * when the host offers it; a plain primary `Button` when the sender is fixed.
+ *
+ * Extracted VERBATIM from the former `ComposerActionBar` Send rendering so the
+ * send-from semantics are unchanged — only the placement moved. Fluent v9
+ * semantic tokens only (ADR-021).
+ */
+import * as React from 'react';
+import {
+  Button,
+  SplitButton,
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  MenuItemRadio,
+  Spinner,
+  makeStyles,
+  tokens,
+  type MenuButtonProps,
+} from '@fluentui/react-components';
+import type { CommunicationSendMode } from '../../../services/communicationApi';
+
+export interface IComposerSendButtonProps {
+  isSending: boolean;
+  canSend: boolean;
+  /** Current send-from selection (drives the SplitButton caret menu). */
+  sendMode?: CommunicationSendMode;
+  /** True when the host lets the user choose the sender — renders the caret menu. */
+  showSendModeChoice?: boolean;
+  /** Called when the user picks a different sender from the caret menu. */
+  onSendModeChange?: (value: CommunicationSendMode) => void;
+  onSend: () => void;
+}
+
+const useStyles = makeStyles({
+  spinnerRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
+  },
+});
+
+const SEND_FROM_LABEL: Record<CommunicationSendMode, string> = {
+  sharedMailbox: 'Send from Spaarke',
+  user: 'Send from my mailbox',
+};
+
+export const ComposerSendButton: React.FC<IComposerSendButtonProps> = ({
+  isSending,
+  canSend,
+  sendMode = 'sharedMailbox',
+  showSendModeChoice,
+  onSendModeChange,
+  onSend,
+}) => {
+  const styles = useStyles();
+  const busy = isSending;
+  const sendLabel = isSending ? (
+    <span className={styles.spinnerRow}>
+      <Spinner size="tiny" />
+      Sending...
+    </span>
+  ) : (
+    'Send'
+  );
+
+  if (showSendModeChoice && onSendModeChange) {
+    return (
+      <Menu
+        positioning="below-start"
+        checkedValues={{ sendFrom: [sendMode] }}
+        onCheckedValueChange={(_e, data) => {
+          const next = data.checkedItems[0] as CommunicationSendMode | undefined;
+          if (next) onSendModeChange(next);
+        }}
+      >
+        <MenuTrigger disableButtonEnhancement>
+          {(triggerProps: MenuButtonProps) => (
+            <SplitButton
+              menuButton={{ ...triggerProps, 'aria-label': 'Choose mailbox' }}
+              primaryActionButton={{ onClick: onSend, disabled: busy || !canSend }}
+              appearance="primary"
+              disabled={busy || !canSend}
+            >
+              {sendLabel}
+            </SplitButton>
+          )}
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItemRadio name="sendFrom" value="sharedMailbox">
+              {SEND_FROM_LABEL.sharedMailbox}
+            </MenuItemRadio>
+            <MenuItemRadio name="sendFrom" value="user">
+              {SEND_FROM_LABEL.user}
+            </MenuItemRadio>
+          </MenuList>
+        </MenuPopover>
+      </Menu>
+    );
+  }
+
+  return (
+    <Button appearance="primary" onClick={onSend} disabled={busy || !canSend}>
+      {sendLabel}
+    </Button>
+  );
+};
+
+ComposerSendButton.displayName = 'ComposerSendButton';


### PR DESCRIPTION
## Summary
Owner UAT 2026-08-03 (3 items) on the Email surface.

1. **Send → From row** (Outlook-style): the primary Send control now lives in the compose header's "From:" row, not a bottom bar. New `ComposerSendButton` (SplitButton send-from caret preserved); bottom bar keeps Cancel + Save Draft.
2. **New → list pane**: removed the "New" verb from the reading-pane toolbar; added a "New email" (+) button to the LEFT email list toolbar (`EmailCardList`), wired via `onCreateNew` → `actions.onNew`. No more compose modal stacked on an opened email-record modal.
3. **Restore list association dot**: `useEmailViews` ran the view's FetchXML unmodified, so a view lacking the association columns showed no dot. New `ensureAssociationColumns(fetchXml)` injects the association attributes before the query (idempotent; `<all-attributes/>` + malformed XML degrade to the original).

## Verification
- `tsc` clean (both packages, after UI.Components dist rebuild — the transient 4 errors were stale-dist from the `spaarke-modal-system` merge, not regressions)
- Jest: Communication.Components email suites 9/9 (69 tests); UI.Components composer suites green incl. new `composerSendPlacement` + updated characterize
- Deployed + verified server-side on spaarkedev1 (`sprk_spaarkeai` + `sprk_emailpage`)

## conflict-check
Ran before starting: no open-PR overlap; `spaarke-modal-system` (merged) deferred the EmailComposer chrome conversion (Issue #713) so no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)