### PR TITLE
fix(email-r5): UAT round 6 — Messages widget thin scrollbar + Communications→Messages reconciliation

### DIFF
--- a/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/__tests__/register-workspace-widgets.test.ts
+++ b/src/client/shared/Spaarke.AI.Widgets/src/widgets/workspace/__tests__/register-workspace-widgets.test.ts
@@ -373,10 +373,11 @@ describe('communications-list — upgrade in place (task 031, FR-14a / NFR-06)',
     expect(communicationsEntries).toEqual(['communications-list']);
   });
 
-  it('metadata (displayName/category) is unchanged by the body-swap upgrade', () => {
+  it('metadata reflects the Messages relabel (messaging-r3 UAT 2026-07-27); category/allowMultiple unchanged', () => {
     const meta = registry.getWorkspaceWidgetMetadata('communications-list');
     expect(meta).toBeDefined();
-    expect(meta!.displayName).toBe('Communications');
+    // Human-facing label is 'Messages' (the widget TYPE string stays 'communications-list').
+    expect(meta!.displayName).toBe('Messages');
     expect(meta!.category).toBe('data');
     expect(meta!.allowMultiple).toBe(true);
   });

--- a/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeFormatToolbar.test.tsx
+++ b/src/client/shared/Spaarke.Compose.Components/src/widgets/ComposeFormatToolbar.test.tsx
@@ -818,9 +818,7 @@ describe('ComposeFormatToolbar — UAT round-1 (2026-08-03): repositioning + ico
   /** Returns the data-testid of every descendant of the toolbar, in DOM order. */
   function toolbarTestIdOrder(): string[] {
     const toolbar = screen.getByTestId('compose-format-toolbar');
-    return Array.from(toolbar.querySelectorAll('[data-testid]')).map(
-      (el) => el.getAttribute('data-testid') as string
-    );
+    return Array.from(toolbar.querySelectorAll('[data-testid]')).map(el => el.getAttribute('data-testid') as string);
   }
 
   it('#3: Create Summary Memo is icon-only (no visible text), carries aria-label + Tooltip, and is the FIRST control in the toolbar (far left, ahead of Body/Paragraph/Font/Table)', () => {

--- a/src/client/shared/Spaarke.UI.Components/src/components/ConversationView/ConversationView.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/ConversationView/ConversationView.tsx
@@ -173,11 +173,15 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     paddingTop: tokens.spacingVerticalS,
     paddingBottom: tokens.spacingVerticalS,
-    // Hide the visible scrollbar (round 4) — the jump-to-latest circle-down
-    // button + mouse wheel drive scrolling; the bar itself is suppressed. Scroll
-    // behavior (wheel, programmatic scrollTop) is unaffected.
-    scrollbarWidth: 'none',
-    '::-webkit-scrollbar': { width: 0, height: 0 },
+    // Thin modern scrollbar (owner UAT 2026-08-04 item 1 — consistency with the Email
+    // widget). The jump-to-latest circle-down button stays as an extra affordance; the
+    // bar is now visible+thin instead of suppressed. Semantic tokens (ADR-021).
+    scrollbarWidth: 'thin',
+    scrollbarColor: `${tokens.colorNeutralStroke1} transparent`,
+    '::-webkit-scrollbar': { width: '8px', height: '8px' },
+    '::-webkit-scrollbar-thumb': { backgroundColor: tokens.colorNeutralStroke1, borderRadius: tokens.borderRadiusMedium },
+    '::-webkit-scrollbar-thumb:hover': { backgroundColor: tokens.colorNeutralStroke1Hover },
+    '::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
   },
   centerState: {
     flex: 1,

--- a/src/client/shared/Spaarke.UI.Components/src/components/ConversationWorkspace/subcomponents/ThreadList.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/ConversationWorkspace/subcomponents/ThreadList.tsx
@@ -194,9 +194,14 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     display: 'flex',
     flexDirection: 'column',
-    // Hide the visible scrollbar (round 4) — wheel scroll still works.
-    scrollbarWidth: 'none',
-    '::-webkit-scrollbar': { width: 0, height: 0 },
+    // Thin modern scrollbar (owner UAT 2026-08-04 item 1 — consistency with the Email
+    // widget's list + reading pane). Semantic tokens (ADR-021) so it themes in dark mode.
+    scrollbarWidth: 'thin',
+    scrollbarColor: `${tokens.colorNeutralStroke1} transparent`,
+    '::-webkit-scrollbar': { width: '8px', height: '8px' },
+    '::-webkit-scrollbar-thumb': { backgroundColor: tokens.colorNeutralStroke1, borderRadius: tokens.borderRadiusMedium },
+    '::-webkit-scrollbar-thumb:hover': { backgroundColor: tokens.colorNeutralStroke1Hover },
+    '::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
     // Rows are separated by thin divider lines (round 7 item 6, Email-widget
     // style) — no inter-row gap, no card radius. Padding lives on the rows so the
     // divider spans the full row width.

--- a/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/EmailComposer/EmailComposer.tsx
@@ -806,9 +806,7 @@ export const EmailComposer = forwardRef<IEmailComposerHandle, IEmailComposerProp
             // thread: the AI generates the author's message, then we re-append the stored quoted
             // block below it (so the thread survives the draft AND is included when sent).
             const quoted = stateRef.current.quotedThread;
-            const nextBody = quoted
-              ? `${result.text}${resultIsHtml ? '<p></p>' : '\n\n'}${quoted}`
-              : result.text;
+            const nextBody = quoted ? `${result.text}${resultIsHtml ? '<p></p>' : '\n\n'}${quoted}` : result.text;
             dispatch({ type: 'SET_BODY_FORMAT', value: resultIsHtml ? 'HTML' : 'PlainText' });
             dispatch({ type: 'SET_FIELD', field: 'body', value: nextBody });
           }


### PR DESCRIPTION
## Summary
Owner-driven UAT round 6.

- **Messages widget thin scrollbar (item 1)**: the Messages widget (`CommunicationsWorkspaceWidget` → `ConversationWorkspace`) hid its scrollbars; now uses the same thin modern scrollbar as the Email widget on the message list (`ThreadList`) and conversation reading pane (`ConversationView`). Semantic tokens (ADR-021).
- **Communications→Messages reconciliation (items 3/4)**: investigation confirmed the source already reconciles to exactly **Messages** (the real `CommunicationsWorkspaceWidget`) + **Email** (`EmailWorkspace`) — the widget was relabelled from "Communications" by messaging-r3 (2026-07-27) and the r5 merge resolved the stub/dependency concern. The lingering "Communications" the owner sees is a **stale deployed build**; a rebuild clears it. Only code change: fix the stale unit test that still asserted `displayName === 'Communications'`.
- **Inbound full thread (item 2)**: already fixed + merged in round 5 (prefer full `body` over Graph `uniqueBody`; the `.eml` path already used full body). No new change — the record shown in UAT predated the round-5 fix.

## Verification
- Frontend tsc: ✅ UI.Components, AI.Widgets clean
- Tests: ✅ ThreadList/ConversationView 66 pass (1 pre-existing failure `ConversationView.forward.test.tsx` present on origin/master itself, unrelated to this change); register-workspace-widgets 40 pass with the corrected label assertion

## Deploy note
Per owner: the Messages-widget scrollbar + label fix will be picked up by the next **SpaarkeAi** deploy (from master). **`sprk_workspacelayoutwizard`** (the section-picker label) is deployed separately by this project since it's unlikely to be redeployed otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)