### PR TITLE
fix(spaarkeai): remove committed merge-conflict markers (master hotfix — unbreaks Deploy SpaarkeAi)

### DIFF
--- a/src/client/shared/Spaarke.AI.Widgets/src/events/PaneEventTypes.ts
+++ b/src/client/shared/Spaarke.AI.Widgets/src/events/PaneEventTypes.ts
@@ -227,8 +227,6 @@ export interface WorkspacePaneEvent {
    *                              progress card leaves NO visible-yet-unmounted remnant (UAT round-4 item
    *                              #10a, ai-advanced-capabilities-agreements-r1). Same "signal
    *                              infrastructure" shape as `nda_review_progress_visibility` above.
-<<<<<<< HEAD
-=======
    * - `nda_review_dispatch_active` — a review run's in-flight state stamped at DISPATCH time, for
    *                              cross-navigation resume persistence (UAT round-6 item #15a,
    *                              ai-advanced-capabilities-agreements-r1). Carries `dispatchActive`
@@ -244,7 +242,6 @@ export interface WorkspacePaneEvent {
    *                              Completion clearing rides the EXISTING `compose_advisory_comments`
    *                              (fires even for a zero-findings clean review). Same "signal
    *                              infrastructure" shape as `nda_review_background_run` above.
->>>>>>> origin/master
    * - `streaming_started`      — a structured-output streaming run has begun; downstream widgets
    *                              (e.g. StructuredOutputStreamWidget, R5 task 017 / D2-07) mount and
    *                              prepare to receive section events. Carries `streamId` so multiple
@@ -347,10 +344,7 @@ export interface WorkspacePaneEvent {
     | 'active_widget_changed'
     | 'nda_review_progress_visibility'
     | 'nda_review_background_run'
-<<<<<<< HEAD
-=======
     | 'nda_review_dispatch_active'
->>>>>>> origin/master
     | 'streaming_started'
     | 'streaming_complete'
     | 'section_started'
@@ -509,8 +503,6 @@ export interface WorkspacePaneEvent {
    */
   backgroundRunActive?: boolean;
 
-<<<<<<< HEAD
-=======
   /**
    * Whether a review binding was just DISPATCHED (true) or the dispatch settled without completing —
    * i.e. failed (false). Required when `type === 'nda_review_dispatch_active'`.
@@ -526,7 +518,6 @@ export interface WorkspacePaneEvent {
    */
   dispatchActive?: boolean;
 
->>>>>>> origin/master
   // ── selection_changed fields ──────────────────────────────────────────────
 
   /**

--- a/src/solutions/SpaarkeAi/src/components/conversation/ConversationPane.tsx
+++ b/src/solutions/SpaarkeAi/src/components/conversation/ConversationPane.tsx
@@ -2648,19 +2648,12 @@ export function ConversationPane(): React.JSX.Element {
             transcript-footer chip slot. Renders nothing when there are no live suggestions. */}
         {suggestions.suggestionSlot}
 
-<<<<<<< HEAD
-        {/* UAT round-4 (item #9): "Rerun a full analysis" — a persistent act-on CARD (not a
-            chip; ASSISTANT-UI-ELEMENT-CRITERIA.md) offered after a QUICK-depth review completes.
-            Renders nothing until a quick run completes; single-slot (never stacks). */}
-        {rerunFullAnalysisCard.cardSlot}
-=======
         {/* UAT round-4 (item #9): "Rerun a full analysis" — a persistent act-on CARD (not a chip;
             ASSISTANT-UI-ELEMENT-CRITERIA.md) offered after a QUICK-depth review completes.
             UAT round-6 (item #14): the card MOVED OUT of this top-of-pane region (it read as pinned
             above the notifications area) and INTO the transcript footer (SprkChat.transcriptFooterSlot,
             see `transcriptFooter` above), so it renders inline beneath the "Quick scan…" completion
             message and scrolls WITH the conversation. */}
->>>>>>> origin/master
 
         {/* nda-r1 follow-up (UAT 2026-07-26): "Review an NDA" moved OUT of this top-of-pane
             notification slot (it read as "hidden" above the fold) and INTO the Suggested-Next-Steps

--- a/src/solutions/SpaarkeAi/src/components/conversation/__tests__/ConversationPane.review-chip-depth-ask.e2e.test.tsx
+++ b/src/solutions/SpaarkeAi/src/components/conversation/__tests__/ConversationPane.review-chip-depth-ask.e2e.test.tsx
@@ -29,11 +29,7 @@ if (typeof (global as any).TextEncoder === 'undefined') (global as any).TextEnco
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 if (typeof (global as any).TextDecoder === 'undefined') (global as any).TextDecoder = NodeTextDecoder;
 import React, { act } from 'react';
-<<<<<<< HEAD
-import { render, screen, fireEvent } from '@testing-library/react';
-=======
 import { render, screen, fireEvent, within } from '@testing-library/react';
->>>>>>> origin/master
 import { FluentProvider, webLightTheme } from '@fluentui/react-components';
 
 import { PaneEventBus, PaneEventBusProvider } from '@spaarke/ai-widgets';
@@ -357,8 +353,6 @@ describe('UAT round-3 item #7: "Review an NDA" chip click now asks Quick/Thoroug
     const reviewBody = dispatchPostBodies.find((b) => b.bindingId === REVIEW_BINDING);
     const args = reviewBody!.args as Record<string, unknown> | undefined;
     expect(args).toMatchObject({ fileIds: [SESSION_FILE_ID], reviewDepth: 'quick' });
-<<<<<<< HEAD
-=======
 
     // UAT round-6 (item #15a): the chip-quick dispatch stamped the cross-navigation resume flag at the
     // ONE `runBindingDispatch` chokepoint — a `nda_review_dispatch_active{dispatchActive:true}` fired on
@@ -370,7 +364,6 @@ describe('UAT round-3 item #7: "Review an NDA" chip click now asks Quick/Thoroug
           (e as WorkspacePaneEvent & { dispatchActive?: boolean }).dispatchActive === true
       )
     ).toBe(true);
->>>>>>> origin/master
   });
 
   it('the file still opens in Compose immediately on the chip click, before the depth question is answered', async () => {
@@ -392,8 +385,6 @@ describe('UAT round-3 item #7: "Review an NDA" chip click now asks Quick/Thoroug
     expect(composeOpen).toBeDefined();
   });
 });
-<<<<<<< HEAD
-=======
 
 // ---------------------------------------------------------------------------
 // UAT round-6 items #14 (card placement) + #15a (rerun-thorough dispatch flag)
@@ -461,4 +452,3 @@ describe('UAT round-6: rerun-full-analysis card renders INLINE in the transcript
     expect(dispatchActiveCountAfter).toBeGreaterThan(dispatchActiveCountBefore);
   });
 });
->>>>>>> origin/master

--- a/src/solutions/SpaarkeAi/src/components/workspace/WorkspacePane.tsx
+++ b/src/solutions/SpaarkeAi/src/components/workspace/WorkspacePane.tsx
@@ -109,10 +109,7 @@ import {
   upsertPersistedComposeTab,
   removePersistedComposeTab,
   clearRunInFlight,
-<<<<<<< HEAD
-=======
   clearRunInFlightBySession,
->>>>>>> origin/master
   isRunResumable,
   hasFindings,
   findLatestFindingsPayload,
@@ -992,15 +989,6 @@ export function WorkspacePane(): React.JSX.Element {
     if (changed) writeComposeRunState(snap);
   }, [tabState.tabs, chatSessionId, isHomeSurface]);
 
-<<<<<<< HEAD
-  // Background-run capture: `nda_review_background_run` (round-4) fires true when a
-  // review whose progress modal was dismissed ("Continue working in background") is
-  // still executing. On the home surface we stamp the ACTIVE Compose tab's persisted
-  // entry with `run:{inFlight,dispatchedAt}` + the current session so a return trip
-  // can resume the spinner + poll; on the terminal false we clear the flag.
-  const handleBackgroundRunChange = React.useCallback((active: boolean): void => {
-    setComposeReviewRunningInBackground(active);
-=======
   // Background-run capture (round-4 dismiss signal): `nda_review_background_run` fires true when a
   // review whose progress modal was dismissed ("Continue working in background") is still executing.
   //
@@ -1023,7 +1011,6 @@ export function WorkspacePane(): React.JSX.Element {
   // the owner hit). Clearing on COMPLETION rides `compose_advisory_comments` (keyed by session — see
   // below); this false branch is the failure clear.
   const handleReviewDispatchActive = React.useCallback((active: boolean): void => {
->>>>>>> origin/master
     if (!isHomeSurfaceRef.current) return;
     const activeTab = managerRef.current.getActiveTab();
     if (!activeTab || activeTab.widgetType !== 'compose') return;
@@ -1046,16 +1033,11 @@ export function WorkspacePane(): React.JSX.Element {
         })
       );
     } else {
-<<<<<<< HEAD
-=======
       // Dispatch failed — clear the active tab's flag so a return trip doesn't resume a dead run.
->>>>>>> origin/master
       writeComposeRunState(clearRunInFlight(current, instanceKey));
     }
   }, []);
 
-<<<<<<< HEAD
-=======
   // Completion clear (UAT round-6 item #15a): a review completion — including a zero-findings clean
   // review, which now dispatches unconditionally (see useNdaReviewAdvisoryCommentsBridge) — arrives as
   // `compose_advisory_comments` carrying the completing `sessionId`. Clear the persisted in-flight flag
@@ -1069,7 +1051,6 @@ export function WorkspacePane(): React.JSX.Element {
     writeComposeRunState(clearRunInFlightBySession(readComposeRunState(Date.now()), sessionId));
   }, []);
 
->>>>>>> origin/master
   // Resume poll (still-running case): show the tab spinner (reusing round-4's
   // `composeReviewRunning` slot) and poll compose-outputs until the review's
   // findings land, then materialize them through the SAME `compose_advisory_comments`
@@ -1607,19 +1588,12 @@ export function WorkspacePane(): React.JSX.Element {
     // dismissed progress card itself is fully unmounted (useNdaReviewRunProgress `visible=false` →
     // NdaReviewProgressModal returns null), so this signal is the ONLY remaining liveness surface.
     if (event.type === 'nda_review_background_run') {
-<<<<<<< HEAD
-      // Drives the round-4 tab spinner AND (item #13) stamps the active home-surface
-      // Compose tab's persisted run-in-flight state for cross-navigation resume.
-=======
       // Round-4 dismiss signal — drives the in-page tab spinner ONLY. UAT round-6 (item #15a): it no
       // longer stamps the persisted run flag; dispatch-time stamping does that (see below).
->>>>>>> origin/master
       handleBackgroundRunChange(event.backgroundRunActive === true);
       return;
     }
 
-<<<<<<< HEAD
-=======
     // UAT round-6 (item #15a): stamp / clear the persisted run-in-flight flag at DISPATCH time (true)
     // and on dispatch failure (false). This fires for EVERY review path (chip/typed/gate/wizard/rerun)
     // because they all funnel through the ONE `runBindingDispatch` chokepoint — so the flag is now
@@ -1639,7 +1613,6 @@ export function WorkspacePane(): React.JSX.Element {
       return;
     }
 
->>>>>>> origin/master
     // FR-34 D-F3 (task 071): the deferred CONTENT-render ack. ComposeWorkspace emits
     // `compose_content_rendered` once a seeded draft actually renders in the editor.
     // If we deferred an ack for this ledgerRef on the originating `workspace_open_tab`

--- a/src/solutions/SpaarkeAi/src/components/workspace/__tests__/WorkspacePane.compose-run-restore.test.tsx
+++ b/src/solutions/SpaarkeAi/src/components/workspace/__tests__/WorkspacePane.compose-run-restore.test.tsx
@@ -24,11 +24,7 @@
 
 import '@testing-library/jest-dom';
 import * as React from 'react';
-<<<<<<< HEAD
-import { render, screen, waitFor, act } from '@testing-library/react';
-=======
 import { render, screen, waitFor, act, cleanup } from '@testing-library/react';
->>>>>>> origin/master
 import { FluentProvider, webLightTheme } from '@fluentui/react-components';
 
 import { PaneEventBus, PaneEventBusProvider, usePaneEvent } from '@spaarke/ai-widgets';
@@ -425,8 +421,6 @@ describe('WorkspacePane item #13 — run-in-flight resume', () => {
     }
   });
 });
-<<<<<<< HEAD
-=======
 
 // ---------------------------------------------------------------------------
 // UAT round-6 item #15a — DISPATCH-TIME run flag (the core fix)
@@ -585,4 +579,3 @@ describe('WorkspacePane item #15a — dispatch-time run flag', () => {
     }
   });
 });
->>>>>>> origin/master


### PR DESCRIPTION
Master's SpaarkeAi surface gate + the CI Deploy SpaarkeAi run broke at `56a5336a4`: five files carried raw merge-conflict markers from a bad resolution on the shared branch. All hunks resolved to the newer (round-6) master side; repo-wide sweep clean; AI.Widgets tsc 0 errors; SpaarkeAi full build green; affected suites 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)