### PR TITLE
fix: #712 LW ai-outputs dep + #716 DocumentOperations copy reconciliation

### DIFF
--- a/infrastructure/dataverse/ribbon/DocumentRibbons/WebResources/sprk_DocumentOperations.js
+++ b/infrastructure/dataverse/ribbon/DocumentRibbons/WebResources/sprk_DocumentOperations.js
@@ -118,14 +118,21 @@ Spaarke.Document._getEnvironmentVariable = function(schemaName) {
     return Xrm.WebApi.retrieveMultipleRecords(
         "environmentvariabledefinition",
         "?$filter=schemaname eq '" + schemaName + "'" +
-        "&$select=environmentvariabledefinitionid" +
+        "&$select=environmentvariabledefinitionid,defaultvalue" +
         "&$expand=environmentvariabledefinition_environmentvariablevalue($select=value)"
     ).then(function(result) {
         if (result.entities && result.entities.length > 0) {
             var definition = result.entities[0];
+            // Override value (if set) takes precedence over defaultvalue. Match the
+            // resolution pattern used by @spaarke/auth's resolveRuntimeConfig.ts and
+            // by sprk_emailactions.js — falling back to defaultvalue is REQUIRED
+            // because in dev/demo envs, sprk_TenantId only has a defaultvalue set.
             var values = definition.environmentvariabledefinition_environmentvariablevalue;
             if (values && values.length > 0 && values[0].value) {
                 return values[0].value;
+            }
+            if (definition.defaultvalue) {
+                return definition.defaultvalue;
             }
         }
         return null;
@@ -167,8 +174,11 @@ Spaarke.Document._resolveEnvironmentConfig = function() {
         var cache = Spaarke.Document._envVarCache;
 
         if (cache.bffApiBaseUrl) {
-            Spaarke.Document.Config.bffApiUrl = cache.bffApiBaseUrl.replace(/\/+$/, "");
-            console.log("[Spaarke.Document] BFF URL from env var:", Spaarke.Document.Config.bffApiUrl);
+            // Normalize: strip trailing slashes AND trailing /api to get HOST ONLY.
+            // All fetch URLs must add /api/ themselves (buildBffApiUrl pattern).
+            // This prevents the recurring /api/api/ double-prefix bug.
+            Spaarke.Document.Config.bffApiUrl = cache.bffApiBaseUrl.replace(/\/+$/, "").replace(/\/api$/i, "");
+            console.log("[Spaarke.Document] BFF URL from env var (normalized):", Spaarke.Document.Config.bffApiUrl);
         } else {
             console.error("[Spaarke.Document] MISSING: sprk_BffApiBaseUrl environment variable not found in Dataverse. Ensure it is defined in Dataverse Environment Variables.");
         }
@@ -2007,18 +2017,23 @@ Spaarke.Document.sendToIndex = async function(primaryControl, selectedItemIds) {
         var isGridContext = false;
 
         // Determine context: form or grid/subgrid
+        // Normalize every GUID to lowercase + strip braces. Xrm APIs return GUIDs in
+        // {UPPERCASE} form; Azure AI Search Edm.String filters are case-sensitive, and
+        // lookups elsewhere (Find Similar, related-doc joins) use lowercase. Normalizing
+        // here gives one consistent shape for the BFF and the index. BFF also normalizes
+        // defensively, but cleaner contract to do it at the source.
         if (selectedItemIds && selectedItemIds.length > 0) {
             // Grid or subgrid context
             documentIds = selectedItemIds.map(function(id) {
-                return id.replace(/[{}]/g, "");
+                return id.replace(/[{}]/g, "").toLowerCase();
             });
             isGridContext = true;
             console.log("[Spaarke.Document] SendToIndex - grid context with", documentIds.length, "documents");
         } else if (primaryControl && primaryControl.data && primaryControl.data.entity) {
             // Form context
             var docInfo = Spaarke.Document.Utils.getDocumentInfo(primaryControl);
-            documentIds = [docInfo.id];
-            console.log("[Spaarke.Document] SendToIndex - form context for document:", docInfo.id);
+            documentIds = [(docInfo.id || "").replace(/[{}]/g, "").toLowerCase()];
+            console.log("[Spaarke.Document] SendToIndex - form context for document:", documentIds[0]);
         } else if (primaryControl && primaryControl.getGrid) {
             // SelectedControl from grid/subgrid
             var selectedRows = primaryControl.getGrid().getSelectedRows();
@@ -2026,7 +2041,7 @@ Spaarke.Document.sendToIndex = async function(primaryControl, selectedItemIds) {
                 selectedRows.forEach(function(row) {
                     var rowData = row.getData();
                     if (rowData && rowData.entity) {
-                        var id = rowData.entity.getId().replace(/[{}]/g, "");
+                        var id = rowData.entity.getId().replace(/[{}]/g, "").toLowerCase();
                         documentIds.push(id);
                     }
                 });
@@ -2117,13 +2132,23 @@ Spaarke.Document.sendToIndex = async function(primaryControl, selectedItemIds) {
                     : data.totalRequested + " documents successfully sent to search index.";
             } else if (data.successCount === 0) {
                 resultMsg = "Failed to index documents. Please try again.";
-                if (data.results && data.results.length > 0 && data.results[0].error) {
-                    resultMsg += "\n\nError: " + data.results[0].error;
+                // Response field is `errorMessage` (per RagEndpoints.cs SendToIndexDocumentResult),
+                // not `error`. The old `data.results[0].error` was always undefined so the user
+                // never saw the actual cause. Fixed 2026-05-19.
+                if (data.results && data.results.length > 0 && data.results[0].errorMessage) {
+                    resultMsg += "\n\nError: " + data.results[0].errorMessage;
                 }
             } else {
                 resultMsg = data.successCount + " of " + data.totalRequested + " documents indexed successfully.";
                 if (data.failedCount > 0) {
                     resultMsg += "\n" + data.failedCount + " document(s) failed.";
+                    if (data.results) {
+                        for (var i = 0; i < data.results.length; i++) {
+                            if (!data.results[i].success && data.results[i].errorMessage) {
+                                resultMsg += "\n  - " + data.results[i].errorMessage;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/solutions/LegalWorkspace/package-lock.json
+++ b/src/solutions/LegalWorkspace/package-lock.json
@@ -28,6 +28,7 @@
         "@lexical/rich-text": "^0.41.0",
         "@lexical/selection": "^0.41.0",
         "@microsoft/applicationinsights-web": "^3.3.11",
+        "@spaarke/ai-outputs": "file:../../client/shared/Spaarke.AI.Outputs",
         "@spaarke/ai-widgets": "file:../../client/shared/Spaarke.AI.Widgets",
         "@spaarke/auth": "file:../../client/shared/Spaarke.Auth",
         "@spaarke/communication-components": "file:../../client/shared/Spaarke.Communication.Components",
@@ -61,6 +62,36 @@
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "../../client/shared/Spaarke.AI.Outputs": {
+      "name": "@spaarke/ai-outputs",
+      "version": "1.0.0",
+      "license": "UNLICENSED",
+      "devDependencies": {
+        "@fluentui/react-components": "^9.73.2",
+        "@fluentui/react-icons": "^2.0.320",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest": "^30.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "eslint": "^9.17.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^30.2.0",
+        "jest-environment-jsdom": "^30.2.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "ts-jest": "^29.4.4",
+        "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "@fluentui/react-components": "^9.0.0",
+        "@fluentui/react-icons": "^2.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "../../client/shared/Spaarke.AI.Widgets": {
@@ -3612,6 +3643,10 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@spaarke/ai-outputs": {
+      "resolved": "../../client/shared/Spaarke.AI.Outputs",
+      "link": true
     },
     "node_modules/@spaarke/ai-widgets": {
       "resolved": "../../client/shared/Spaarke.AI.Widgets",

--- a/src/solutions/LegalWorkspace/package.json
+++ b/src/solutions/LegalWorkspace/package.json
@@ -31,6 +31,7 @@
     "@lexical/rich-text": "^0.41.0",
     "@lexical/selection": "^0.41.0",
     "@microsoft/applicationinsights-web": "^3.3.11",
+    "@spaarke/ai-outputs": "file:../../client/shared/Spaarke.AI.Outputs",
     "@spaarke/ai-widgets": "file:../../client/shared/Spaarke.AI.Widgets",
     "@spaarke/auth": "file:../../client/shared/Spaarke.Auth",
     "@spaarke/communication-components": "file:../../client/shared/Spaarke.Communication.Components",


### PR DESCRIPTION
Two owner-directed fixes (2026-08-05): LegalWorkspace's missing `@spaarke/ai-outputs` dependency (fresh-worktree build now verified green) and the `sprk_DocumentOperations.js` two-copy drift reconciled to the org-verified src lineage (byte-identical now). Closes #712. Closes #716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)