### PR TITLE
chore(assistant-r2): portfolio register/archive docs + test format (docs-only)

### DIFF
--- a/projects/spaarkeai-assistant-enhancements-r2/.archived
+++ b/projects/spaarkeai-assistant-enhancements-r2/.archived
@@ -1,0 +1,7 @@
+Archived: 2026-08-10
+Final status: Completed
+Closing PR: #749 (https://github.com/spaarke-dev/spaarke/pull/749)
+Follow-on hotfix PR: #750 (shared-auth cold-start fix) + #752 (prettier)
+Worktree: c:/code_files/spaarke-wt-spaarkeai-assistant-enhancements-r2 (PRESERVED — not removed by archive; clean up separately if desired)
+Remote branch: work/spaarkeai-assistant-enhancements-r2 (still on origin)
+Issue: #753 (closed, Status=Completed, Closed Date=2026-08-10, Parent Epic #421)

--- a/projects/spaarkeai-assistant-enhancements-r2/README.md
+++ b/projects/spaarkeai-assistant-enhancements-r2/README.md
@@ -1,5 +1,7 @@
 # SpaarkeAI Assistant Enhancements R2
 
+> **Portfolio**: [Project Issue #753](https://github.com/spaarke-dev/spaarke/issues/753) · Parent [Epic #421 (SPAARKE AI)](https://github.com/spaarke-dev/spaarke/issues/421) · Board [Project #2](https://github.com/users/spaarke-dev/projects/2)
+>
 > **Last Updated**: 2026-08-10
 >
 > **Status**: ✅ Complete

--- a/projects/spaarkeai-assistant-enhancements-r2/notes/test-diet-report.md
+++ b/projects/spaarkeai-assistant-enhancements-r2/notes/test-diet-report.md
@@ -59,6 +59,17 @@ None.
 
 `useAuthProbe.ts` is live in `App.tsx` and shipped in this deploy, but was previously characterized as structurally superseded by the `requireSilentOnly` flag revert. With the flag reverted the popup fallback succeeds, so the probe's retry can now resolve — it is not broken, but its continued necessity is a design question. Left in place because it is part of the deployed, about-to-be-re-UAT'd state; ripping it out during wrap-up would change App-mount auth gating unverified. Recommend a follow-up review (or R3 note) rather than a wrap-up change. Its test stays (MAINTAIN) as long as the hook stays.
 
+## Addendum — post-close auth hotfix tests (2026-08-10, re-run)
+
+The auth cold-start hotfix (PR #750) added **2 new test files** after the 090 close-out. Re-classified here:
+
+| File | Class | Why |
+|---|---|---|
+| `src/client/shared/Spaarke.Auth/tests/initAuth.idempotency.test.ts` | **MAINTAIN** | Behavioral — asserts a duplicate init for the same clientId coalesces (exactly one `PublicClientApplication` constructed) and a different clientId replaces. Guards the dual-MSAL-instance regression. Lives in the maintained `@spaarke/auth` suite. |
+| `src/client/shared/Spaarke.Auth/tests/SpaarkeAuthProvider.proactiveRefresh.test.ts` | **MAINTAIN** | Behavioral — asserts the background refresh timer never initiates a cold interactive acquire, and does refresh when a session exists. Guards the `interaction_in_progress` regression. |
+
+**Verdict: 2 new MAINTAIN, 0 scaffolding.** Both are regression guards for a real production defect (every bug = regression, ADR-038 KEEP category). Total project test-diet remains clean.
+
 ## Industry citation
 
 Build-vs-maintain per ADR-038 §7 (Beck "delete the scaffolding"; Feathers characterization-vs-behavior; Google test-sizes). 17-ban classifier B1–B17.

--- a/src/client/shared/Spaarke.Auth/tests/SpaarkeAuthProvider.proactiveRefresh.test.ts
+++ b/src/client/shared/Spaarke.Auth/tests/SpaarkeAuthProvider.proactiveRefresh.test.ts
@@ -24,8 +24,9 @@ const freshJwt = (): string => makeJwt(Math.floor(Date.now() / 1000) + 60 * 60);
 class StubStrategy implements AuthStrategy {
   readonly name = 'stub';
   public token = ''; // '' = cold (no session); a JWT = warm
-  acquire = jest.fn(async (): Promise<TokenResult> =>
-    this.token ? { accessToken: this.token, expiresOn: 0 } : { accessToken: '', expiresOn: 0 }
+  acquire = jest.fn(
+    async (): Promise<TokenResult> =>
+      this.token ? { accessToken: this.token, expiresOn: 0 } : { accessToken: '', expiresOn: 0 }
   );
   clearCache = jest.fn();
   logout = jest.fn(async () => {});


### PR DESCRIPTION
Docs + test-format only — no code/behavior change. Carries to master: README portfolio pointer block (Issue #753), `.archived` marker, test-diet addendum, and a CI Prettier reformat of the proactiveRefresh test. Closes out the R2 archive on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)