### PR TITLE
docs(customer-provisioning): 2026-08-12 assessment update + component inventory

### DIFF
--- a/projects/customer-provisioning-orchestration-r1/COMPONENT-INVENTORY.md
+++ b/projects/customer-provisioning-orchestration-r1/COMPONENT-INVENTORY.md
@@ -1,0 +1,240 @@
+# Spaarke Solution — Authoritative Component Inventory (Bill of Materials)
+
+> **Created**: 2026-08-12
+> **Owner**: customer-provisioning-orchestration-r1
+> **Purpose**: The authoritative bill-of-materials for one Spaarke customer environment — every deployable/seedable artifact, its deploy mechanism, dependency order, and per-customer-vs-shared disposition. This is the dependency that the provisioning package (`Provision-Customer.ps1` → control plane) must fully cover.
+> **Status**: Reconnaissance-grade → being hardened to authoritative. Counts marked ✅ come from the machine source of truth; counts marked ⚠️ are agent-surveyed and need one verification pass against a live env.
+
+---
+
+## 0. Sources of truth (how this inventory was assembled)
+
+| Source | What it authoritatively defines | Path |
+|---|---|---|
+| **`Build-SpaarkeMaster.ps1`** ✅ | The machine composition of the full Dataverse component set — entities, web resources, option sets, PCF, roles, env-vars, MDA app/sitemap. Discovers by `sprk_` prefix + explicit IDs; **386 total components** (incl. auto-added subcomponents). | `scripts/Build-SpaarkeMaster.ps1` |
+| `Deploy-DataverseSolutions.ps1` | Managed-solution import set + dependency order | `scripts/` |
+| `src/client/pcf/*` | PCF control source (33 control folders) | repo tree |
+| `src/solutions/*`, `src/client/code-pages/*` | Code-page SPA source | repo tree |
+| `infrastructure/bicep/**` | Azure resource stamp (modules + model1/model2 stacks) | repo |
+| `docs/data-model/entity-relationship-model.md` | Entity schema + relationships | repo |
+| `scripts/seed-data/**`, `infra/dataverse/**` | Config/seed data (the layer solutions don't carry) | repo |
+| `.claude/skills/spe-integration/SKILL.md` | SharePoint Embedded provisioning | repo |
+
+**Structural fact that governs everything below:** managed solutions carry table/column **definitions** but **not configuration rows**. A fully imported solution is still a non-functional app until the **config/seed layer (§9)** is loaded. This is the single most important thing this inventory exists to make visible.
+
+---
+
+## 1. Dataverse solution layer
+
+Imported in dependency order by `Deploy-DataverseSolutions.ps1` (~10 managed solutions). `SpaarkeCore` first (entities, option sets, security roles); then web resources; then feature solutions.
+
+| # | Solution | Contents | Import order | Deploy mechanism |
+|---|---|---|---|---|
+| 1 | **SpaarkeCore** | Root entities, option sets, security roles, sitemap, MDA app shell | **1st (dependency root)** | `pac solution import` (managed) |
+| 2 | webresources | JS + ribbon web resources | 2nd | solution import / web-resource upload |
+| 3 | spaarke_document_management | `sprk_container`, `sprk_document` | after core | solution import |
+| 4 | spaarke_documents | `sprk_aiprofile`, `sprk_document`, `sprk_documentassociation`, `sprk_documentitem` + plugin assemblies | after core | solution import |
+| 5 | **Spaarke.CustomApiProxy** | Custom API proxy plugin registration (`BaseProxyPlugin`, `GetFilePreviewUrlPlugin`) | after core | solution import (Managed=Both) |
+| 6–10 | ~5 feature solutions | Wrap code pages + PCF + feature schema (LegalWorkspace, AI/Analysis, Communication, Reporting, etc.) | last | solution import |
+
+> **ALM note (ADR-027, amended 2026-06-02):** the repo currently uses **unmanaged** solutions everywhere for dev; **managed** packaging for customer environments is locked as decision **D1** but the scripted export→fix→pack-managed→verify pipeline is a build item (r1 handler **H6**). `src/dataverse/solutions/*` folders are **unpacked skeletons** (`Entities/` are `.gitkeep` stubs) — not the sole source of truth; schema is provisioned by a mix of managed-ZIP import and Web-API/PAC `Deploy-*.ps1` scripts.
+
+---
+
+## 2. Dataverse schema — entities
+
+**87+ custom `sprk_*` entities** ✅ (discovered by prefix in `Build-SpaarkeMaster.ps1`) + **3 customized standard entities** (`account`, `contact`, `businessunit` — metadata + `sprk_` columns). Grouped by seed obligation:
+
+### 2A. Transactional entities — start EMPTY (filled at runtime / data migration)
+- **Core**: `sprk_matter`, `sprk_project`, `sprk_organization`, `sprk_document`, `sprk_fileversion`, `sprk_container`, `sprk_documentassociation`, `sprk_documentitem`
+- **Financial**: `sprk_invoice`, `sprk_billingevent`, `sprk_budget`, `sprk_budgetbucket`, `sprk_kpiassessment`, `sprk_spendsignal`, `sprk_spendsnapshot`
+- **Activity/Comms**: `sprk_event`, `sprk_eventset`, `sprk_workassignment`, `sprk_communication`, `sprk_communicationaccount`, `sprk_todo`, `sprk_notificationoutbox`
+- **AI runtime**: `sprk_analysis` + children (`sprk_analysisaction` [instance], `sprk_analysischatmessage`, `sprk_analysisoutput`, `sprk_analysisknowledge`, `sprk_analysisskill`, `sprk_analysistool`, `sprk_analysisworkingversion`, `sprk_analysisemailmetadata`)
+
+### 2B. Reference `*_ref` entities — NEED seed rows (option-list style)
+`sprk_mattertype_ref`, `sprk_mattersubtype_ref`, `sprk_recordtype_ref` (**polymorphic discriminator — load-bearing for regarding lookups**), `sprk_practicearea_ref`, `sprk_eventtype_ref`; AI type lookups `sprk_aiactiontype`/`sprk_analysisactiontype`, `sprk_aiknowledgetype`, `sprk_aitooltype`, `sprk_aiskilltype`, `sprk_aioutputtype`, `sprk_airetrievalmode`, `sprk_analysisdeliverytype`.
+
+### 2C. Configuration/definition entities — NEED seed rows (app is non-functional without them → see §9)
+`sprk_gridconfiguration`, `sprk_fieldmappingprofile` + `sprk_fieldmappingrule`, `sprk_workspacelayout`, `sprk_analysisaction` (definitions), `sprk_analysisplaybook`, `sprk_playbookconsumer` (**the single AI routing surface, ADR-039**), `sprk_analysistool`, `sprk_aimodeldeployment`, `sprk_aiknowledgesource`, `sprk_chartdefinition`.
+
+### 2D. M2M intersection tables (auto-added as relationship subcomponents; do not seed directly)
+`sprk_analysis_knowledge/skill/tool`, `sprk_analysisplaybook_action/analysisoutput/mattertype`, `sprk_playbook_knowledge/skill/tool`, `sprk_playbooknode_skill/knowledge/tool`, `sprk_matter_contact`, `sprk_event_contact`, `sprk_project_contact`, `sprk_project_organization`, `sprk_matter_organization`, `sprk_project_sprk_matter`.
+
+> ⚠️ **Verification item**: the full 87-entity roster is not enumerated in code (discovered by prefix). A complete named catalog should be exported from a live env (`EntityDefinitions?$filter=startswith(LogicalName,'sprk_')`) and pinned here.
+
+---
+
+## 3. Other Dataverse metadata components (from `Build-SpaarkeMaster.ps1` ✅)
+
+| Component type | Count | Notes |
+|---|---|---|
+| Web resources (`sprk_*`) | **195** | JS + code-page bundles + ribbon; type 61 |
+| Global option sets (`sprk_*`) | **24** | type 9 |
+| Environment variable **definitions** (`sprk_*`) | **21** | type 380 — client surfaces read these at runtime |
+| Environment variable **values** | per-env | type 381 — **7 are set per-customer** by `Provision-Customer.ps1` step 8 (see §9) |
+| Security roles ("Spaarke", root BU) | **7** | type 20 |
+| MDA app | **1** | `sprk_MatterManagement` (type 80) |
+| Sitemap | **1** | `sprk_MatterManagement` (type 62) |
+| App module components | **14** | from `SpaarkeCorporateCounselApp` (type 10075) |
+| Customized standard entities | **3** | account, contact, businessunit (metadata + `sprk_` columns) |
+| **TOTAL solution components** | **386** | incl. auto-added subcomponents |
+
+---
+
+## 4. PCF controls
+
+**33 control folders** in `src/client/pcf/`. Only **7 are confirmed in-use and included in SpaarkeMaster** ✅; the rest are either feature-solution-scoped, orphaned, or retired. This is a real signal for the provisioning package — do not assume all 33 ship.
+
+### 4A. Confirmed in-use (in SpaarkeMaster, explicit IDs)
+`DocumentRelationshipViewer`, `EventFormController`, `RelatedDocumentCount`, `SpeDocumentViewer`, `VisualHost`, `SemanticSearchControl`, `EventAutoAssociate`.
+
+### 4B. Explicitly EXCLUDED / orphaned per `Build-SpaarkeMaster.ps1`
+- Not on forms: `UpdateRelatedButton`, `EmailProcessingMonitor`, `ThemeEnforcer`, `RegardingLink`
+- Removed from forms: `ScopeConfigEditor`, `UniversalDocumentUpload`
+- **Broken** (bad `styles.css` web-resource ref): `UniversalDatasetGrid` (also sunsetting in DataGrid Framework Phase F)
+
+### 4C. Retired
+`AssociationResolver` (superseded by `RegardingResolver`).
+
+### 4D. Remaining controls (feature-solution-scoped; verify per-feature)
+AnalysisBuilder, AnalysisWorkspace, CommunicationActions, CommunicationAttachments, CommunicationConnections, CommunicationConversationPanel, CommunicationMessageActions, CommunicationTimeline, CommunicationTimelineRegarding, DrillThroughWorkspace, DueDatesWidget, EventCalendarFilter, MatterHeader, PlaybookBuilderHost, RegardingResolver, ScopeConfigEditor, SpaarkeGridCustomizer, SpeFileViewer, TrackingFieldTrio, UniversalQuickCreate.
+
+> ⚠️ **Verification item**: reconcile the 33 source folders against what each feature solution actually packs. The 7-vs-33 gap is the kind of thing that silently breaks a customer standup.
+
+---
+
+## 5. Code pages (React/Vite SPAs → Dataverse web resources)
+
+Deployed as web resources via `code-page-deploy` / `Deploy-*CodePages.ps1`. ~28 SPAs in `src/solutions/` + ~6 in `src/client/code-pages/`.
+
+**Flagship / active**: **SpaarkeAi** (primary AI workspace host), DailyBriefing (Pattern D dual-use), Reporting, SmartTodo, EmailPage, Notepad, PlaybookLibrary, AllDocuments, FindSimilarCodePage, SpeAdminApp, WorkspaceLayoutWizard, EventsPage/EventDetailSidePane, CalendarSidePane, communication/invoice/KPI pages, SummarizeFilesWizard.
+**Wizards (7, thin wrappers on shared WizardShell)**: CreateEvent / CreateInvoice / CreateMatter / CreateProject / CreateReportCard / CreateTodo / CreateWorkAssignment; plus DocumentUploadWizard.
+**Retired (kept as component library, not standalone)**: **LegalWorkspace** — SpaarkeAi is the host (OC-R4-05).
+**Non-SPA in folder**: CopilotAgent (M365 declarative agent), EventCommands (ribbon JS), SpaarkeCore/spaarke_insights (solution staging), DemoRegistration, TodoDetailSidePane.
+
+---
+
+## 6. Dataverse plugins
+
+| Assembly | Plugins | Registration | Path |
+|---|---|---|---|
+| `Spaarke.Dataverse.CustomApiProxy` (.NET FW 4.6.2) | `BaseProxyPlugin` (base), `GetFilePreviewUrlPlugin`; helper `SimpleAuthHelper` | Plugin assembly + step registration on Custom API messages; Custom API message definitions must exist in target org | `src/dataverse/plugins/Spaarke.CustomApiProxy/` |
+
+Proxies Dataverse Custom API calls → BFF (e.g., file-preview URL generation).
+
+---
+
+## 7. BFF + Azure resource stamp (per customer)
+
+BFF `Sprk.Bff.Api` (.NET 8 Minimal API, ~35 DI modules / 269 registrations) → **Azure App Service** (`bff-deploy` / `Deploy-BffApi.ps1`; **≤60 MB compressed** ceiling). Backing Azure resources (per `infrastructure/bicep/**` + `auth-azure-resources.md`):
+
+| Resource | Purpose | Disposition (see §11) |
+|---|---|---|
+| App Service + Plan | BFF host | 🟡 shared (Model 1) / 🔴 dedicated (Model 2 / r1 D3) |
+| User-Assigned Managed Identity | Server-outbound identity (Graph app-only, Dataverse, Cosmos, KV) | 🔴 per-deployment |
+| Key Vault | All secrets; App Service resolves `@Microsoft.KeyVault(...)` via UAMI | 🔴 dedicated (cheap) |
+| Azure OpenAI (+ model deployments) | LLM inference, embeddings | **decision point** — see §11 |
+| Azure AI Search | Vector + semantic RAG (7-index catalog) | **decision point** — see §11 |
+| Cosmos DB (serverless) | AI sessions, prompts, audit, memory, feedback; **also ProvisioningRun state (r1 D13)** | 🟡 partition by `/tenantId` |
+| Redis | OBO token cache (ADR-009), session state | 🟡 key-prefix / 🔴 Premium+VNet |
+| Service Bus | Job queues + membership topic (ADR-034) | 🟢 shareable |
+| Storage | temp/doc-processing/AI-chunks | 🟡 container / 🔴 doc content |
+| App Insights + Log Analytics | Telemetry, audit, UAC-DIAG | 🟢 shareable |
+| Content Safety, Doc Intelligence | Prompt-injection detection, OCR | 🟢 shareable (stateless) |
+| SignalR (optional/Null-Object) | Notifications spine realtime | 🟢 |
+| Power BI Embedded | Reporting module | per-customer workspace |
+
+> **RBAC provisioning steps (each a known failure point):** UAMI → KV Secrets User; **`keyVaultReferenceIdentity` PATCHed to UAMI** (silent-failure trap); UAMI → **Cognitive Services User** (wildcard, narrower OpenAI-User role insufficient for `kind=AIServices`); UAMI → Cosmos Data Contributor; **MI registered as Dataverse Application User** in every env (silent 403→500 if omitted); ~11 Graph app-role grants replicated onto MI; **two Exchange ApplicationAccessPolicies** (app-reg + MI); GitHub OIDC → Contributor. Staging slot has a **different MI** → grant KV RBAC to both slots.
+
+---
+
+## 8. Static Web Apps / add-ins / external SPA
+
+| Artifact | Deploy target | Current isolation |
+|---|---|---|
+| Outlook add-in | Azure Static Web App (`office-addins-deploy` / SWA CLI) | **single shared SWA today** |
+| Word add-in (Compose) | Azure Static Web App | single shared SWA today |
+| external-spa (Entra External ID portal) | Static Web App / Power Pages code site | single shared; **BFF host baked at Vite build time** (rebuild+redeploy on host change) |
+| M365 Copilot declarative agent | CopilotAgent manifest package | 1 |
+
+> ⚠️ Office add-ins + external portal are **single shared instances**, not per-customer. If a customer needs an isolated add-in/portal, that provisioning **does not exist yet** (gap).
+
+---
+
+## 9. Configuration & seed data — THE CRITICAL LAYER
+
+Managed solutions do **not** carry these rows. A fresh environment imports solutions and creates SPE containers but **grids render nothing, wizards don't map fields, the AI layer is dark, and the workspace won't render** until these run. **This layer is decoupled from `Provision-Customer.ps1` today (top gap — see PROJECT-UPDATE §6, Gap 1).**
+
+| Config data | Table(s) | Seeder | Order |
+|---|---|---|---|
+| AI type lookups | `sprk_ai*type`, `sprk_analysisactiontype` | `Deploy-TypeLookups` via `Deploy-All-AI-SeedData.ps1` (`type-lookups.json`) | 1 (AI prereq) |
+| AI Actions (defs) | `sprk_analysisaction` | `infra/dataverse/actions/*.action.json` + `Deploy-AnalysisAction.ps1` (**current R7**); legacy MVP `scripts/seed-data/actions.json` | 2 |
+| Analysis tools | `sprk_analysistool` | `infra/dataverse/sprk_analysistool-*-row.json` (~40) + `Seed-TypedHandlers.ps1` | 3 |
+| Knowledge / skills / output-types | `sprk_aiknowledgesource`, `sprk_analysisskill`, `sprk_aioutputtype` | `Deploy-Knowledge/Skills/OutputTypes.ps1` | 4 |
+| Playbooks | `sprk_analysisplaybook` (+ intersections) | `Deploy-Playbooks.ps1` (`playbooks.json`); multinode in `infra/dataverse/playbooks/` | 5 |
+| **Bindings (AI routing surface)** | `sprk_playbookconsumer` | `Seed-PlaybookConsumers.ps1`, mirror `infra/dataverse/sprk_playbookconsumer-rows.json` | 6 |
+| DataGrid configs | `sprk_gridconfiguration` | authored records (`sprk_configjson`); maker/MCP export | any |
+| Field-mapping profiles/rules | `sprk_fieldmappingprofile` + `sprk_fieldmappingrule` | authored (OOB forms); Web-API seeding recipe in `FIELD-MAPPING-ADMIN-GUIDE.md` | any |
+| System workspace layouts | `sprk_workspacelayout` (isSystem) | `Deploy-SystemWorkspaceLayouts.ps1` | any |
+| Chart definitions | `sprk_chartdefinition` | `Create-*ChartDefinitions.ps1` / `Load-DemoSampleData.ps1` | any |
+| AI model deployments | `sprk_aimodeldeployment` | env-specific; points at the customer's Azure OpenAI deployment | after infra |
+| **7 Dataverse env-var values** | `environmentvariablevalue` | `Provision-Customer.ps1` step 8 | after infra |
+| AI Search indexes | (Azure) | `ai-search/Deploy-AllIndexes.ps1` (7 indexes) | after infra |
+
+**One-shot for AI layer**: `scripts/seed-data/Deploy-All-AI-SeedData.ps1` (type-lookups → actions → tools → knowledge → skills → playbooks → output-types), then `Seed-PlaybookConsumers.ps1`.
+
+**7 per-customer env-var values** (client surfaces are non-functional without them): `sprk_BffApiBaseUrl`, `sprk_BffApiAppId`, `sprk_MsalClientId`, `sprk_TenantId`, `sprk_AzureOpenAiEndpoint`, `sprk_ShareLinkBaseUrl`, `sprk_SharePointEmbeddedContainerId`.
+
+> ⚠️ **Drift risk**: two competing AI seed sources — `scripts/seed-data/*.json` (2026-01 MVP) vs `infra/dataverse/**` (R7 current). Confirm authoritative source per environment before seeding.
+
+---
+
+## 10. SharePoint Embedded (SPE)
+
+Policy: **one container per client/business unit** (ADR-005 flat storage; hierarchy in Dataverse `sprk_documentassociation`; access via `SpeFileStore` facade, ADR-007).
+
+| Step | Automated? | Tooling | Frequency |
+|---|---|---|---|
+| Create container **type** (owned by BFF API app) | Semi (needs global-admin consent) | `Create-NewContainerType.ps1` | one-time per Entra tenant |
+| Register owning app + MI with container type | Yes | `Register-BffApiWithContainerType.ps1`, `Register-BffMiWithContainerType.ps1` | one-time per tenant |
+| Register container type in **consuming tenant** | Manual consent + script | `RegisterContainer.ps1` | one-time per tenant |
+| Cert bootstrap (KV → register) | Yes | `Import-And-Register.ps1` | one-time |
+| Create per-customer **container** | Yes | `Provision-Customer.ps1` step 10 (Graph `POST /storage/fileStorage/containers`) | per customer |
+| Additional BU containers | Yes | `New-BusinessUnitContainer.ps1` | on demand |
+| Wire container ID into Dataverse | Yes | `Set-ContainerId.ps1` + `sprk_SharePointEmbeddedContainerId` | per customer |
+
+> ⚠️ **Live drift trap**: container creation now **403s on the delegated token** ("public client not allowed") — needs a **confidential-client app-only** token. Documented as not-yet-fixed in the scripts. Also: SPE content **always lands in the consuming (customer) tenant's** SharePoint, and container-type setting changes take **up to 24h** to replicate.
+
+---
+
+## 11. Per-customer provisioning BOM — summary
+
+| Deploy mechanism | Count | Disposition |
+|---|---|---|
+| Dataverse managed-solution import | ~10 solutions (386 components) | 🔴 per-customer env |
+| PCF controls | 7 in-use (of 33 built) | shipped inside solutions |
+| Code-page web resources | ~28 SPAs (+~6) | shipped inside solutions |
+| Dataverse plugin assembly | 1 (2 plugins) + Custom API msgs | inside CustomApiProxy solution |
+| App Service (BFF) | 1 + ~10 backing Azure services | see §7 |
+| Static Web Apps | 2–3 (Office add-ins + external portal) | ⚠️ shared today |
+| Config/seed layer | ~12 seed operations (§9) | 🔴 per-customer, **not yet in orchestrator** |
+| SPE container | 1+ per customer | 🔴 per-customer |
+| M365 Copilot agent | 1 | shared/per-customer TBD |
+
+### Shared-vs-dedicated decision (the open architectural fork)
+- 🔴 **Always dedicated (cheap/customer-owned)**: Dataverse, SPE, Key Vault secrets, Storage, MI, Entra app config, CIAM.
+- 🟡 **The cost levers (fixed floors)**: **App Service Plan, Azure OpenAI (provisioned TPM), Azure AI Search (fixed tier)** — shared in Model 1; **dedicated under r1 decision D3**.
+- 🟢 **Safely shared**: Service Bus, App Insights/Log Analytics, Content Safety, Doc Intelligence.
+
+> r1 **D3 (no shared resources) + D4 (subscription per customer)** dissolve the cost-allocation problem (native per-customer Azure bill) at the price of a per-customer fixed floor. If a **shared trial/SMB tier** is added, it requires an **APIM/gateway token-metering layer** (per-tenant attribution) + fixed-cost allocation for AI Search. See PROJECT-UPDATE §4–5.
+
+---
+
+## 12. Inventory gaps / verification backlog
+
+1. ⚠️ Export and pin the **complete named 87-entity roster** from a live env.
+2. ⚠️ Reconcile **33 PCF folders → 7 in-use** and map each remaining control to the feature solution that packs it (or mark retired).
+3. ⚠️ Resolve the **two-source AI seed drift** (`scripts/seed-data` MVP vs `infra/dataverse` R7) → single authoritative source.
+4. ⚠️ Produce a **single validated env-var/app-setting manifest** reconciled against BFF code `[Required]` annotations (today split across two docs; ~25 settings found only by startup exceptions).
+5. ⚠️ Confirm **managed-solution export/fix/pack** pipeline (r1 H6) covers all 10 solutions.
+6. ⚠️ Decide per-customer vs shared for **Office add-ins, external SPA, Copilot agent** (currently shared).

--- a/projects/customer-provisioning-orchestration-r1/PROJECT-UPDATE-2026-08-12.md
+++ b/projects/customer-provisioning-orchestration-r1/PROJECT-UPDATE-2026-08-12.md
@@ -1,0 +1,146 @@
+# Project Update — Customer Provisioning & Deployment Orchestration (r1)
+
+> **Date**: 2026-08-12
+> **Author**: Owner working session (assessment + discussion)
+> **Project**: `customer-provisioning-orchestration-r1`
+> **Worktree**: `C:\code_files\spaarke-wt-customer-provisioning-orchestration-r1` · branch `work/customer-provisioning-orchestration-r1`
+> **Design status before this update**: design.md written 2026-06-27, Q1–Q6 resolved (D12–D17), **awaiting owner review → `/design-to-spec`**. Cold ~7 weeks.
+> **Purpose of this update**: Capture the 2026-08-12 assessment (fresh investigation of existing code, docs, prior projects, and Aug-2026 best practices), reconcile it with the locked design, and define a **design-refresh + to-do list** to run before `/design-to-spec` → `/project-pipeline`.
+> **Companion doc**: [`COMPONENT-INVENTORY.md`](COMPONENT-INVENTORY.md) — authoritative bill-of-materials.
+
+---
+
+## 1. Why this update exists
+
+The owner asked for a structured, repeatable, maximally-automated process to deploy Spaarke for new customers, with a north star of **"provision + deploy a new customer, off-the-shelf, in a day."** A six-workstream investigation (deployment tooling, prior projects, solution footprint, Azure/auth architecture, data side, and Aug-2026 best practices) plus a legal-AI cost-economics research pass produced the findings below. This project (`customer-provisioning-orchestration-r1`) is confirmed as the **correct convergence home** for that effort — but its design predates several of these findings and one locked decision (D3) is now worth re-validating.
+
+---
+
+## 2. Headline: this is a "unify + close 4 gaps" effort, not greenfield
+
+Spaarke is ~70% of the way to repeatable customer deployment. The spine already exists and is production-proven (it built the demo env):
+
+- **`scripts/Provision-Customer.ps1`** — 13-step, idempotent, resumable orchestrator (RG → Bicep → KV → Dataverse env → solution import → env-vars → SPE container → registry → smoke test).
+- **`infrastructure/bicep/`** — 26 modules + `platform.bicep`/`customer.bicep` + **both** model stacks (`model1-shared`, `model1-customer`, `model2-full`), parameterized by `customerId`.
+- **`Deploy-Release.ps1` / `Deploy-Platform.ps1` / `Decommission-Customer.ps1` / `Validate-DeployedEnvironment.ps1`** — app-layer release, platform, teardown, acceptance-scan.
+- **`Build-SpaarkeMaster.ps1`** — machine composition of the full 386-component Dataverse solution.
+- **This project's `design.md`** — 3-layer control-plane architecture (L1 handlers → L2 control-plane API/MCP → L3 swappable front ends), D1–D17 locked.
+
+The real work: **converge ~10 overlapping deployment projects + ~11 drifting guides into one package + one control plane + one guide**, close four gaps (§6), and productize per the locked 3-layer design.
+
+---
+
+## 3. The two models map onto Microsoft's 2026 tenancy spectrum
+
+| Spaarke model | Microsoft pattern | Target |
+|---|---|---|
+| **Model 1** (Spaarke-hosted, shared platform + per-customer isolation) | fully-multitenant / vertically-partitioned | SMB / trial — accept **logical** isolation |
+| **Model 2** (fully dedicated stamp) | automated single-tenant / deployment stamp | Regulated legal — **physical** isolation |
+
+Microsoft's own guidance uses **cloud software for legal firms** as the canonical example that justifies dedicated stamps, and states dedicated-per-customer is "unsustainable unless you provision a **dedicated subscription per tenant**." → When dedicating, the isolation boundary is an **Azure subscription per customer** (r1 **D4** already locked this), not just a resource group.
+
+**Azure-tenant question resolved**: do **not** mint a separate Entra tenant per customer. Use **one Spaarke tenant + one multitenant Entra app**, isolate at the **subscription** layer. A separate tenant only enters when a customer **brings their own** (Model 2 in their tenant). This resolves the `spe-multi-tenant-architecture-r1` blocker as a **code change** (remove hardcoded `TENANT_ID`, make BFF multi-issuer aware), not a tenant-proliferation strategy.
+
+**Recommended overall posture**: **vertically-partitioned** — Model 2 dedicated as the default for real/regulated customers; a Model 1 shared, metered tier for trials/demos where a per-prospect fixed floor is uneconomic.
+
+---
+
+## 4. ⚠️ Decision to reconcile: D3 (no shared resources) vs. cost of the fixed floors
+
+**This is the one place where the assessment pushes back on the locked design and should be re-validated before spec.** (Per root CLAUDE.md §6.5 ADR/decision-conflict protocol.)
+
+- **Locked**: r1 **D3 = "no shared resources between customers"** — dedicated per-customer OpenAI, AI Search, Doc Intelligence, Service Bus, Redis, Key Vault, App Insights; **D4 = subscription per customer**.
+- **The tension**: three resources carry a **fixed monthly floor** regardless of usage — **App Service Plan, Azure OpenAI (provisioned TPM), Azure AI Search (fixed tier)**. Dedicating them per customer is honest and noisy-neighbor-free (Azure Cost Management + tags = native per-customer bill, **zero metering infra**), but the floor is brutal for small/trial customers who barely use the system.
+- **The counter-option (Model 1 sharing)**: far lower floor, but requires building a **per-tenant token-metering layer** (APIM gateway or app-level custom metric keyed on tenant) to bill fairly, and accepts logical-only isolation (hard sell to regulated legal).
+
+**Recommendation (to confirm)**: **keep D3 dedicated as the default** (right for legal; makes billing honest) **and** add two things as a **D3 amendment**:
+1. A **shared, metered trial/SMB tier** (Model 1) for prospects — needs the metering layer.
+2. Build the **per-tenant token-metering layer anyway** — it is a **no-regret** investment: it powers the pricing model (§5) under *any* tenancy choice.
+
+**Resolution path**: Path A (project-scoped D3 amendment documented in design.md ADR-tensions) — not a full ADR change.
+
+---
+
+## 5. Cost economics — the Harvey/Legora per-seat problem, and how our model answers it
+
+Legal-AI vendors are openly moving off flat per-seat pricing because agentic usage decouples cost from headcount (10–100× per-user variance). **Harvey** (Nov 2025) → usage/outcome + revenue-share; **Legora** (Jun 2026) → credit-based metered "Agent Pro." Category consensus: **hybrid — seat/platform floor + metered/credit lane for heavy usage.**
+
+**Where token cost derives** (matters for architecture, not just pricing):
+1. **Context re-transmission in the agent loop** (dominant — stateless model resends accumulated context every step; a 20-step task ≈ 200× a chat turn).
+2. RAG context stuffing (2–10K tokens/query untuned).
+3. **Long legal documents** (128K-context turn costs 4–6× a 16K one) — *Spaarke is agentic **and** long-document = worst-case token profile.*
+4. Tool-schema/planning overhead, reasoning tokens, retries; then output/embeddings/OCR.
+
+**Two-layer answer for Spaarke:**
+
+**(a) Architectural cost controls** (attack the drivers): **prompt caching** on the stable agent-loop prefix (~50–90% off cached input), **model tiering** (cheap for routing/extraction, frontier for drafting; ~90% reduction reported), **retrieval + context compression** (RAG saves 60–80% vs stuffing), **per-tenant token budgets/quotas** (runaway-loop guardrail), **batch API** (~50% off) for non-interactive work, evaluate **PTU only after 30–60 days PAYG telemetry**.
+
+**(b) Pricing model**: **platform/seat fee (predictable floor = margin hedge) + included AI allowance (credits/tasks) + metered overage.** Matches where Harvey/Legora landed. Reserve outcome/revenue-share as an experimental enterprise motion.
+
+**The synthesis that closes the loop**: with r1's **dedicated-per-customer** model, each customer's Azure spend **is** their AI cost → **usage-passthrough pricing becomes natural and honest** (arguably more defensible than Harvey's, because COGS is transparently the customer's own dedicated resource bill). The **per-tenant metering layer is the single no-regret engineering investment** under any pricing model.
+
+---
+
+## 6. The four gaps between "70%" and push-button
+
+| # | Gap | Fix | r1 handler |
+|---|---|---|---|
+| **1** | **Config seed decoupled from provisioning** (highest leverage). Solutions ship definitions, not rows → fresh env is non-functional (grids blank, wizards unmapped, AI dark, workspace won't render). | Fold existing seeders (`Deploy-All-AI-SeedData.ps1`, `Seed-PlaybookConsumers.ps1`, grid/field-mapping/workspace-layout seeds) into the orchestrator as a **declarative config-seed manifest step**; resolve the two-source AI seed drift. | H12 (make first-class, not "thin") |
+| **2** | **Web-resource/code-page layer hardcoded to `spaarkedev1`.** | Harden `Deploy-Release.ps1` Phase 4 to be `customerId`-driven; chain into the orchestrator. | H6 + release |
+| **3** | **Entra app registrations + Dataverse App User manual/single-tenant.** ~11 grants by hand, admin consent human-only, App User is PPAC-UI-only. Customer-tenant (Model 2) needs multi-issuer BFF + per-customer app-reg automation + admin-consent landing flow. Two steps are **irreducibly manual** (admin consent; SPE billing/consent). | H3 scripts grants idempotently; H10 attempts SDK then gate; build consent landing. | H3, H10, H11 |
+| **4** | **No single verified acceptance gate; docs fragmented.** 4 overlapping master guides (stale ones not deprecated in-body), contradictory env-var counts, **silent-failure class** (`keyVaultReferenceIdentity`→UAMI; two Exchange policies; staging-slot different MI) not in customer runbook. | One authoritative guide + one validated env-var/app-setting manifest (reconciled to code `[Required]`) + extend `Validate-DeployedEnvironment.ps1` into an end-to-end "customer production-ready" gate. | validation |
+
+**Live drift traps to fix regardless**: (a) SPE container creation now **403s on delegated token** → needs confidential-client app-only; (b) **Cosmos DB provisioning not in the 13 steps** though BFF won't start without it.
+
+---
+
+## 7. Self-service feasibility & data side (objectives #6, #7)
+
+- **Customer self-deploy**: automatable for ~95%, gated by **two irreducible customer-admin actions** — (1) admin consent to the multitenant Entra app (per-tenant, cannot be bulk-applied), (2) SPE billing/consent activation. Package = solution primitives (managed solutions + Package Deployer) + control-plane pipeline + Claude Code primitives + **one** onboarding guide with `[CUSTOMER ADMIN]` gates marked. Build the **BFF to double as the consent-capture onboarding client** (capture `tid` on consent callback → trigger pipeline).
+- **Data migration** (**genuine gap**): `Migrate-DataverseData.ps1` is Dataverse→Dataverse only and **excludes `sprk_document`/SPE content**; no CSV/legacy import, no bulk "load files into SPE + create `sprk_document` + index." Lives in the `spaarke-data` CLI (`SPAARKE-DATA-CLI`, Phase 0 only). r1 currently **scopes migration out** — confirm that's still right for "day-one" (acceptable: new customer starts empty-but-functional; migration is a follow-on).
+
+---
+
+## 8. Tooling recommendation: adopt the Terraform Power Platform provider (hybrid)
+
+The "single package for Power Apps + Azure" is the **first-party Terraform Power Platform provider** — the only IaC toolchain covering **both** Dataverse environment lifecycle and Azure in one plan/state (Bicep has no Power Platform provider). **Recommendation (hybrid, not rip-replace):** keep the 26 tuned Bicep modules for the Azure stamp; adopt the **Terraform Power Platform provider for Dataverse env provisioning** (exactly where D14's manual PPAC steps live); use **Package Deployer** for the solution artifact. Gotcha: SPs **can't** create `Developer`-type envs (use Sandbox/Production); SP must be admin-bootstrapped via BAP API once.
+
+---
+
+## 9. North star reality check
+
+**"Up and running in a day" is real for a clean off-the-shelf standup.** The automatable path runs in <1h of pipeline time. The three things that blow past a day are **lead-time, not compute**: Azure quota / OpenAI region capacity (1–3 days), SPE container-type replication (up to 24h), customer admin consent + security review (customer-dependent). **Restated north star**: *"Automated provisioning completes in <1h of pipeline runtime; customer is production-ready within one business day of admin consent + quota being in place."* Front-load the three lead-time items.
+
+---
+
+## 10. To-do — design-refresh before `/design-to-spec`
+
+Ordered. Items 1–4 are the design-refresh delta; 5–6 are the deliverables already produced this session.
+
+1. **[DECISION] Re-validate D3/D4** against §4–5. Either reaffirm D3 + add the metering-layer & shared-trial-tier amendment, or amend. Document in design.md **ADR-Tensions** (Path A). — *owner decision; blocks spec.*
+2. **[DESIGN] Make config-seed (Gap 1) a first-class handler** — promote H12 from "thin" to a declarative config-seed manifest; resolve `scripts/seed-data` vs `infra/dataverse` source-of-truth. — *highest functional payoff.*
+3. **[DESIGN] Refresh footprint** — the solution has grown since June (Compose, notifications, messaging, email-intelligence, etc.). [`COMPONENT-INVENTORY.md`](COMPONENT-INVENTORY.md) is the new baseline; work its §12 verification backlog.
+4. **[DECISION] Confirm data-migration scope** (in or deferred to `spaarke-data` CLI) for the day-one north star.
+5. **[DELIVERABLE ✅] Authoritative component inventory** — [`COMPONENT-INVENTORY.md`](COMPONENT-INVENTORY.md).
+6. **[DELIVERABLE ✅] This project update** — captures assessment, decisions, gaps, to-do.
+
+**Then**: `/design-to-spec` → `/project-pipeline`. Build sequence stays L1 handlers → L2 control plane → L3 operator skill (D8).
+
+### Fast-follow engineering items (independent of tenancy decision)
+- Build the **per-tenant token-metering layer** (APIM gateway or app-level custom metric) — no-regret.
+- Fix the **SPE delegated-token 403** (confidential-client app-only).
+- Add **Cosmos DB provisioning** to the orchestrator.
+- Consolidate deployment docs → one authoritative guide + one validated env-var/app-setting manifest.
+- Extend `Validate-DeployedEnvironment.ps1` → single end-to-end acceptance gate.
+
+---
+
+## 11. References
+
+- Design: [`design.md`](design.md) (D1–D17, handler catalog H0–H14, risk register) · [`discovery/phase-0-discovery-report.md`](discovery/phase-0-discovery-report.md)
+- Inventory: [`COMPONENT-INVENTORY.md`](COMPONENT-INVENTORY.md)
+- Spine: `scripts/Provision-Customer.ps1`, `Deploy-Release.ps1`, `Deploy-Platform.ps1`, `Build-SpaarkeMaster.ps1`, `Validate-DeployedEnvironment.ps1`
+- IaC: `infrastructure/bicep/**` (stacks `model1-shared`, `model1-customer`, `model2-full`)
+- Guides to consolidate: `SPAARKE-DEPLOYMENT-GUIDE.md`, `CUSTOMER-ONBOARDING-RUNBOOK.md`, `auth-deployment-setup.md`, `MULTI-ENVIRONMENT-PROVISIONING-GUIDE.md`
+- Related projects: `production-environment-setup-r2` (env-agnostic config), `spe-multi-tenant-architecture-r1` (customer-hosted auth — unbuilt), `spaarke-demo-data-setup-r1` (`spaarke-data` CLI)
+- Architecture: `INFRASTRUCTURE-PACKAGING-STRATEGY.md` (Model 1/2), ADR-014, ADR-027 (subscription isolation; unmanaged-solution amendment 2026-06-02), ADR-028 (auth)


### PR DESCRIPTION
## Summary
Adds two documents to the `customer-provisioning-orchestration-r1` project from the 2026-08-12 owner assessment session:

- **PROJECT-UPDATE-2026-08-12.md** — six-workstream deployment assessment: the "70%-built, unify + close 4 gaps" reframe, Model 1/2 tenancy mapping, the D3 shared-vs-dedicated decision to reconcile before spec, legal-AI cost economics (Harvey/Legora), and the ordered design-refresh to-do list ending at `/design-to-spec`.
- **COMPONENT-INVENTORY.md** — authoritative per-customer bill-of-materials (Dataverse solutions/schema/config-seed, PCF, code pages, BFF + Azure stamp, SPE), with a verification backlog.

Docs-only. No source/config changes.

## Related
Feeds `projects/customer-provisioning-orchestration-r1/design.md` (design-refresh before pipeline).

## Testing
N/A — documentation only.