### PR TITLE
hotfix: repair stale AccountId param breaking the test build on master

### DIFF
--- a/tests/integration/Spe.Integration.Tests/ExternalAccess/ExternalAccessIntegrationTests.cs
+++ b/tests/integration/Spe.Integration.Tests/ExternalAccess/ExternalAccessIntegrationTests.cs
@@ -77,7 +77,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             ProjectId: Guid.NewGuid(),
             AccessLevel: ExternalAccessLevel.ViewOnly,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(GrantEndpoint, validRequest);
@@ -116,7 +116,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             FirstName: null,
             LastName: null,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(InviteEndpoint, validRequest);
@@ -221,7 +221,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             ProjectId: Guid.NewGuid(),
             AccessLevel: ExternalAccessLevel.ViewOnly,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(GrantEndpoint, request);
@@ -242,7 +242,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             ProjectId: Guid.Empty,
             AccessLevel: ExternalAccessLevel.ViewOnly,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(GrantEndpoint, request);
@@ -387,7 +387,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             FirstName: null,
             LastName: null,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(InviteEndpoint, request);
@@ -410,7 +410,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             FirstName: null,
             LastName: null,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(InviteEndpoint, request);
@@ -435,7 +435,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             FirstName: null,
             LastName: null,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(InviteEndpoint, request);
@@ -508,7 +508,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             ProjectId: Guid.NewGuid(),
             AccessLevel: ExternalAccessLevel.ViewOnly,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(GrantEndpoint, request);
@@ -570,7 +570,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             ProjectId: Guid.NewGuid(),
             AccessLevel: ExternalAccessLevel.ViewOnly,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(GrantEndpoint, request);
@@ -707,7 +707,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             ProjectId: Guid.NewGuid(),
             AccessLevel: ExternalAccessLevel.ViewOnly,
             ExpiryDate: null,
-            AccountId: null);
+            OrganizationId: null);
 
         // Act
         var response = await _authenticatedClient.PostAsJsonAsync(GrantEndpoint, request);
@@ -834,7 +834,7 @@ public class ExternalAccessIntegrationTests : IClassFixture<IntegrationTestFixtu
             ProjectId: Guid.NewGuid(),
             AccessLevel: ExternalAccessLevel.Collaborate,
             ExpiryDate: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
-            AccountId: null);
+            OrganizationId: null);
 
         var response = await _authenticatedClient.PostAsJsonAsync(GrantEndpoint, request);
 


### PR DESCRIPTION
## Summary
Master's test build is broken: `ExternalAccessIntegrationTests.cs` (merged via #758) still passes `AccountId: null` to `GrantAccessRequest` / `InviteExternalUserRequest`, but those records renamed `AccountId → OrganizationId` in the polymorphic-grant work (task 070 — `sprk_organization`, not the OOB `account`). The stale param is a **compile error that breaks the entire integration test build**, turning the required checks red and blocking other projects' merges (reported by email-communication-intelligence-r2, PR #755).

Fix: renamed all 11 `AccountId: null` sites to `OrganizationId: null`.

## Verification
- Local build: ✅ `dotnet build tests/integration/Spe.Integration.Tests/ -c Release` → **0 errors**
- No behavior change (the param was always passed `null`)

## Conflict resolution
None — clean cherry-pick onto master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)