### PR TITLE
external-access-r2: #4C DataGrid inline-fetchXml entity-extraction hardening

### DIFF
--- a/projects/spaarke-SPA-external-access-platform-r2/current-task.md
+++ b/projects/spaarke-SPA-external-access-platform-r2/current-task.md
@@ -16,6 +16,14 @@
 | **PCF version history** | …v1.0.22 wording; v1.0.23 = OverlayDrawer side-pane redesign (SUPERSEDED); **v1.0.24 = native advanced lookup + Manage Access polish (#2/#3/#5/#6/#7) + email fixes (#9 regarding-name, #10 recipient lookup, #11 attachment upload) + SprkModal `nonBlocking`**. Rebuild recipe: bump 5 files → **build shared lib first (`npm run build` in Spaarke.UI.Components — REQUIRED when shared .tsx changed)** → `npm run build:prod` in TrackingFieldTrio → `cp out/controls/bundle.js Solution/Controls/.../bundle.js` → `cd Solution; ./pack.ps1` → `pac solution import --path bin/…zip --force-overwrite --publish-changes`. Packed ControlManifest.xml is hand-maintained — keep in sync. |
 | **Branch/sync** | `work/spaarke-SPA-external-access-platform-r2` — clean, 0 unpushed (last commit **8c1ac557b**), **7 ahead / 1 behind** origin/master. |
 
+## ✅ Merged to master (2026-08-12) — PR #761
+All post-#758 external-access-r2 work (PCF TrackingFieldTrio v1.0.20→v1.0.29, shared-lib SprkModal/
+AccessGrantModal/TrackingFieldTrio/SendEmailDialog changes, external-spa 5B Partner-primary login,
+test-suite rewrites, docs) merged to master via **PR #761** (`3107c679d`). Master Tier-1 blocking CI =
+GREEN. Master merge auto-triggered **Deploy SpaarkeAi**. Other projects can now conflict-check against
+master + build/deploy bff.api + spaarke.ai from latest shared code. Working tree clean; branch fully
+pushed. (Branch protection was OFF this session.)
+
 ## 🔥 Master-red hotfix (2026-08-12) — RESOLVED
 Master CI was red (blocking email-communication-intelligence-r2 PR #755): (1) our stale
 `ExternalAccessIntegrationTests.cs` passed removed `AccountId` param (11 sites) → broke the whole

--- a/src/client/external-spa/src/components/auth/RealmChooser.tsx
+++ b/src/client/external-spa/src/components/auth/RealmChooser.tsx
@@ -73,8 +73,7 @@ export const RealmChooser: React.FC<RealmChooserProps> = ({ onChoose }) => {
           Continue as Partner
         </Button>
         <Text className={s.workforceRow} block>
-          Spaarke employee?{' '}
-          <Link onClick={() => onChoose('workforce')}>Sign in with your work account</Link>
+          Spaarke employee? <Link onClick={() => onChoose('workforce')}>Sign in with your work account</Link>
         </Text>
       </div>
     </div>

--- a/src/client/shared/Spaarke.UI.Components/src/components/DataGrid/DataGrid.tsx
+++ b/src/client/shared/Spaarke.UI.Components/src/components/DataGrid/DataGrid.tsx
@@ -713,14 +713,25 @@ async function resolveSource(
 
 function extractEntityFromFetchXml(fetchXml: string): string | undefined {
   if (!fetchXml) return undefined;
+  // Primary: DOMParser (browser). Fall back to a regex when DOMParser is
+  // unavailable/returns a parsererror (owner UAT 2026-08-12 #4C — a valid inline
+  // fetchXml was yielding an empty entityName → the "Cannot resolve entityName"
+  // error; the regex makes extraction robust to DOMParser quirks/XML-decl/BOM/
+  // entity-encoded quotes). Matches `<entity name="…">` or `name='…'`.
   try {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(fetchXml, 'text/xml');
-    if (doc.querySelector('parsererror')) return undefined;
-    return doc.querySelector('entity')?.getAttribute('name') ?? undefined;
+    if (typeof DOMParser !== 'undefined') {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(fetchXml, 'text/xml');
+      if (!doc.querySelector('parsererror')) {
+        const name = doc.querySelector('entity')?.getAttribute('name');
+        if (name) return name;
+      }
+    }
   } catch {
-    return undefined;
+    /* fall through to regex */
   }
+  const m = /<entity\b[^>]*\bname\s*=\s*['"]([^'"]+)['"]/i.exec(fetchXml);
+  return m?.[1] ?? undefined;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Follow-on to PR #761. Hardens `extractEntityFromFetchXml` in the shared DataGrid framework with a regex fallback so a valid inline `<entity name='…'>` always resolves even when `DOMParser` returns null at runtime — fixes the Service Request grid "Cannot resolve entityName" error (UAT #4C) and hardens every inline-fetchXml grid. Plus the r2 checkpoint doc.

## Verification
- Shared lib build: ✅ 0 errors · DataGrid tests: ✅ 64/64

🤖 Generated with [Claude Code](https://claude.com/claude-code)